### PR TITLE
fix(install): support macOS universal binary (darwin_all)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -198,8 +198,9 @@ find_download_url() {
     local binary_pattern="${BIN_NAME}_${platform}"
 
     # Extract browser_download_url for matching asset
+    # Use || true to prevent grep from causing script exit when no match found
     echo "$release_json" | grep -o '"browser_download_url":[[:space:]]*"[^"]*'"${binary_pattern}"'"' | \
-        sed -E 's/.*"browser_download_url":[[:space:]]*"([^"]+)".*/\1/' | head -1
+        sed -E 's/.*"browser_download_url":[[:space:]]*"([^"]+)".*/\1/' | head -1 || true
 }
 
 # Ensure install directory exists
@@ -273,6 +274,15 @@ install_ntm() {
         # Some releases use dashes instead of underscores
         local alt_platform="${platform//_/-}"
         download_url=$(find_download_url "$alt_platform" "$release_json")
+    fi
+
+    if [ -z "$download_url" ]; then
+        # macOS uses universal binary (darwin_all) instead of arch-specific
+        case "$platform" in
+            darwin_amd64|darwin_arm64)
+                download_url=$(find_download_url "darwin_all" "$release_json")
+                ;;
+        esac
     fi
 
     if [ -z "$download_url" ]; then


### PR DESCRIPTION
## Summary

The install script was failing on macOS because it looked for platform-specific binaries (`ntm_darwin_amd64`, `ntm_darwin_arm64`) but the releases only include a universal binary named `ntm_darwin_all`.

**Changes:**
- Add fallback to check for `darwin_all` when detected platform is `darwin_amd64` or `darwin_arm64`
- Add `|| true` to the grep pipeline in `find_download_url()` to prevent early script exit when no match is found (due to `set -e`)

## Test plan

- [x] Tested on macOS Intel - install script now correctly finds and downloads `ntm_darwin_all`
- [ ] Should also work on Apple Silicon (same `darwin_all` binary)

---

Thanks for building ntm - really useful tool for managing tmux sessions with AI agents! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)