### PR TITLE
fix: palette viewport scrolling — 3 bugs in model.go

### DIFF
--- a/internal/palette/model.go
+++ b/internal/palette/model.go
@@ -475,6 +475,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err == nil {
 			m.recents = msg.keys
 			m.buildVisualOrder()
+			m.listViewport.GotoTop()
 		}
 		return m, nil
 
@@ -907,14 +908,27 @@ func (m *Model) visualPosToLineNum(pos int) int {
 		itemsBeforePos += recentsCount
 	}
 
-	// Category sections: each has header + items + blank
-	// Estimate categories from remaining items
-	remainingItems := len(m.visualOrder) - itemsBeforePos
-	if remainingItems > 0 && pos >= itemsBeforePos {
-		posInCategories := pos - itemsBeforePos
-		// Estimate ~4 items per category on average, with 2 extra lines per category
-		estimatedCategories := (posInCategories / 4) + 1
-		lineNum += posInCategories + (estimatedCategories * 2)
+	// Category sections: 1 header + N items (1 line each) + 1 blank per category.
+	// Iterate through visualOrder to get the exact line number — same structure
+	// as renderCommandList, so this matches the actual rendered output exactly.
+	prevCat := ""
+	for i := itemsBeforePos; i < len(m.visualOrder); i++ {
+		idx := m.visualOrder[i]
+		cat := m.filtered[idx].Category
+		if cat == "" {
+			cat = "General"
+		}
+		if cat != prevCat {
+			if prevCat != "" {
+				lineNum++ // blank separator after previous category
+			}
+			lineNum++ // header for this category
+			prevCat = cat
+		}
+		if i == pos {
+			return lineNum
+		}
+		lineNum++ // count past this item
 	}
 
 	return lineNum
@@ -925,20 +939,22 @@ func (m *Model) ensureCursorVisible() {
 	pos := m.cursorVisualPos()
 	linePos := m.visualPosToLineNum(pos)
 
-	// If cursor is above the visible area, scroll up
+	// If cursor is above the visible area, scroll up.
+	// Direct YOffset assignment bypasses SetYOffset()'s clamping to maxYOffset()
+	// (which returns 0 in Update() because SetContent() is only called in View()).
 	if linePos < m.listViewport.YOffset {
-		m.listViewport.SetYOffset(linePos)
+		m.listViewport.YOffset = linePos
 	}
 
-	// If cursor is below the visible area, scroll down
-	// Leave a small margin at the bottom
+	// If cursor is below the visible area, scroll down.
+	// Leave a small margin at the bottom.
 	visibleBottom := m.listViewport.YOffset + m.listViewport.Height - 2
 	if linePos > visibleBottom {
 		newOffset := linePos - m.listViewport.Height + 3
 		if newOffset < 0 {
 			newOffset = 0
 		}
-		m.listViewport.SetYOffset(newOffset)
+		m.listViewport.YOffset = newOffset
 	}
 }
 


### PR DESCRIPTION
> **Note:** We understand you may not be accepting direct contributions at this time. This PR is offered purely as a reference — feel free to close it and cherry-pick anything useful at your leisure.

---

## Problem

`ntm palette` opens with the first ~17 items hidden: the viewport is scrolled to the bottom of the list rather than the top. Pressing arrow keys does not scroll the list.

Three bugs in `internal/palette/model.go` combine to produce this:

---

## Fix 1 — `recentsMsg` handler: call `GotoTop()` after `buildVisualOrder()`

`fetchRecents()` fires asynchronously in `Init()`. When it completes, `buildVisualOrder()` rebuilds `visualOrder` (reordering pinned → recents → categories), but the viewport offset is never reset. The viewport stays wherever it was after the initial render, which ends up showing the tail of the list.

```go
case recentsMsg:
    if msg.err == nil {
        m.recents = msg.keys
        m.buildVisualOrder()
        m.listViewport.GotoTop()  // ← added
    }
    return m, nil
```

---

## Fix 2 — `visualPosToLineNum`: replace per-category estimate with exact iteration

The category section of `visualPosToLineNum` used a heuristic (`~4 items per category`) to estimate the rendered line number. The actual render structure is deterministic: **1 header line + 1 line per item + 1 blank separator per category**. The estimate caused off-by-N scroll positioning for any command that isn't in the first category.

Replaced with an exact iteration that mirrors `renderCommandList`'s structure.

---

## Fix 3 — `ensureCursorVisible`: bypass `SetYOffset()` clamping

This is the root cause of non-functional scrolling.

`SetYOffset(n)` clamps to `min(n, maxYOffset())` where `maxYOffset() = len(lines) - Height`. The `lines` slice is only populated by `SetContent()`, which is only called inside `View()`. `View()` operates on a **value receiver** (throw-away copy) — mutations there are lost. In `Update()`, `lines` is always `nil`, so `maxYOffset() = 0`, and `SetYOffset()` always clamps to `0`.

`ensureCursorVisible()` is called from `Update()`, so every scroll attempt is silently discarded.

Fix: assign `YOffset` directly, bypassing the clamping method. `View()` will call `SetContent()` (which internally re-clamps `YOffset` against real content), so the value is self-correcting on the next render.

```go
// Before
m.listViewport.SetYOffset(linePos)
m.listViewport.SetYOffset(newOffset)

// After
m.listViewport.YOffset = linePos
m.listViewport.YOffset = newOffset
```

---

## Testing

Tested against NTM v1.7.0 on a session with ~60 commands across 8 categories and a populated recents list. After these fixes:
- Palette opens scrolled to item 1
- Up/Down arrows scroll the list correctly
- Scroll position tracks the cursor accurately across all categories