### PR TITLE
fix(palette): constrain view to terminal height and fix filter box border alignment

### DIFF
--- a/internal/palette/model.go
+++ b/internal/palette/model.go
@@ -1299,7 +1299,8 @@ func (m Model) viewCommandPhase() string {
 		Width(listWidth - 4)
 
 	searchIcon := lipgloss.NewStyle().Foreground(t.Mauve).Render(ic.Search + " ")
-	b.WriteString("  " + filterBox.Render(searchIcon+m.filter.View()) + "\n\n")
+	filterRendered := lipgloss.NewStyle().MarginLeft(2).Render(filterBox.Render(searchIcon + m.filter.View()))
+	b.WriteString(filterRendered + "\n\n")
 
 	// ═══════════════════════════════════════════════════════════════
 	// RESPONSIVE LAYOUT: Adapts to terminal width
@@ -1335,7 +1336,7 @@ func (m Model) viewCommandPhase() string {
 	listBox := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.Surface2).
-		Width(listWidth - 2).
+		Width(listWidth-2).
 		Padding(1, 1)
 
 	var columns string
@@ -1370,7 +1371,9 @@ func (m Model) viewCommandPhase() string {
 	// ═══════════════════════════════════════════════════════════════
 	b.WriteString("  " + m.renderHelpBar() + "\n")
 
-	return b.String()
+	// Constrain the entire view to the terminal dimensions so that line
+	// wrapping or rounding errors never push the header off-screen.
+	return lipgloss.Place(m.width, m.height, lipgloss.Left, lipgloss.Top, b.String())
 }
 
 func (m Model) renderCommandList(width int) string {


### PR DESCRIPTION
  - Fix palette header/top lines being pushed off-screen by wrapping the entire view output in `lipgloss.Place` to hard-constrain it to terminal dimensions                                                                               
  - Fix filter/search box border misalignment by using `MarginLeft(2)` instead of a string prefix that only indented the first line of the bordered box                                                                                   
 - gofmt fixes