### PR TITLE
fix(assign): treat --agent any as no provider filter

### DIFF
--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -201,7 +201,7 @@ Examples:
 	cmd.Flags().IntVar(&assignLimit, "limit", 0, "Maximum number of assignments (0 = unlimited)")
 
 	// Agent type filters
-	cmd.Flags().StringVar(&assignAgentType, "agent", "", "Filter by agent type: claude, codex, gemini")
+	cmd.Flags().StringVar(&assignAgentType, "agent", "", "Filter by agent type: any, claude, codex, gemini")
 	cmd.Flags().BoolVar(&assignCCOnly, "cc-only", false, "Only assign to Claude agents (alias for --agent=claude)")
 	cmd.Flags().BoolVar(&assignCodOnly, "cod-only", false, "Only assign to Codex agents (alias for --agent=codex)")
 	cmd.Flags().BoolVar(&assignGmiOnly, "gmi-only", false, "Only assign to Gemini agents (alias for --agent=gemini)")
@@ -650,7 +650,7 @@ func buildAssignWatchOverlayWarning(key string, err error) string {
 func resolveAgentTypeFilter() string {
 	// Explicit --agent flag takes precedence
 	if assignAgentType != "" {
-		return robot.ResolveAgentType(assignAgentType)
+		return normalizeAssignAgentTypeFilter(assignAgentType)
 	}
 	// Convenience flags
 	if assignCCOnly {
@@ -663,6 +663,21 @@ func resolveAgentTypeFilter() string {
 		return "gemini"
 	}
 	return "" // No filter
+}
+
+func normalizeAssignAgentTypeFilter(agentTypeFilter string) string {
+	trimmed := strings.TrimSpace(agentTypeFilter)
+	switch strings.ToLower(trimmed) {
+	case "", "any", "all", "*":
+		return ""
+	default:
+		return robot.ResolveAgentType(trimmed)
+	}
+}
+
+func assignAgentTypeMatchesFilter(agentType, agentTypeFilter string) bool {
+	normalizedFilter := normalizeAssignAgentTypeFilter(agentTypeFilter)
+	return normalizedFilter == "" || agentType == normalizedFilter
 }
 
 func resolveAssignTimeout(timeout time.Duration) time.Duration {
@@ -1415,7 +1430,7 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 		}
 
 		// Apply agent type filter
-		if opts.AgentTypeFilter != "" && at != opts.AgentTypeFilter {
+		if !assignAgentTypeMatchesFilter(at, opts.AgentTypeFilter) {
 			continue
 		}
 
@@ -4422,8 +4437,8 @@ func PerformAutoReassignment(completedBeadID string, opts *AutoReassignOptions) 
 func getIdleAgents(session, agentTypeFilter string, verbose bool) ([]assignAgentInfo, error) {
 	normalizedFilter := ""
 	if agentTypeFilter != "" {
-		normalizedFilter = robot.ResolveAgentType(agentTypeFilter)
-		if normalizedFilter == "" || normalizedFilter == "unknown" || normalizedFilter == "user" {
+		normalizedFilter = normalizeAssignAgentTypeFilter(agentTypeFilter)
+		if normalizedFilter == "unknown" || normalizedFilter == "user" {
 			return nil, fmt.Errorf("invalid agent type filter %q", agentTypeFilter)
 		}
 	}

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -963,6 +963,30 @@ func TestDetectModelFromTitle(t *testing.T) {
 	}
 }
 
+func TestAssignAgentTypeFilterTreatsAnyAsNoFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentType string
+		filter    string
+		want      bool
+	}{
+		{name: "empty matches codex", agentType: "codex", filter: "", want: true},
+		{name: "any matches codex", agentType: "codex", filter: "any", want: true},
+		{name: "all matches claude", agentType: "claude", filter: "all", want: true},
+		{name: "star matches gemini", agentType: "gemini", filter: "*", want: true},
+		{name: "alias cod matches codex", agentType: "codex", filter: "cod", want: true},
+		{name: "claude excludes codex", agentType: "codex", filter: "claude", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := assignAgentTypeMatchesFilter(tc.agentType, tc.filter); got != tc.want {
+				t.Fatalf("assignAgentTypeMatchesFilter(%q, %q) = %v, want %v", tc.agentType, tc.filter, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDetermineAgentState_NormalizesAliasHints(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Treat `--agent any`, `--agent all`, and `--agent *` as no provider filter for `ntm assign`.
- Reuse the same normalization in both the enhanced assign scan and `getIdleAgents`.
- Add a regression test so `any` cannot silently become a literal provider name again.

## Root cause

`--agent any` was passed through `ResolveAgentType`, which returned the literal string `any`. The enhanced assign path then compared each pane provider (`claude`, `codex`, etc.) against `any`, so every pane was filtered out before idle detection ran. In mixed-provider sessions this made `idle_agent_count` report `0` even while health/activity surfaces showed idle panes.

## Impact

Controller/watch flows configured with `--agent any` can now dispatch to all eligible providers as intended. Existing provider-specific filters (`claude`, `codex`, aliases like `cod`) keep their previous behavior.

## Validation

- `go test ./internal/cli ./internal/robot ./internal/agent`
- Live sanity check in a mixed Claude/Codex session: `ntm assign ... --agent any --dry-run --json` went from `idle_agent_count: 0` to matching the all-provider idle pool.

Kept intentionally small and easy to cherry-pick/squash/reword if you prefer to land it manually.
