### PR TITLE
bd-exoe6: skip blocked beads in assign recommendations

### DIFF
--- a/internal/bv/client.go
+++ b/internal/bv/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -349,7 +350,7 @@ func (c *BVClient) convertRecommendation(rec TriageRecommendation) Recommendatio
 		UnblocksCount: len(rec.UnblocksIDs),
 		UnblocksIDs:   rec.UnblocksIDs,
 		BlockedByIDs:  rec.BlockedBy,
-		IsActionable:  len(rec.BlockedBy) == 0,
+		IsActionable:  IsActionableRecommendation(rec),
 		Tags:          rec.Labels,
 		Score:         rec.Score,
 		Action:        rec.Action,
@@ -366,6 +367,16 @@ func (c *BVClient) convertRecommendation(rec TriageRecommendation) Recommendatio
 	r.EstimatedSize = c.estimateSize(rec)
 
 	return r
+}
+
+// IsActionableRecommendation reports whether a triage recommendation should be
+// considered assignable. A bead that is already marked blocked is never
+// assignable, even if its dependency list is empty.
+func IsActionableRecommendation(rec TriageRecommendation) bool {
+	if strings.EqualFold(strings.TrimSpace(rec.Status), "blocked") {
+		return false
+	}
+	return len(rec.BlockedBy) == 0
 }
 
 // estimateSize estimates task size based on heuristics.

--- a/internal/bv/client_pure_test.go
+++ b/internal/bv/client_pure_test.go
@@ -176,6 +176,22 @@ func TestBVClientConvertRecommendation(t *testing.T) {
 			t.Fatalf("EstimatedSize = %q, want %q", out.EstimatedSize, "medium")
 		}
 	})
+
+	t.Run("blocked_status_without_blockers_is_not_actionable", func(t *testing.T) {
+		t.Parallel()
+
+		out := client.convertRecommendation(TriageRecommendation{
+			ID:        "bd-4",
+			Title:     "Blocked by status only",
+			Type:      "task",
+			Status:    "blocked",
+			BlockedBy: nil,
+		})
+
+		if out.IsActionable {
+			t.Fatalf("IsActionable = true, want false")
+		}
+	})
 }
 
 func TestBVClientBuildInsightsFromResponse(t *testing.T) {

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -1487,28 +1487,7 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 			readyBeads = filteredBeads
 		}
 	} else {
-		// Filter blocked beads from recommendations
-		for _, rec := range allRecs {
-			// Skip if blocked by other beads
-			if len(rec.BlockedBy) > 0 {
-				blockedBeads = append(blockedBeads, SkippedItem{
-					BeadID:       rec.ID,
-					BeadTitle:    rec.Title,
-					Reason:       "blocked_by_dependency",
-					BlockedByIDs: rec.BlockedBy,
-				})
-				if opts.Verbose {
-					fmt.Fprintf(os.Stderr, "[DEP] Skipping %s - blocked by: %v\n", rec.ID, rec.BlockedBy)
-				}
-				continue
-			}
-			// Convert TriageRecommendation to BeadPreview
-			readyBeads = append(readyBeads, bv.BeadPreview{
-				ID:       rec.ID,
-				Title:    rec.Title,
-				Priority: fmt.Sprintf("P%d", rec.Priority),
-			})
-		}
+		readyBeads, blockedBeads = partitionAssignableRecommendations(allRecs, opts.Verbose)
 		if opts.Verbose && len(blockedBeads) > 0 {
 			fmt.Fprintf(os.Stderr, "[DEP] Filtered %d blocked beads, %d actionable\n", len(blockedBeads), len(readyBeads))
 		}
@@ -1630,6 +1609,42 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 	result.Summary.SkippedCount = len(result.Skipped)
 
 	return result, nil
+}
+
+func partitionAssignableRecommendations(recs []bv.TriageRecommendation, verbose bool) ([]bv.BeadPreview, []SkippedItem) {
+	readyBeads := make([]bv.BeadPreview, 0, len(recs))
+	blockedBeads := make([]SkippedItem, 0)
+
+	for _, rec := range recs {
+		if !bv.IsActionableRecommendation(rec) {
+			reason := "blocked_status"
+			if len(rec.BlockedBy) > 0 {
+				reason = "blocked_by_dependency"
+			}
+			blockedBeads = append(blockedBeads, SkippedItem{
+				BeadID:       rec.ID,
+				BeadTitle:    rec.Title,
+				Reason:       reason,
+				BlockedByIDs: append([]string(nil), rec.BlockedBy...),
+			})
+			if verbose {
+				if len(rec.BlockedBy) > 0 {
+					fmt.Fprintf(os.Stderr, "[DEP] Skipping %s - blocked by: %v\n", rec.ID, rec.BlockedBy)
+				} else {
+					fmt.Fprintf(os.Stderr, "[DEP] Skipping %s - status=blocked\n", rec.ID)
+				}
+			}
+			continue
+		}
+
+		readyBeads = append(readyBeads, bv.BeadPreview{
+			ID:       rec.ID,
+			Title:    rec.Title,
+			Priority: fmt.Sprintf("P%d", rec.Priority),
+		})
+	}
+
+	return readyBeads, blockedBeads
 }
 
 // generateAssignmentsEnhanced creates assignment recommendations using the enhanced strategy logic.

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -137,6 +137,62 @@ func TestBlockedBeadsReasonString(t *testing.T) {
 	}
 }
 
+func TestPartitionAssignableRecommendationsSkipsBlockedStatusAndDependencies(t *testing.T) {
+	recs := []bv.TriageRecommendation{
+		{
+			ID:       "bd-ready",
+			Title:    "Ready bead",
+			Priority: 1,
+			Status:   "open",
+		},
+		{
+			ID:       "bd-blocked-status",
+			Title:    "Blocked by status only",
+			Priority: 2,
+			Status:   "blocked",
+		},
+		{
+			ID:       "bd-blocked-deps",
+			Title:    "Blocked by dependency",
+			Priority: 3,
+			Status:   "open",
+			BlockedBy: []string{
+				"bd-parent",
+			},
+		},
+	}
+
+	ready, blocked := partitionAssignableRecommendations(recs, false)
+
+	if len(ready) != 1 {
+		t.Fatalf("len(ready) = %d, want 1", len(ready))
+	}
+	if ready[0].ID != "bd-ready" {
+		t.Fatalf("ready[0].ID = %q, want bd-ready", ready[0].ID)
+	}
+
+	if len(blocked) != 2 {
+		t.Fatalf("len(blocked) = %d, want 2", len(blocked))
+	}
+
+	if blocked[0].BeadID != "bd-blocked-status" {
+		t.Fatalf("blocked[0].BeadID = %q, want bd-blocked-status", blocked[0].BeadID)
+	}
+	if blocked[0].Reason != "blocked_status" {
+		t.Fatalf("blocked[0].Reason = %q, want blocked_status", blocked[0].Reason)
+	}
+
+	if blocked[1].BeadID != "bd-blocked-deps" {
+		t.Fatalf("blocked[1].BeadID = %q, want bd-blocked-deps", blocked[1].BeadID)
+	}
+	if blocked[1].Reason != "blocked_by_dependency" {
+		t.Fatalf("blocked[1].Reason = %q, want blocked_by_dependency", blocked[1].Reason)
+	}
+	if len(blocked[1].BlockedByIDs) != 1 || blocked[1].BlockedByIDs[0] != "bd-parent" {
+		t.Fatalf("blocked[1].BlockedByIDs = %v, want [bd-parent]", blocked[1].BlockedByIDs)
+	}
+}
+
 // TestAssignOutputEnhancedStructure tests the output structure is correct for JSON
 func TestAssignOutputEnhancedStructure(t *testing.T) {
 	output := AssignOutputEnhanced{


### PR DESCRIPTION
This PR addresses the controller/assigner regression where blocked parent beads could be proposed as assignable during dependency-driven dry-runs.

Changes:
- exclude recommendations with status=blocked even when blocked_by is empty
- keep dependency-blocked recommendations skipped with an explicit blocked reason
- add regression coverage for blocked-status and blocked-by filtering

Verified locally:
- go test ./internal/bv -run TestBVClientConvertRecommendation -count=1
- go test ./internal/cli -run TestPartitionAssignableRecommendationsSkipsBlockedStatusAndDependencies -count=1
- ntm assign notaryware --dry-run --strategy=dependency --agent codex --limit=4 --json

Upstream push from this shell is read-only on Dicklesworthstone/ntm, so the code is published on fork branch IvanWest33/ntm:bd-exoe6.