### PR TITLE
Fix scanner stdout pipe race in hook scan

### DIFF
--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -294,7 +294,7 @@ This is also called by the installed hook script.`,
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 	cmd.Flags().BoolVar(&failOnWarning, "fail-on-warning", true, "Fail on warnings")
-	cmd.Flags().IntVar(&timeout, "timeout", 60, "Timeout in seconds")
+	cmd.Flags().IntVar(&timeout, "timeout", 120, "Timeout in seconds")
 
 	return cmd
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -151,8 +151,8 @@ func TestDefaultPreCommitConfig(t *testing.T) {
 	if !cfg.FailOnWarning {
 		t.Error("FailOnWarning should be true")
 	}
-	if cfg.Timeout != 60*time.Second {
-		t.Errorf("Timeout = %v, want 60s", cfg.Timeout)
+	if cfg.Timeout != 120*time.Second {
+		t.Errorf("Timeout = %v, want 120s", cfg.Timeout)
 	}
 	if cfg.Verbose {
 		t.Error("Verbose should be false")

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -33,7 +33,7 @@ func DefaultPreCommitConfig() PreCommitConfig {
 		MaxCritical:   0,
 		MaxWarning:    0,
 		FailOnWarning: true,
-		Timeout:       60 * time.Second,
+		Timeout:       120 * time.Second,
 		Verbose:       false,
 		SkipEmpty:     true,
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 	"time"
@@ -27,6 +26,38 @@ const MaxScanOutputBytes = 10 * 1024 * 1024
 // Scanner wraps the UBS command-line tool.
 type Scanner struct {
 	binaryPath string
+}
+
+// limitedOutputBuffer keeps scanner output bounded without returning a write
+// error to os/exec's copy goroutine. Returning an error here would turn an
+// oversized scan output into a process/run error; instead Scan reports the
+// existing ErrOutputTooLarge sentinel after cmd.Run returns.
+type limitedOutputBuffer struct {
+	bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *limitedOutputBuffer) Write(p []byte) (int, error) {
+	if b.limit <= 0 {
+		b.exceeded = true
+		return len(p), nil
+	}
+
+	remaining := b.limit - b.Len()
+	if remaining <= 0 {
+		b.exceeded = true
+		return len(p), nil
+	}
+
+	if len(p) > remaining {
+		b.exceeded = true
+		_, _ = b.Buffer.Write(p[:remaining])
+		return len(p), nil
+	}
+
+	_, _ = b.Buffer.Write(p)
+	return len(p), nil
 }
 
 // New creates a new Scanner instance.
@@ -71,46 +102,25 @@ func (s *Scanner) Scan(ctx context.Context, path string, opts ScanOptions) (*Sca
 	cmd := exec.CommandContext(ctx, s.binaryPath, args...)
 	cmd.WaitDelay = 2 * time.Second
 
-	// Capture stderr separately
+	// Capture stdout/stderr without StdoutPipe. cmd.Run starts the process,
+	// drains stdout while it is running, and waits only after the copy completes.
+	// This avoids read-after-Wait / closed-pipe races while preserving the
+	// MaxScanOutputBytes memory cap.
+	var stdout limitedOutputBuffer
+	stdout.limit = MaxScanOutputBytes + 1
 	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("creating stdout pipe: %w", err)
-	}
-
 	startTime := time.Now()
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("starting ubs: %w", err)
-	}
-
-	// Ensure process is cleaned up if we return early (e.g. read error)
-	// We need to ensure we don't double-wait or double-kill in the success path.
-	// We will handle cleanup explicitly in error paths or rely on Wait() at the end.
-	// But defer is safer.
-	var waitDone bool
-	defer func() {
-		if !waitDone && cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait() // Reap the zombie
-		}
-	}()
-
-	// Read output with limit
-	output, err := io.ReadAll(io.LimitReader(stdoutPipe, MaxScanOutputBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("reading output: %w", err)
-	}
+	waitErr := cmd.Run()
+	duration := time.Since(startTime)
+	output := stdout.Bytes()
 
 	// Check if output exceeded limit
-	if len(output) > MaxScanOutputBytes {
+	if stdout.exceeded || len(output) > MaxScanOutputBytes {
 		return nil, ErrOutputTooLarge
 	}
-
-	waitErr := cmd.Wait()
-	waitDone = true
-	duration := time.Since(startTime)
 
 	// Check for timeout
 	if ctx.Err() == context.DeadlineExceeded {


### PR DESCRIPTION
## Summary

Fixes a scanner pipe lifecycle failure in `internal/scanner/scanner.go` where NTM could abort pre-commit scans with `reading output: read |0: file already closed` when staged source files triggered UBS scanning.

The scanner no longer uses `cmd.StdoutPipe` plus a manual read path. Instead it attaches a bounded stdout writer to the command and uses `cmd.Run()`, so stdout is drained while the process runs and `Run` waits only after the copy completes. The existing `MaxScanOutputBytes` cap is preserved by a small writer that records overflow without returning a write error to `os/exec`'s copy goroutine.

This also aligns the pre-commit hook's CLI/default timeout to 120s, matching NTM's scanner config default. On a downstream Next.js project reproduction in the local environment, the staged source-file scan completed cleanly in about 70-80 seconds, so the prior 60s hook default was too short for that real guard path.

## Verification

- `go test ./internal/scanner -run 'Test(IsAvailable|DefaultOptions|BuildArgs|Parse|ScanResult|Format|Severity|Compute|Analyze|Truncate|Sort|Shorten|Config|Extract)'`
- `go test ./internal/hooks -run PreCommit`
- `make build`
- `./ntm version`
- Real downstream reproduction in a Next.js project: staged `.tsx` source file no longer fails pre-commit with `file already closed` and exits 0 with the default hook timeout.
- Normal guarded git commit without `--no-verify` succeeds for a staged `.tsx` file.
- Beads-only guarded commit succeeds.

Note: local `go test ./internal/scanner` exercises real UBS scans and timed out in the local environment (`TestAutoScanner_TriggerScan`, `TestScanDirectory`), so targeted pure scanner tests plus the downstream hook reproduction were used as acceptance proof.

Posted by Codex on behalf of profplum700.
