### PR TITLE
docs(ntm): add checkpoint recovery cadence

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -146,6 +146,27 @@ ntm changes conflicts myproject
 ntm resume myproject
 ```
 
+Checkpoint as an operator cadence, not only as a last-resort recovery tool:
+
+```bash
+ntm checkpoint save myproject -m "after spawn and prompt receipt"
+ntm checkpoint save myproject -m "after restore and prompt receipt"
+ntm checkpoint save myproject -m "after investigation: root cause isolated"
+ntm checkpoint save myproject -m "before risky edits: auth refactor"
+ntm checkpoint save myproject -m "after uncommitted edits before verification"
+ntm checkpoint save myproject -m "after green verification"
+ntm checkpoint save myproject -m "before merge, cleanup, or handoff"
+```
+
+Take these after spawn or restore once prompts are received, after useful investigation
+findings, before risky edits, after significant uncommitted edits before verification,
+after green verification, and before merge, cleanup, or handoff.
+
+Agent Mail may be an external MCP or service-manager process outside the `tmux` session.
+If Agent Mail and `tmux` fail together, do not assume `tmux` killed Agent Mail. Check the
+service manager, cgroup/process ancestry, memory or OOM signals, restart policy, and
+Agent Mail health before relaunching workers.
+
 Isolation options:
 
 ```bash

--- a/references/COMMANDS.md
+++ b/references/COMMANDS.md
@@ -149,6 +149,43 @@ ntm changes conflicts myproject
 ntm resume myproject
 ```
 
+Use checkpoints as a normal operating cadence:
+
+```bash
+ntm checkpoint save myproject -m "after spawn and prompt receipt"
+ntm checkpoint save myproject -m "after restore and prompt receipt"
+ntm checkpoint save myproject -m "after investigation: database timeout isolated"
+ntm checkpoint save myproject -m "before risky edits: session restore path"
+ntm checkpoint save myproject -m "after uncommitted edits before verification"
+ntm checkpoint save myproject -m "after green verification"
+ntm checkpoint save myproject -m "before merge, cleanup, or handoff"
+```
+
+Good checkpoint moments are after spawn or restore once prompts are received, after
+useful investigation findings, before risky edits, after significant uncommitted edits
+before verification, after green verification, and before merge, cleanup, or handoff.
+
+When recovering coordination, remember that Agent Mail may run outside `tmux` as an
+external MCP server or service-managed process. If `tmux` and Agent Mail are both down
+or degraded, do not infer a single failure boundary. Check process ownership and health
+before relaunching workers:
+
+```bash
+# If Agent Mail is managed by systemd user services on this host
+systemctl --user status mcp-agent-mail.service
+journalctl --user -u mcp-agent-mail.service -n 100 --no-pager
+
+# Confirm parentage, cgroup, and memory kill pressure for a known PID
+ps -o pid,ppid,stat,cmd -p <pid>
+cat /proc/<pid>/cgroup
+cat /proc/<pid>/oom_score /proc/<pid>/oom_score_adj
+dmesg -T | tail -n 100
+```
+
+Look for service restart state, parent process, cgroup, OOM or memory-pressure signals,
+and MCP health before deciding whether to restart Agent Mail, restore NTM sessions, or
+send more work to agents.
+
 Worktree-specific commands when repo policy allows them:
 
 ```bash


### PR DESCRIPTION
## Summary

Operator recovery guidance now treats checkpoints as a normal cadence instead of a one-off recovery action. The NTM skill also reminds operators that Agent Mail may live outside tmux, so a simultaneous tmux and Agent Mail outage should be investigated at the service/process boundary before workers are relaunched.

## Verification

- `git diff --check -- SKILL.md references/COMMANDS.md`
- `rg -n '[[:blank:]]+$|\t$' SKILL.md references/COMMANDS.md` returned no matches
- fenced-code balance check with `awk` for `SKILL.md` and `references/COMMANDS.md`

`ubs` and `markdownlint` were not available in this environment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
