### PR TITLE
fix(agentmail): classify lock-list resource timeouts

### DIFF
--- a/internal/agentmail/errors.go
+++ b/internal/agentmail/errors.go
@@ -152,6 +152,8 @@ func mapJSONRPCError(rpcErr *JSONRPCError) error {
 		return fmt.Errorf("%w: %s", ErrContactBlocked, rpcErr.Message)
 	case strings.Contains(msg, "conflict") && strings.Contains(msg, "reservation"):
 		return fmt.Errorf("%w: %s", ErrReservationConflict, rpcErr.Message)
+	case strings.Contains(msg, "request timed out") || strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "timeout"):
+		return fmt.Errorf("%w: %s", ErrTimeout, rpcErr.Message)
 	case strings.Contains(msg, "not found") && !strings.Contains(msg, "method not found"):
 		return fmt.Errorf("%w: %s", ErrNotFound, rpcErr.Message)
 	case strings.Contains(msg, "busy") || strings.Contains(msg, "temporarily unavailable"):

--- a/internal/agentmail/resource_test.go
+++ b/internal/agentmail/resource_test.go
@@ -239,3 +239,34 @@ func TestListReservations_FallbackToToolsWhenResourceFails(t *testing.T) {
 		t.Fatalf("unexpected path pattern: %q", filtered[0].PathPattern)
 	}
 }
+
+func TestReadResourceJSONRPCTimeoutMapsToTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req JSONRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		resp := JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error: &JSONRPCError{
+				Code:    -32000,
+				Message: "request timed out",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewClient(WithBaseURL(server.URL + "/"))
+	_, err := c.ReadResource(context.Background(), "resource://file_reservations/test")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !IsTimeout(err) {
+		t.Fatalf("IsTimeout=false for %v", err)
+	}
+}

--- a/internal/cli/locks.go
+++ b/internal/cli/locks.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	pathpkg "path"
@@ -718,13 +719,32 @@ func printLocksAdviceResult(result LocksAdviceResult) error {
 
 // LocksResult contains the list of active file reservations.
 type LocksResult struct {
-	Success      bool                        `json:"success"`
-	Session      string                      `json:"session"`
-	Agent        string                      `json:"agent,omitempty"`
-	ProjectKey   string                      `json:"project_key"`
-	Reservations []agentmail.FileReservation `json:"reservations"`
-	Count        int                         `json:"count"`
-	Error        string                      `json:"error,omitempty"`
+	Success              bool                        `json:"success"`
+	Session              string                      `json:"session"`
+	Agent                string                      `json:"agent,omitempty"`
+	ProjectKey           string                      `json:"project_key"`
+	Reservations         []agentmail.FileReservation `json:"reservations"`
+	Count                int                         `json:"count"`
+	Error                string                      `json:"error,omitempty"`
+	ErrorCode            string                      `json:"error_code,omitempty"`
+	ReasonCode           string                      `json:"reason_code,omitempty"`
+	AgentMailDiagnostics *LocksAgentMailDiagnostics  `json:"agent_mail_diagnostics,omitempty"`
+}
+
+// LocksAgentMailDiagnostics is the doctor-style breakdown attached to
+// `ntm locks list --json` when Agent Mail reservation discovery fails.
+type LocksAgentMailDiagnostics struct {
+	Surface               string `json:"surface"`
+	Operation             string `json:"operation"`
+	FailureClass          string `json:"failure_class"`
+	MCPTransport          string `json:"mcp_transport"`
+	DaemonHealth          string `json:"daemon_health"`
+	HealthStatus          string `json:"health_status,omitempty"`
+	HealthLevel           string `json:"health_level,omitempty"`
+	Database              string `json:"database"`
+	ResourceSerialization string `json:"resource_serialization"`
+	RecoveryMode          string `json:"recovery_mode,omitempty"`
+	RecoveryNextAction    string `json:"recovery_next_action,omitempty"`
 }
 
 func runLocks(session string, allAgents bool) error {
@@ -785,6 +805,8 @@ func runLocks(session string, allAgents bool) error {
 	if err != nil {
 		result.Success = false
 		result.Error = err.Error()
+		result.ErrorCode = "AGENT_MAIL_RESERVATION_LIST_FAILED"
+		result.ReasonCode, result.AgentMailDiagnostics = classifyLocksAgentMailFailure(client, err)
 	} else {
 		result.Success = true
 	}
@@ -810,6 +832,81 @@ func fetchActiveReservations(ctx context.Context, client *agentmail.Client, proj
 		return nil, fmt.Errorf("listing reservations: %w", err)
 	}
 	return reservations, nil
+}
+
+func classifyLocksAgentMailFailure(client *agentmail.Client, err error) (string, *LocksAgentMailDiagnostics) {
+	diag := &LocksAgentMailDiagnostics{
+		Surface:               "file_reservations",
+		Operation:             "resources/read",
+		FailureClass:          "agent_mail_reservation_list_failed",
+		MCPTransport:          "unknown",
+		DaemonHealth:          "not_checked",
+		Database:              "no_signal",
+		ResourceSerialization: "no_signal",
+	}
+	reasonCode := "agentmail_reservations_list_failed"
+
+	var apiErr *agentmail.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.Operation != "" {
+			diag.Operation = apiErr.Operation
+		}
+	}
+
+	errText := strings.ToLower(err.Error())
+	switch {
+	case agentmail.IsTimeout(err) && strings.Contains(errText, "resources/read"):
+		reasonCode = "agentmail_resources_read_timeout"
+		diag.FailureClass = "mcp_resources_read_timeout"
+		diag.MCPTransport = "timeout"
+		diag.ResourceSerialization = "timeout_possible"
+	case agentmail.IsTimeout(err):
+		reasonCode = "agentmail_request_timeout"
+		diag.FailureClass = "mcp_request_timeout"
+		diag.MCPTransport = "timeout"
+	case agentmail.IsServerUnavailable(err):
+		reasonCode = "agentmail_server_unavailable"
+		diag.FailureClass = "mcp_transport_unavailable"
+		diag.MCPTransport = "unavailable"
+	case agentmail.IsUnauthorized(err):
+		reasonCode = "agentmail_unauthorized"
+		diag.FailureClass = "mcp_transport_unauthorized"
+		diag.MCPTransport = "unauthorized"
+	case strings.Contains(errText, "database is locked") || strings.Contains(errText, "database locked") || strings.Contains(errText, "sqlite busy"):
+		reasonCode = "agentmail_resources_read_database_lock"
+		diag.FailureClass = "database_lock"
+		diag.Database = "lock_suspected"
+	case strings.Contains(errText, "resource://file_reservations") ||
+		strings.Contains(errText, "cannot unmarshal") ||
+		strings.Contains(errText, "invalid character"):
+		reasonCode = "agentmail_resources_read_serialization_failed"
+		diag.FailureClass = "resource_serialization_failed"
+		diag.ResourceSerialization = "failed"
+	}
+
+	if client != nil {
+		healthCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if health, healthErr := client.HealthCheck(healthCtx); healthErr == nil {
+			diag.DaemonHealth = "reachable"
+			diag.HealthStatus = health.Status
+			diag.HealthLevel = health.HealthLevel
+			if health.Recovery != nil {
+				diag.RecoveryMode = health.Recovery.Mode
+				diag.RecoveryNextAction = health.Recovery.NextAction
+				if diag.Database == "no_signal" && strings.Contains(strings.ToLower(health.Recovery.Mode+" "+health.Recovery.NextAction), "lock") {
+					diag.Database = "lock_suspected"
+				}
+			}
+		} else {
+			diag.DaemonHealth = "unreachable"
+			if diag.MCPTransport == "unknown" {
+				diag.MCPTransport = "health_check_failed"
+			}
+		}
+	}
+
+	return reasonCode, diag
 }
 
 func printLocksResult(result LocksResult, allAgents bool) error {

--- a/internal/cli/mail_test.go
+++ b/internal/cli/mail_test.go
@@ -43,6 +43,7 @@ type mailStub struct {
 	releaseResult      agentmail.ReleaseReservationsResult
 	renewResult        agentmail.RenewReservationsResult
 	forceReleaseResult agentmail.ForceReleaseResult
+	resourceReadError  string
 	failIDs            map[int]string // messageID -> error message
 }
 
@@ -165,6 +166,10 @@ func newMailStub(t *testing.T, inbox []agentmail.InboxMessage) *mailStub {
 		}
 
 		if rpc.Method == "resources/read" {
+			if stub.resourceReadError != "" {
+				writeError(w, rpc.ID, -32000, stub.resourceReadError)
+				return
+			}
 			params, _ := rpc.Params.(map[string]interface{})
 			uri := toString(params["uri"])
 			projectKey := ""
@@ -1566,6 +1571,65 @@ func TestRunLocksUsesSessionProjectDir(t *testing.T) {
 	}
 	if got := stub.listCalls[0].Project; got != projectKey {
 		t.Fatalf("expected list project %q, got %q", projectKey, got)
+	}
+}
+
+func TestRunLocksJSONClassifiesResourcesReadTimeout(t *testing.T) {
+	resetFlags()
+	isolateSessionAgentStorage(t)
+
+	projectsBase := canonicalTempDir(t)
+	projectKey := filepath.Join(projectsBase, "mysession")
+	if err := os.MkdirAll(projectKey, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	stub := newMailStub(t, nil)
+	stub.resourceReadError = "request timed out"
+	defer stub.Close()
+
+	oldCfg := cfg
+	cfg = &config.Config{ProjectsBase: projectsBase}
+	t.Cleanup(func() { cfg = oldCfg })
+	oldJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = oldJSON })
+
+	t.Setenv("AGENT_MAIL_URL", stub.server.URL+"/")
+	t.Chdir(canonicalTempDir(t))
+
+	out, err := captureStdout(t, func() error {
+		return runLocks("mysession", true)
+	})
+	if err == nil {
+		t.Fatal("expected JSON failure exit")
+	}
+
+	var got LocksResult
+	if decodeErr := json.Unmarshal([]byte(out), &got); decodeErr != nil {
+		t.Fatalf("decode locks result: %v\n%s", decodeErr, out)
+	}
+	if got.Success {
+		t.Fatalf("Success=true, want false: %+v", got)
+	}
+	if got.ReasonCode != "agentmail_resources_read_timeout" {
+		t.Fatalf("ReasonCode=%q, want agentmail_resources_read_timeout; output=%s", got.ReasonCode, out)
+	}
+	if got.ErrorCode != "AGENT_MAIL_RESERVATION_LIST_FAILED" {
+		t.Fatalf("ErrorCode=%q, want AGENT_MAIL_RESERVATION_LIST_FAILED", got.ErrorCode)
+	}
+	if got.AgentMailDiagnostics == nil {
+		t.Fatal("AgentMailDiagnostics=nil")
+	}
+	diag := got.AgentMailDiagnostics
+	if diag.Operation != "resources/read" || diag.MCPTransport != "timeout" || diag.DaemonHealth != "reachable" {
+		t.Fatalf("diagnostics=%+v, want resources/read timeout with reachable daemon", diag)
+	}
+	if diag.Database != "no_signal" || diag.ResourceSerialization != "timeout_possible" {
+		t.Fatalf("diagnostics=%+v, want database no_signal and serialization timeout_possible", diag)
+	}
+	if diag.HealthStatus != "ok" {
+		t.Fatalf("health status=%q, want ok", diag.HealthStatus)
 	}
 }
 


### PR DESCRIPTION
## Summary
- map JSON-RPC timeout messages to Agent Mail ErrTimeout
- add typed locks list error_code/reason_code and Agent Mail diagnostics for resources/read failures
- cover the resources/read timeout path without waiting on a real timeout

## Validation
- go test ./internal/agentmail ./internal/cli -run 'TestReadResourceJSONRPCTimeoutMapsToTimeout|TestRunLocksJSONClassifiesResourcesReadTimeout|TestBuildLocksAdviceResult|TestLocksAgentMail|TestRunLocks|TestLocksCheckPathMatches|TestLocksComparable'

SkillOS bead: skillos-ok7k0