### PR TITLE
Route robot alerts to actionable owners

### DIFF
--- a/internal/robot/robot.go
+++ b/internal/robot/robot.go
@@ -4388,18 +4388,137 @@ type SnapshotReplayWindowInfo struct {
 
 // AlertInfo provides detailed alert information for robot output
 type AlertInfo struct {
-	ID         string                 `json:"id"`
-	Source     string                 `json:"source,omitempty"`
-	Type       string                 `json:"type"`
-	Severity   string                 `json:"severity"`
-	Message    string                 `json:"message"`
-	Session    string                 `json:"session,omitempty"`
-	Pane       string                 `json:"pane,omitempty"`
-	BeadID     string                 `json:"bead_id,omitempty"`
-	Context    map[string]interface{} `json:"context,omitempty"`
-	CreatedAt  string                 `json:"created_at"`
-	DurationMs int64                  `json:"duration_ms"`
-	Count      int                    `json:"count"`
+	ID            string                 `json:"id"`
+	Source        string                 `json:"source,omitempty"`
+	Type          string                 `json:"type"`
+	Severity      string                 `json:"severity"`
+	Message       string                 `json:"message"`
+	Session       string                 `json:"session,omitempty"`
+	Pane          string                 `json:"pane,omitempty"`
+	BeadID        string                 `json:"bead_id,omitempty"`
+	Project       string                 `json:"project,omitempty"`
+	Owner         string                 `json:"owner,omitempty"`
+	OwnerType     string                 `json:"owner_type,omitempty"`
+	ReasonCode    string                 `json:"reason_code,omitempty"`
+	DedupeKey     string                 `json:"dedupe_key,omitempty"`
+	BeadCandidate bool                   `json:"bead_candidate,omitempty"`
+	NextAction    string                 `json:"next_action,omitempty"`
+	Context       map[string]interface{} `json:"context,omitempty"`
+	CreatedAt     string                 `json:"created_at"`
+	DurationMs    int64                  `json:"duration_ms"`
+	Count         int                    `json:"count"`
+}
+
+func alertInfoFromAlert(a alerts.Alert, defaultProject string) AlertInfo {
+	info := AlertInfo{
+		ID:            a.ID,
+		Source:        a.Source,
+		Type:          string(a.Type),
+		Severity:      string(a.Severity),
+		Message:       a.Message,
+		Session:       a.Session,
+		Pane:          a.Pane,
+		BeadID:        a.BeadID,
+		Context:       a.Context,
+		CreatedAt:     a.CreatedAt.Format(time.RFC3339),
+		DurationMs:    a.Duration().Milliseconds(),
+		Count:         a.Count,
+		DedupeKey:     alertDedupeKey(a),
+		BeadCandidate: alertBeadCandidate(a),
+		NextAction:    alertNextAction(a),
+	}
+	info.Project, info.Owner, info.OwnerType, info.ReasonCode = alertRouting(a, defaultProject)
+	return info
+}
+
+func alertDedupeKey(a alerts.Alert) string {
+	if strings.TrimSpace(a.ID) != "" {
+		return "ntm-alert:" + strings.TrimSpace(a.ID)
+	}
+	parts := []string{string(a.Type), strings.TrimSpace(a.Session), strings.TrimSpace(a.Pane), strings.TrimSpace(a.BeadID)}
+	for i, part := range parts {
+		if part == "" {
+			parts[i] = "_"
+		}
+	}
+	return "ntm-alert:" + strings.Join(parts, ":")
+}
+
+func alertRouting(a alerts.Alert, defaultProject string) (project, owner, ownerType, reasonCode string) {
+	project = firstContextString(a.Context, "project_key", "project_dir", "project", "workspace")
+	if project == "" && strings.TrimSpace(a.Session) != "" {
+		project = strings.TrimSpace(a.Session)
+	}
+	if project == "" {
+		project = strings.TrimSpace(defaultProject)
+	}
+
+	switch {
+	case strings.TrimSpace(a.BeadID) != "":
+		owner = strings.TrimSpace(firstContextString(a.Context, "assignee", "owner"))
+		if owner != "" {
+			ownerType = "bead_assignee"
+		} else {
+			owner = strings.TrimSpace(a.BeadID)
+			ownerType = "bead"
+		}
+	case strings.TrimSpace(a.Session) != "":
+		owner = strings.TrimSpace(a.Session)
+		ownerType = "session"
+	case strings.TrimSpace(a.Source) != "":
+		owner = strings.TrimSpace(a.Source)
+		ownerType = "alert_source"
+	}
+
+	if owner == "" {
+		reasonCode = "owner_not_inferred"
+	}
+	return project, owner, ownerType, reasonCode
+}
+
+func firstContextString(ctx map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if raw, ok := ctx[key]; ok {
+			if value := strings.TrimSpace(fmt.Sprint(raw)); value != "" && value != "<nil>" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func alertNextAction(a alerts.Alert) string {
+	if strings.TrimSpace(a.BeadID) != "" {
+		if a.Type == alerts.AlertBeadStale {
+			return "reassign_or_close_stale_in_progress_bead"
+		}
+		return "inspect_linked_bead"
+	}
+
+	switch a.Type {
+	case alerts.AlertAgentError, alerts.AlertAgentCrashed, alerts.AlertRateLimit:
+		return "create_or_link_agent_alert_bead"
+	case alerts.AlertDependencyCycle:
+		return "run_bv_dep_cycles"
+	case alerts.AlertDiskLow:
+		return "free_disk_space"
+	case alerts.AlertFileConflict:
+		return "resolve_file_reservation_conflict"
+	default:
+		return "inspect_alert_source"
+	}
+}
+
+func alertBeadCandidate(a alerts.Alert) bool {
+	if strings.TrimSpace(a.BeadID) != "" {
+		return false
+	}
+	switch a.Type {
+	case alerts.AlertAgentError, alerts.AlertAgentCrashed, alerts.AlertRateLimit:
+		return true
+	default:
+		return false
+	}
 }
 
 // AlertSummaryInfo provides aggregate alert statistics
@@ -8933,38 +9052,13 @@ func GetAlertsDetailed(includeResolved bool) (*AlertsOutput, error) {
 	}
 
 	for i, a := range active {
-		output.Active[i] = AlertInfo{
-			ID:         a.ID,
-			Type:       string(a.Type),
-			Severity:   string(a.Severity),
-			Message:    a.Message,
-			Session:    a.Session,
-			Pane:       a.Pane,
-			BeadID:     a.BeadID,
-			Context:    a.Context,
-			CreatedAt:  a.CreatedAt.Format(time.RFC3339),
-			DurationMs: a.Duration().Milliseconds(),
-			Count:      a.Count,
-		}
+		output.Active[i] = alertInfoFromAlert(a, wd)
 	}
 
 	if includeResolved {
 		output.Resolved = make([]AlertInfo, len(resolved))
 		for i, a := range resolved {
-			output.Resolved[i] = AlertInfo{
-				ID:         a.ID,
-				Source:     a.Source,
-				Type:       string(a.Type),
-				Severity:   string(a.Severity),
-				Message:    a.Message,
-				Session:    a.Session,
-				Pane:       a.Pane,
-				BeadID:     a.BeadID,
-				Context:    a.Context,
-				CreatedAt:  a.CreatedAt.Format(time.RFC3339),
-				DurationMs: a.Duration().Milliseconds(),
-				Count:      a.Count,
-			}
+			output.Resolved[i] = alertInfoFromAlert(a, wd)
 		}
 	}
 

--- a/internal/robot/robot_test.go
+++ b/internal/robot/robot_test.go
@@ -3108,6 +3108,97 @@ func TestGetAlertsDetailedRespectsDisabledAlertsConfig(t *testing.T) {
 	}
 }
 
+func TestAlertInfoFromAlertRoutesAgentErrors(t *testing.T) {
+	info := alertInfoFromAlert(alerts.Alert{
+		ID:       "agent-alert-1",
+		Source:   "agents:alpsinsurance",
+		Type:     alerts.AlertAgentError,
+		Severity: alerts.SeverityError,
+		Message:  "Error detected in agent output",
+		Session:  "alpsinsurance",
+		Pane:     "%32",
+		Context:  map[string]interface{}{"matched_line": "error: failed"},
+		Count:    1,
+	}, "/Users/josh/Developer/skillos")
+
+	if info.Source != "agents:alpsinsurance" {
+		t.Fatalf("Source = %q, want agents:alpsinsurance", info.Source)
+	}
+	if info.Project != "alpsinsurance" {
+		t.Fatalf("Project = %q, want alpsinsurance", info.Project)
+	}
+	if info.Owner != "alpsinsurance" || info.OwnerType != "session" {
+		t.Fatalf("owner routing = %q/%q, want alpsinsurance/session", info.Owner, info.OwnerType)
+	}
+	if info.DedupeKey != "ntm-alert:agent-alert-1" {
+		t.Fatalf("DedupeKey = %q", info.DedupeKey)
+	}
+	if info.NextAction != "create_or_link_agent_alert_bead" {
+		t.Fatalf("NextAction = %q", info.NextAction)
+	}
+	if !info.BeadCandidate {
+		t.Fatal("BeadCandidate = false, want true for unlinked agent alert")
+	}
+	if info.ReasonCode != "" {
+		t.Fatalf("ReasonCode = %q, want empty when owner is inferred", info.ReasonCode)
+	}
+}
+
+func TestAlertInfoFromAlertRoutesStaleBeads(t *testing.T) {
+	info := alertInfoFromAlert(alerts.Alert{
+		ID:       "bead-stale-1",
+		Source:   "beads",
+		Type:     alerts.AlertBeadStale,
+		Severity: alerts.SeverityWarning,
+		Message:  "Bead skillos-byftm has been in_progress",
+		BeadID:   "skillos-byftm",
+		Context: map[string]interface{}{
+			"assignee":     "MagentaOwl",
+			"title":        "Land stale HOME-substrate WIP branch",
+			"last_updated": "2026-06-09T19:57:45Z",
+		},
+		Count: 1,
+	}, "/Users/josh/Developer/skillos")
+
+	if info.Project != "/Users/josh/Developer/skillos" {
+		t.Fatalf("Project = %q, want SkillOS project path", info.Project)
+	}
+	if info.Owner != "MagentaOwl" || info.OwnerType != "bead_assignee" {
+		t.Fatalf("owner routing = %q/%q, want MagentaOwl/bead_assignee", info.Owner, info.OwnerType)
+	}
+	if info.BeadID != "skillos-byftm" {
+		t.Fatalf("BeadID = %q", info.BeadID)
+	}
+	if info.NextAction != "reassign_or_close_stale_in_progress_bead" {
+		t.Fatalf("NextAction = %q", info.NextAction)
+	}
+	if info.DedupeKey != "ntm-alert:bead-stale-1" {
+		t.Fatalf("DedupeKey = %q", info.DedupeKey)
+	}
+	if info.BeadCandidate {
+		t.Fatal("BeadCandidate = true, want false for linked stale bead alert")
+	}
+}
+
+func TestAlertInfoFromAlertExplainsMissingOwner(t *testing.T) {
+	info := alertInfoFromAlert(alerts.Alert{
+		ID:       "source-less",
+		Type:     alerts.AlertQuotaWarning,
+		Severity: alerts.SeverityWarning,
+		Message:  "quota warning",
+	}, "")
+
+	if info.Owner != "" || info.OwnerType != "" {
+		t.Fatalf("owner routing = %q/%q, want empty", info.Owner, info.OwnerType)
+	}
+	if info.ReasonCode != "owner_not_inferred" {
+		t.Fatalf("ReasonCode = %q, want owner_not_inferred", info.ReasonCode)
+	}
+	if info.DedupeKey != "ntm-alert:source-less" {
+		t.Fatalf("DedupeKey = %q", info.DedupeKey)
+	}
+}
+
 func TestBuildProjectionBackedSnapshotSessionsUsesRuntimeProjection(t *testing.T) {
 	tmpDir := t.TempDir()
 	store, err := state.Open(filepath.Join(tmpDir, "state.db"))

--- a/internal/robot/testdata/robot_redesign/goldens/schema_snapshot.golden.json
+++ b/internal/robot/testdata/robot_redesign/goldens/schema_snapshot.golden.json
@@ -116,6 +116,10 @@
       },
       "AlertInfo": {
         "properties": {
+          "bead_candidate": {
+            "description": "Bead candidate",
+            "type": "boolean"
+          },
           "bead_id": {
             "description": "Bead i d",
             "type": "string"
@@ -133,6 +137,10 @@
             "description": "Created at",
             "type": "string"
           },
+          "dedupe_key": {
+            "description": "Dedupe key",
+            "type": "string"
+          },
           "duration_ms": {
             "description": "Duration ms",
             "type": "integer"
@@ -145,8 +153,28 @@
             "description": "Message",
             "type": "string"
           },
+          "next_action": {
+            "description": "Next action",
+            "type": "string"
+          },
+          "owner": {
+            "description": "Owner",
+            "type": "string"
+          },
+          "owner_type": {
+            "description": "Owner type",
+            "type": "string"
+          },
           "pane": {
             "description": "Pane",
+            "type": "string"
+          },
+          "project": {
+            "description": "Project",
+            "type": "string"
+          },
+          "reason_code": {
+            "description": "Reason code",
             "type": "string"
           },
           "session": {

--- a/internal/robot/tui_parity.go
+++ b/internal/robot/tui_parity.go
@@ -3048,15 +3048,25 @@ type TUIAlertsOutput struct {
 
 // TUIAlertInfo represents a single alert with TUI-parity fields
 type TUIAlertInfo struct {
-	ID          string `json:"id"`
-	Type        string `json:"type"`     // "agent_stuck", "disk_low", "mail_backlog", etc.
-	Severity    string `json:"severity"` // "info", "warning", "error", "critical"
-	Session     string `json:"session,omitempty"`
-	Pane        string `json:"pane,omitempty"`
-	Message     string `json:"message"`
-	CreatedAt   string `json:"created_at"` // RFC3339
-	AgeSeconds  int    `json:"age_seconds"`
-	Dismissible bool   `json:"dismissible"`
+	ID            string                 `json:"id"`
+	Source        string                 `json:"source,omitempty"`
+	Type          string                 `json:"type"`     // "agent_stuck", "disk_low", "mail_backlog", etc.
+	Severity      string                 `json:"severity"` // "info", "warning", "error", "critical"
+	Session       string                 `json:"session,omitempty"`
+	Pane          string                 `json:"pane,omitempty"`
+	BeadID        string                 `json:"bead_id,omitempty"`
+	Project       string                 `json:"project,omitempty"`
+	Owner         string                 `json:"owner,omitempty"`
+	OwnerType     string                 `json:"owner_type,omitempty"`
+	ReasonCode    string                 `json:"reason_code,omitempty"`
+	DedupeKey     string                 `json:"dedupe_key,omitempty"`
+	BeadCandidate bool                   `json:"bead_candidate,omitempty"`
+	NextAction    string                 `json:"next_action,omitempty"`
+	Context       map[string]interface{} `json:"context,omitempty"`
+	Message       string                 `json:"message"`
+	CreatedAt     string                 `json:"created_at"` // RFC3339
+	AgeSeconds    int                    `json:"age_seconds"`
+	Dismissible   bool                   `json:"dismissible"`
 }
 
 // TUIAlertsOptions configures alerts query for TUI parity
@@ -3079,6 +3089,7 @@ func GetAlertsTUI(cfg *config.Config, opts TUIAlertsOptions) (*TUIAlertsOutput, 
 	// disabled/custom alert settings remain authoritative here too.
 	alertCfg := alertConfigForProject(cfg, "")
 	alertList := alerts.GetActiveAlerts(alertCfg)
+	defaultProject := strings.TrimSpace(alertCfg.ProjectsDir)
 
 	now := time.Now()
 	for _, a := range alertList {
@@ -3093,17 +3104,7 @@ func GetAlertsTUI(cfg *config.Config, opts TUIAlertsOptions) (*TUIAlertsOutput, 
 			continue
 		}
 
-		info := TUIAlertInfo{
-			ID:          a.ID,
-			Type:        string(a.Type),
-			Severity:    string(a.Severity),
-			Session:     a.Session,
-			Pane:        a.Pane,
-			Message:     a.Message,
-			CreatedAt:   FormatTimestamp(a.CreatedAt),
-			AgeSeconds:  int(now.Sub(a.CreatedAt).Seconds()),
-			Dismissible: true,
-		}
+		info := tuiAlertInfoFromAlert(a, defaultProject, now)
 
 		output.Alerts = append(output.Alerts, info)
 	}
@@ -3133,6 +3134,31 @@ func GetAlertsTUI(cfg *config.Config, opts TUIAlertsOptions) (*TUIAlertsOutput, 
 	}
 
 	return output, nil
+}
+
+func tuiAlertInfoFromAlert(a alerts.Alert, defaultProject string, now time.Time) TUIAlertInfo {
+	routed := alertInfoFromAlert(a, defaultProject)
+	return TUIAlertInfo{
+		ID:            routed.ID,
+		Source:        routed.Source,
+		Type:          routed.Type,
+		Severity:      routed.Severity,
+		Session:       routed.Session,
+		Pane:          routed.Pane,
+		BeadID:        routed.BeadID,
+		Project:       routed.Project,
+		Owner:         routed.Owner,
+		OwnerType:     routed.OwnerType,
+		ReasonCode:    routed.ReasonCode,
+		DedupeKey:     routed.DedupeKey,
+		BeadCandidate: routed.BeadCandidate,
+		NextAction:    routed.NextAction,
+		Context:       routed.Context,
+		Message:       routed.Message,
+		CreatedAt:     FormatTimestamp(a.CreatedAt),
+		AgeSeconds:    int(now.Sub(a.CreatedAt).Seconds()),
+		Dismissible:   true,
+	}
 }
 
 // PrintAlertsTUI outputs current alerts with TUI-parity formatting.

--- a/internal/robot/tui_parity_test.go
+++ b/internal/robot/tui_parity_test.go
@@ -1096,6 +1096,46 @@ func TestAlertInfoFromRealAlert(t *testing.T) {
 	}
 }
 
+func TestTUIAlertInfoFromAlertIncludesRoutingMetadata(t *testing.T) {
+	now := time.Now()
+	info := tuiAlertInfoFromAlert(alerts.Alert{
+		ID:       "agent-alert-1",
+		Source:   "agents:vrtx",
+		Type:     alerts.AlertAgentError,
+		Severity: alerts.SeverityError,
+		Session:  "vrtx",
+		Pane:     "%36",
+		Message:  "Error detected in agent output",
+		Context:  map[string]interface{}{"matched_line": "error: failed"},
+		Count:    2,
+	}, "/Users/josh/Developer/skillos", now)
+
+	if info.Source != "agents:vrtx" {
+		t.Fatalf("Source = %q, want agents:vrtx", info.Source)
+	}
+	if info.Project != "vrtx" {
+		t.Fatalf("Project = %q, want vrtx", info.Project)
+	}
+	if info.Owner != "vrtx" || info.OwnerType != "session" {
+		t.Fatalf("owner routing = %q/%q, want vrtx/session", info.Owner, info.OwnerType)
+	}
+	if info.DedupeKey != "ntm-alert:agent-alert-1" {
+		t.Fatalf("DedupeKey = %q", info.DedupeKey)
+	}
+	if info.NextAction != "create_or_link_agent_alert_bead" {
+		t.Fatalf("NextAction = %q", info.NextAction)
+	}
+	if !info.BeadCandidate {
+		t.Fatal("BeadCandidate = false, want true for unlinked agent alert")
+	}
+	if info.ReasonCode != "" {
+		t.Fatalf("ReasonCode = %q, want empty when owner is inferred", info.ReasonCode)
+	}
+	if !info.Dismissible {
+		t.Fatal("Dismissible = false, want true")
+	}
+}
+
 // =============================================================================
 // PrintInspectPane Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- add owner routing metadata to `--robot-alerts --json` output
- include project, owner, owner_type, reason_code, dedupe_key, bead_candidate, and next_action on alert rows
- share routing logic with TUI parity output and pin the JSON schema golden

## Validation
- `go test ./internal/robot -run 'TestAlertInfoFromAlert|TestTUIAlertInfoFromAlertIncludesRoutingMetadata|TestGetAlertsDetailedRespectsDisabledAlertsConfig|TestGolden_CoreSchemas/Snapshot'`\n- `go build ./cmd/ntm`\n- `go run ./cmd/ntm --robot-alerts --json` returned routed alert rows with project/owner/dedupe/next_action fields\n\nContext: SkillOS bead `skillos-21dgk` found that robot alerts exposed fleet errors without routing them to the session/bead/source owner, leaving downstream automation unable to decide whether to create/link a bead or inspect a linked stale bead.