### PR TITLE
Harden agent lifecycle: menu-state recovery, idle-dispatch race, claude --effort threading, kill orphan-reap

### DIFF
--- a/internal/agent/menu_detect_test.go
+++ b/internal/agent/menu_detect_test.go
@@ -1,0 +1,50 @@
+package agent
+import "testing"
+
+// realMenuFooters are footers captured live from Claude Code pickers. Each must
+// classify the pane as menu-blocked so autonomous dispatch can Esc-recover it.
+var realMenuFooters = map[string]string{
+	"effort/list picker": "  5. Chat about this\n\nEnter to select · Tab/Arrow keys to navigate · Esc to cancel\n",
+	"wrapped nav hint":   "  5. Chat about this\n\nEnter to select · Tab/Arrow keys to\nnavigate · Esc to cancel\n",
+	"/model picker":      "  ◐ Medium effort ←/→ to adjust\n  Enter to set as default · s to use\n  this session only · Esc to cancel\n",
+}
+
+func TestInteractiveMenuDetection(t *testing.T) {
+	for name, footer := range realMenuFooters {
+		body := "  Some agent output above.\n────────────────────────────────────────\n" + footer
+		st, _ := NewParser().ParseWithHint(body, AgentTypeClaudeCode)
+		if !st.IsMenuBlocked {
+			t.Errorf("[%s] IsMenuBlocked=false, want true", name)
+		}
+		if st.IsIdle || st.IsWorking {
+			t.Errorf("[%s] should be neither idle nor working; idle=%v working=%v", name, st.IsIdle, st.IsWorking)
+		}
+		if got := st.GetRecommendation(); got != RecommendRecoverMenu {
+			t.Errorf("[%s] recommendation=%v, want RECOVER_MENU", name, got)
+		}
+	}
+}
+
+func TestCleanIdleNotMenu(t *testing.T) {
+	idle := "✻ Baked for 16m 20s\n\n────────\n❯ \n────────\n  ⏵⏵ bypass permissions on          ·\n"
+	st, _ := NewParser().ParseWithHint(idle, AgentTypeClaudeCode)
+	if st.IsMenuBlocked {
+		t.Errorf("clean idle pane wrongly flagged IsMenuBlocked")
+	}
+	if !st.IsIdle {
+		t.Errorf("clean idle pane should be idle; got idle=%v", st.IsIdle)
+	}
+}
+
+func TestProseNotMenu(t *testing.T) {
+	// Prose mentioning one phrase but not the menu structure must not match.
+	for _, prose := range []string{
+		"I will let you select the option and press Enter when ready.\n❯ \n",
+		"Press Esc to cancel the operation if needed; otherwise continue.\n❯ \n",
+	} {
+		st, _ := NewParser().ParseWithHint(prose, AgentTypeClaudeCode)
+		if st.IsMenuBlocked {
+			t.Errorf("prose wrongly flagged as menu: %q", prose)
+		}
+	}
+}

--- a/internal/agent/parser.go
+++ b/internal/agent/parser.go
@@ -214,6 +214,21 @@ func (p *parserImpl) detectStateFlags(output string, state *AgentState) {
 		return
 	}
 
+	// Interactive-menu detection (checked before idle/working). When a Claude
+	// Code selection menu is the LIVE state — the /effort or /model picker, a
+	// permission selector — the pane is parked awaiting an Enter/arrow choice.
+	// It is neither a dispatchable text prompt (a sent prompt would be typed
+	// into the menu) nor active work, so we surface it as a distinct, recoverable
+	// state instead of letting it fall through to UNKNOWN. Autonomous dispatch
+	// can then Esc-recover the pane to a clean prompt before assigning.
+	if p.detectInteractiveMenu(output, state.Type) {
+		state.IsMenuBlocked = true
+		state.IsIdle = false
+		state.IsWorking = false
+		state.IsInError = p.detectError(output, state.Type)
+		return
+	}
+
 	// Idle detection
 	// We check this BEFORE trusting IsWorking, because IsWorking patterns
 	// (like "testing", "running") might still be present in the scrollback
@@ -270,6 +285,24 @@ func (p *parserImpl) detectRateLimit(output string, agentType AgentType) bool {
 			matchAny(recentOutput, aiderRateLimitPatterns) ||
 			matchAny(recentOutput, ollamaRateLimitPatterns)
 	}
+}
+
+// detectInteractiveMenu reports whether the live tail of the pane is showing a
+// Claude Code interactive selection menu (the /effort or /model picker, a
+// permission selector, etc.). It scans only the recent tail so a menu that was
+// dismissed earlier in the scrollback does not strand the pane: the
+// distinctive nav-hint footer ("Enter to select · Tab/Arrow keys to navigate ·
+// Esc to cancel") is only rendered while the menu is actually open. Menus are
+// currently a Claude-Code-only affordance; other concrete agent types return
+// false (Unknown is allowed through so content-detected CC panes still match).
+func (p *parserImpl) detectInteractiveMenu(output string, agentType AgentType) bool {
+	if agentType != AgentTypeClaudeCode && agentType != AgentTypeUnknown {
+		return false
+	}
+	// 8 lines is enough to catch the footer even when the hint wraps across
+	// two lines, while staying well clear of stale menus higher in scrollback.
+	lastLines := util.GetLastNLines(output, 8)
+	return matchAnyRegex(lastLines, ccMenuPatterns)
 }
 
 // detectWorking checks if the agent is actively producing output.

--- a/internal/agent/patterns.go
+++ b/internal/agent/patterns.go
@@ -90,6 +90,31 @@ var (
 		regexp.MustCompile(`Running…`),          // Explicit running spinner
 	}
 
+	// ccMenuPatterns detect Claude Code's interactive selection-menu footer
+	// (the /effort picker, /model picker, permission selectors, etc.). When one
+	// of these is the live state, the pane is parked waiting for an Enter/arrow
+	// selection — it is NOT a dispatchable text prompt and NOT actively working.
+	// An agent stranded here (e.g. a `/effort` send that opened the picker but
+	// never confirmed) otherwise classifies as UNKNOWN and is invisible to
+	// autonomous dispatch + recovery. We key on the highly distinctive nav hint
+	// rather than the menu body so normal prose can't false-match; the hint can
+	// wrap across two lines, so we tolerate the line break between phrases.
+	// The invariant across Claude Code's selection menus is a confirm/navigate
+	// hint paired with "Esc to cancel" in the (often line-wrapped) footer. The
+	// concrete footer text varies by picker, e.g.:
+	//   "Enter to select · Tab/Arrow keys to navigate · Esc to cancel"   (/effort, lists)
+	//   "Enter to set as default · s to use this session only · Esc to cancel"  (/model)
+	//   "◐ Medium effort ←/→ to adjust … Esc to cancel"                  (effort adjuster)
+	// We require BOTH halves within a bounded, newline-tolerant window so prose
+	// that merely mentions one phrase can't false-match. The bound keeps a stray
+	// "Esc to cancel" far from a hint (e.g. across unrelated output) from matching.
+	ccMenuPatterns = []*regexp.Regexp{
+		// "Enter to <verb> …  Esc to cancel"  (select / set as default / confirm / …)
+		regexp.MustCompile(`(?is)\benter\s+to\s+\S+.{0,160}?\besc\s+to\s+cancel\b`),
+		// Arrow-key navigation hint …  Esc to cancel
+		regexp.MustCompile(`(?is)(?:tab/arrow|arrow\s+keys|←/→|↑/↓|→/←).{0,160}?\besc\s+to\s+cancel\b`),
+	}
+
 	// ccErrorPatterns indicates an error condition.
 	ccErrorPatterns = []string{
 		"error:",

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -171,6 +171,7 @@ type AgentState struct {
 	IsContextLow  bool `json:"context_low"`  // Below configured threshold
 	IsIdle        bool `json:"is_idle"`      // Waiting for user input (safe to restart)
 	IsInError     bool `json:"is_in_error"`  // Error state detected
+	IsMenuBlocked bool `json:"is_menu_blocked"` // Stuck at an interactive selection menu (e.g. /effort, /model picker); needs Esc to recover before it can take work
 
 	// Evidence for debugging and confidence calculation
 	WorkIndicators  []string `json:"work_indicators,omitempty"`  // Patterns that indicate working
@@ -204,6 +205,13 @@ const (
 	// RecommendErrorState means the agent is in an error state and may need intervention.
 	RecommendErrorState Recommendation = "ERROR_STATE"
 
+	// RecommendRecoverMenu means the agent is stuck at an interactive selection menu
+	// (e.g. the /effort or /model picker) and is not dispatchable as-is: sending a text
+	// prompt would be typed into the menu. An orchestrator should send Esc to return the
+	// pane to a clean prompt, after which it becomes idle and dispatchable. This is a
+	// recoverable, machine-actionable state — distinct from UNKNOWN, which is a dead end.
+	RecommendRecoverMenu Recommendation = "RECOVER_MENU"
+
 	// RecommendUnknown means we couldn't determine the agent state with confidence.
 	RecommendUnknown Recommendation = "UNKNOWN"
 )
@@ -233,6 +241,15 @@ func (s *AgentState) GetRecommendation() Recommendation {
 			return RecommendContextLowContinue
 		}
 		return RecommendDoNotInterrupt
+	}
+
+	// Priority 3.5: Menu-blocked - the agent is parked at an interactive selection
+	// menu (not generating, not a clean prompt). Surfaced over Idle because a text
+	// dispatch would be typed INTO the menu; the orchestrator must Esc-recover first.
+	// Placed after Working so a genuine in-flight turn is never interrupted on a
+	// false menu match (the parser also clears IsWorking when a live menu is seen).
+	if s.IsMenuBlocked {
+		return RecommendRecoverMenu
 	}
 
 	// Priority 4: Idle - safe to take action

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -956,6 +956,9 @@ func getAssignOutput(opts robot.AssignOptions) (*robot.AssignOutput, error) {
 		// Capture state
 		scrollback, _ := tmux.CaptureForStatusDetection(pane.ID)
 		state := determineAgentState(scrollback, agentType)
+		// Self-heal a menu strand (e.g. a /effort picker left open) so the pane
+		// becomes dispatchable instead of being skipped as a dead UNKNOWN.
+		state = recoverIfMenuBlocked(pane.ID, agentType, state)
 		if state == "idle" {
 			idleAgentPanes = append(idleAgentPanes, fmt.Sprintf("%d", pane.Index))
 		}
@@ -1166,6 +1169,15 @@ func determineAgentState(scrollback, agentTypeStr string) string {
 		return "unknown"
 	}
 
+	// Menu-blocked is reported before the live-window working check: a pane
+	// parked at an interactive selection menu (e.g. the /effort picker) is not
+	// doing useful work and must be Esc-recovered before it can take a dispatch.
+	// A distinct state lets callers recover it instead of treating it as a dead
+	// "unknown" — the pre-fix behaviour that stranded /effort sends as UNKNOWN.
+	if state.IsMenuBlocked {
+		return "menu_blocked"
+	}
+
 	// Live-window THINKING check overrides any verdict — the legacy parser
 	// can miss in-flight work when the assignment store has no record.
 	if robot.IsLiveBusy(scrollback, agentTypeStr) {
@@ -1180,6 +1192,30 @@ func determineAgentState(scrollback, agentTypeStr string) string {
 	}
 
 	return "unknown"
+}
+
+// recoverIfMenuBlocked Esc-recovers a pane parked at an interactive selection
+// menu (the /effort or /model picker, a permission selector) and returns the
+// re-evaluated state. When the pane is not menu-blocked it returns the input
+// state unchanged and sends no keystroke, so it is safe to call on every pane
+// during an idle scan or a direct dispatch. This is what lets autonomous
+// dispatch self-heal a menu strand into a dispatchable idle pane instead of
+// skipping it as UNKNOWN — the failure that previously stalled the swarm when
+// an interactive `/effort` send opened a picker that nothing confirmed.
+func recoverIfMenuBlocked(paneTarget, agentType, state string) string {
+	if state != "menu_blocked" {
+		return state
+	}
+	if err := tmux.SendEscape(paneTarget); err != nil {
+		return state
+	}
+	// Brief settle so the TUI redraws the clean prompt before we re-read.
+	time.Sleep(200 * time.Millisecond)
+	scrollback, err := tmux.CaptureForStatusDetection(paneTarget)
+	if err != nil {
+		return state
+	}
+	return determineAgentState(scrollback, agentType)
 }
 
 func normalizedAssignAgentHint(agentTypeStr string) agent.AgentType {
@@ -1546,6 +1582,7 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 		model := detectModelFromTitle(at, pane.Title)
 		scrollback, _ := tmux.CaptureForStatusDetection(pane.ID)
 		state := determineAgentState(scrollback, at)
+		state = recoverIfMenuBlocked(pane.ID, at, state)
 
 		if state == "idle" {
 			idleAgents = append(idleAgents, assignAgentInfo{
@@ -3430,6 +3467,9 @@ func runReassignment(cmd *cobra.Command, session string) error {
 	// Check if target pane is busy (unless --force)
 	scrollback, _ := tmux.CapturePaneOutput(targetPane.ID, 10)
 	state := determineAgentState(scrollback, targetAgentType)
+	// If the pane is parked at an interactive menu, Esc-recover it to a clean
+	// prompt so a direct dispatch lands instead of being refused as busy.
+	state = recoverIfMenuBlocked(targetPane.ID, targetAgentType, state)
 
 	if state != "idle" && !assignForce {
 		// Check if pane has an existing assignment
@@ -4153,6 +4193,7 @@ func runDirectPaneAssignment(cmd *cobra.Command, opts *AssignCommandOptions) err
 
 	scrollback, _ := tmux.CapturePaneOutput(targetPane.ID, 10)
 	state := determineAgentState(scrollback, agentType)
+	state = recoverIfMenuBlocked(targetPane.ID, agentType, state)
 
 	// Build assignment item
 	assignItem := &DirectAssignItem{
@@ -4580,6 +4621,7 @@ func getIdleAgents(session, agentTypeFilter string, verbose bool) ([]assignAgent
 		model := detectModelFromTitle(agentType, pane.Title)
 		scrollback, _ := tmux.CaptureForStatusDetection(pane.ID)
 		state := determineAgentState(scrollback, agentType)
+		state = recoverIfMenuBlocked(pane.ID, agentType, state)
 
 		if state == "idle" {
 			idleAgents = append(idleAgents, assignAgentInfo{

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -776,6 +776,26 @@ func loadActiveAssignmentBeadIDs(session string) map[string]struct{} {
 	return active
 }
 
+// loadActiveAssignmentPanes returns the set of pane indices that currently hold
+// an active (assigned/working, not completed/failed) assignment. A pane in this
+// set is responsible for an in-flight bead and must NOT receive a second one,
+// even when its screen momentarily shows an idle prompt between turns — the
+// between-turns race that otherwise lets the watch loop pile a new bead onto a
+// pane already working one. The watch's completion detector marks assignments
+// completed when their bead closes, so a pane is released from this set the
+// moment its work is genuinely done; excluding it here cannot strand it.
+func loadActiveAssignmentPanes(session string) map[int]struct{} {
+	active := make(map[int]struct{})
+	store, err := assignment.LoadStore(session)
+	if err != nil {
+		return active
+	}
+	for _, item := range store.ListActive() {
+		active[item.Pane] = struct{}{}
+	}
+	return active
+}
+
 // countSkippedByReason counts SkippedItems matching a specific reason. Used to
 // keep BlockedCount in the assignment summary semantically narrow ("blocked by
 // a dependency") even after the broader skipped-reason taxonomy was added.
@@ -943,6 +963,7 @@ func getAssignOutput(opts robot.AssignOptions) (*robot.AssignOutput, error) {
 	}
 
 	// Build agent info similar to robot.PrintAssign
+	activePanes := loadActiveAssignmentPanes(opts.Session)
 	var idleAgentPanes []string
 	totalAgents := 0
 
@@ -959,7 +980,8 @@ func getAssignOutput(opts robot.AssignOptions) (*robot.AssignOutput, error) {
 		// Self-heal a menu strand (e.g. a /effort picker left open) so the pane
 		// becomes dispatchable instead of being skipped as a dead UNKNOWN.
 		state = recoverIfMenuBlocked(pane.ID, agentType, state)
-		if state == "idle" {
+		// Skip panes that already hold an in-flight assignment (between-turns race).
+		if _, busy := activePanes[pane.Index]; state == "idle" && !busy {
 			idleAgentPanes = append(idleAgentPanes, fmt.Sprintf("%d", pane.Index))
 		}
 	}
@@ -1566,6 +1588,11 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 	}
 
 	// Build agent info and filter by type if needed
+	// Panes already holding an in-flight assignment are not available for new
+	// work, even when their screen momentarily shows an idle prompt between
+	// turns — guarding against the between-turns race that otherwise piled a
+	// second bead onto a pane already working one.
+	activePanes := loadActiveAssignmentPanes(opts.Session)
 	var idleAgents []assignAgentInfo
 
 	for _, pane := range panes {
@@ -1584,7 +1611,7 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 		state := determineAgentState(scrollback, at)
 		state = recoverIfMenuBlocked(pane.ID, at, state)
 
-		if state == "idle" {
+		if _, busy := activePanes[pane.Index]; state == "idle" && !busy {
 			idleAgents = append(idleAgents, assignAgentInfo{
 				pane:       pane,
 				agentType:  at,
@@ -4605,6 +4632,8 @@ func getIdleAgents(session, agentTypeFilter string, verbose bool) ([]assignAgent
 		return nil, fmt.Errorf("failed to get panes: %w", err)
 	}
 
+	// Exclude panes already holding an in-flight assignment (between-turns race).
+	activePanes := loadActiveAssignmentPanes(session)
 	var idleAgents []assignAgentInfo
 
 	for _, pane := range panes {
@@ -4623,7 +4652,7 @@ func getIdleAgents(session, agentTypeFilter string, verbose bool) ([]assignAgent
 		state := determineAgentState(scrollback, agentType)
 		state = recoverIfMenuBlocked(pane.ID, agentType, state)
 
-		if state == "idle" {
+		if _, busy := activePanes[pane.Index]; state == "idle" && !busy {
 			idleAgents = append(idleAgents, assignAgentInfo{
 				pane:       pane,
 				agentType:  agentType,

--- a/internal/cli/assign_active_panes_test.go
+++ b/internal/cli/assign_active_panes_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/Dicklesworthstone/ntm/internal/assignment"
+)
+
+// A pane holding an active assignment must appear in the active-pane set so the
+// idle-collection paths exclude it from new dispatch (the between-turns race fix).
+func TestLoadActiveAssignmentPanes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store := assignment.NewStore("race-test")
+	if _, err := store.Assign("bead-A", "Some title", 3, "claude", "Agent", "prompt"); err != nil {
+		t.Fatalf("Assign failed: %v", err)
+	}
+
+	active := loadActiveAssignmentPanes("race-test")
+	if _, ok := active[3]; !ok {
+		t.Errorf("pane 3 (active assignment) missing from active set: %v", active)
+	}
+	if _, ok := active[5]; ok {
+		t.Errorf("pane 5 (no assignment) wrongly present in active set")
+	}
+}
+
+// An empty/missing store must yield an empty set (no panes excluded) so a fresh
+// session with no assignments dispatches normally.
+func TestLoadActiveAssignmentPanes_Empty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if active := loadActiveAssignmentPanes("nonexistent-session"); len(active) != 0 {
+		t.Errorf("expected empty active set for fresh session, got %v", active)
+	}
+}

--- a/internal/cli/kill_reap_test.go
+++ b/internal/cli/kill_reap_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	procpkg "github.com/Dicklesworthstone/ntm/internal/process"
+)
+
+// collectProcessSubtree must include a real child process under a parent.
+func TestCollectProcessSubtree(t *testing.T) {
+	// sh -c 'sleep 30 & wait' → sh has a child sleep
+	parent := exec.Command("sh", "-c", "sleep 30")
+	if err := parent.Start(); err != nil {
+		t.Fatalf("start parent: %v", err)
+	}
+	defer func() { _ = parent.Process.Kill(); _, _ = parent.Process.Wait() }()
+	time.Sleep(200 * time.Millisecond)
+
+	tree := collectProcessSubtree(parent.Process.Pid, 0)
+	if len(tree) == 0 || tree[0] != parent.Process.Pid {
+		t.Fatalf("subtree must start with parent pid; got %v", tree)
+	}
+}
+
+// reapOrphanedAgents must SIGTERM/SIGKILL a real orphan and leave it dead.
+func TestReapOrphanedAgents(t *testing.T) {
+	victim := exec.Command("sleep", "300")
+	if err := victim.Start(); err != nil {
+		t.Fatalf("start victim: %v", err)
+	}
+	pid := victim.Process.Pid
+	go func() { _, _ = victim.Process.Wait() }() // reap zombie after kill
+	time.Sleep(150 * time.Millisecond)
+
+	if !procpkg.IsAlive(pid) {
+		t.Fatalf("victim should be alive before reap")
+	}
+	if n := reapOrphanedAgents([]int{pid}); n != 1 {
+		t.Errorf("expected 1 signalled, got %d", n)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if procpkg.IsAlive(pid) {
+		t.Errorf("victim still alive after reap")
+	}
+}
+
+// Safety: self and pid<=1 must never be signalled.
+func TestReapExcludesSelfAndInit(t *testing.T) {
+	if n := reapOrphanedAgents([]int{1, 0, -5}); n != 0 {
+		t.Errorf("pid<=1 must be excluded; got %d", n)
+	}
+}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/integrations/dcg"
 	"github.com/Dicklesworthstone/ntm/internal/kernel"
 	"github.com/Dicklesworthstone/ntm/internal/output"
+	procpkg "github.com/Dicklesworthstone/ntm/internal/process"
 	"github.com/Dicklesworthstone/ntm/internal/prompt"
 	"github.com/Dicklesworthstone/ntm/internal/redaction"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
@@ -2220,10 +2221,30 @@ func runKill(w io.Writer, session string, force bool, tags []string, noHooks boo
 		_ = output
 	}
 
+	// Capture each pane's agent process subtree BEFORE the shells die. tmux
+	// kill-session terminates the pane shells but detached agent children
+	// (node-based claude/codex/gemini launched with --dangerously-skip-permissions)
+	// survive SIGHUP and reparent to init — leaking processes that hold agent-mail
+	// registrations and file locks. The tree must be walked now, because after the
+	// shells exit the children reparent and can no longer be found from the shell PID.
+	var agentPIDs []int
+	for _, p := range panesForStop {
+		if p.PID > 0 {
+			agentPIDs = append(agentPIDs, collectProcessSubtree(p.PID, 0)...)
+		}
+	}
+
 	if err := tmux.KillSession(session); err != nil {
 		return err
 	}
 	auditKilled = true
+
+	// Reap any agent processes orphaned by kill-session. Shells are already gone
+	// (SIGTERM on them is a harmless no-op); the surviving agents get a graceful
+	// SIGTERM then a SIGKILL backstop. self/parent are excluded defensively.
+	if reaped := reapOrphanedAgents(agentPIDs); reaped > 0 {
+		fmt.Printf("Reaped %d orphaned agent process(es)\n", reaped)
+	}
 
 	fmt.Printf("Killed session '%s'\n", session)
 
@@ -2248,6 +2269,55 @@ func runKill(w io.Writer, session string, force bool, tags []string, noHooks boo
 	}
 
 	return nil
+}
+
+// collectProcessSubtree returns pid plus all of its transitive descendants,
+// recursing through process.GetChildPIDs (which reads /proc on Linux and falls
+// back to pgrep elsewhere). The depth bound guards against cycles / runaway
+// recursion; the per-level child cap keeps a fork-bombed pane from exploding the
+// walk. Used to capture a pane's full agent process tree before the shell dies.
+func collectProcessSubtree(pid, depth int) []int {
+	if pid <= 1 || depth > 6 {
+		return nil
+	}
+	out := []int{pid}
+	for _, child := range procpkg.GetChildPIDs(pid, 64) {
+		out = append(out, collectProcessSubtree(child, depth+1)...)
+	}
+	return out
+}
+
+// reapOrphanedAgents terminates the given PIDs (a session's captured agent
+// process trees) after the tmux session has been killed. It sends SIGTERM, waits
+// a short grace period, then SIGKILLs any survivor. The current process and its
+// parent are excluded defensively, as are pid<=1; duplicates are de-duped.
+// Returns the number of distinct live processes that were signalled.
+func reapOrphanedAgents(pids []int) int {
+	self := os.Getpid()
+	parent := os.Getppid()
+	seen := make(map[int]bool, len(pids))
+	var signalled []int
+	for _, pid := range pids {
+		if pid <= 1 || pid == self || pid == parent || seen[pid] {
+			continue
+		}
+		seen[pid] = true
+		// SIGTERM; ESRCH (already-dead shells) is a harmless no-op.
+		if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
+			signalled = append(signalled, pid)
+		}
+	}
+	if len(signalled) == 0 {
+		return 0
+	}
+	// Grace period for clean shutdown, then a SIGKILL backstop for survivors.
+	time.Sleep(750 * time.Millisecond)
+	for _, pid := range signalled {
+		if procpkg.IsAlive(pid) {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	}
+	return len(signalled)
 }
 
 // runKillProject kills all sessions matching a base project name (bd-3cu02.14).

--- a/internal/config/claude_effort_test.go
+++ b/internal/config/claude_effort_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// The default Claude command template must thread ReasoningEffort into claude's
+// --effort flag (which the CLI supports), mirroring the Codex template's
+// model_reasoning_effort. Regression for the silent effort-drop: spawning a
+// Claude agent with an effort previously rendered no flag, forcing a fragile
+// interactive /effort send that could strand the agent at the picker menu.
+func TestClaudeTemplateThreadsEffort(t *testing.T) {
+	fm := template.FuncMap{
+		"memLimitPrefix": func() string { return "" },
+		"shellQuote":     func(s string) string { return s },
+	}
+	tp := template.Must(template.New("claude").Funcs(fm).Parse(DefaultAgentTemplates().Claude))
+
+	render := func(vars map[string]interface{}) string {
+		var b strings.Builder
+		if err := tp.Execute(&b, vars); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		return b.String()
+	}
+
+	withEffort := render(map[string]interface{}{"Model": "claude-opus-4-8", "ReasoningEffort": "xhigh"})
+	if !strings.Contains(withEffort, "--effort xhigh") {
+		t.Errorf("Claude template dropped effort; got: %s", withEffort)
+	}
+	noEffort := render(map[string]interface{}{"Model": "claude-opus-4-8"})
+	if strings.Contains(noEffort, "--effort") {
+		t.Errorf("empty effort must omit --effort; got: %s", noEffort)
+	}
+}

--- a/internal/config/templates.go
+++ b/internal/config/templates.go
@@ -229,7 +229,7 @@ func IsTemplateCommand(cmd string) bool {
 // System prompt injection is supported via SystemPromptFile for persona agents.
 func DefaultAgentTemplates() AgentConfig {
 	return AgentConfig{
-		Claude: `{{memLimitPrefix}} claude --dangerously-skip-permissions{{if .Model}} --model {{shellQuote .Model}}{{end}}{{if .SystemPromptFile}} --system-prompt-file {{shellQuote .SystemPromptFile}}{{end}}`,
+		Claude: `{{memLimitPrefix}} claude --dangerously-skip-permissions{{if .Model}} --model {{shellQuote .Model}}{{end}}{{if .ReasoningEffort}} --effort {{shellQuote .ReasoningEffort}}{{end}}{{if .SystemPromptFile}} --system-prompt-file {{shellQuote .SystemPromptFile}}{{end}}`,
 		Codex:  `{{if .SystemPromptFile}}CODEX_SYSTEM_PROMPT="$(cat {{shellQuote .SystemPromptFile}})" {{end}}codex --dangerously-bypass-approvals-and-sandbox -m {{shellQuote (.Model | default "gpt-5.5")}} -c model_reasoning_effort={{shellQuote (.ReasoningEffort | default "xhigh")}} -c model_reasoning_summary_format=experimental --search`,
 		Gemini: `gemini{{if .Model}} --model {{shellQuote .Model}}{{end}} --yolo`,
 		// Antigravity (agy): the model is hard-pinned to "Gemini 3.1 Pro (High)"

--- a/internal/robot/is_working.go
+++ b/internal/robot/is_working.go
@@ -57,6 +57,7 @@ type PaneWorkStatus struct {
 	AgentType            string         `json:"agent_type"`
 	IsWorking            bool           `json:"is_working"`
 	IsIdle               bool           `json:"is_idle"`
+	IsMenuBlocked        bool           `json:"is_menu_blocked"`
 	IsRateLimited        bool           `json:"is_rate_limited"`
 	IsContextLow         bool           `json:"is_context_low"`
 	ContextRemaining     *float64       `json:"context_remaining,omitempty"`
@@ -260,6 +261,7 @@ func GetIsWorking(opts IsWorkingOptions) (*IsWorkingOutput, error) {
 			AgentType:        string(state.Type),
 			IsWorking:        state.IsWorking,
 			IsIdle:           state.IsIdle,
+			IsMenuBlocked:    state.IsMenuBlocked,
 			IsRateLimited:    state.IsRateLimited,
 			IsContextLow:     state.IsContextLow,
 			ContextRemaining: state.ContextRemaining,

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -909,6 +909,16 @@ func (c *Client) SendKeysWithDelay(target, keys string, enter bool, enterDelay t
 	return nil
 }
 
+// SendEscape sends a single Escape key press to a pane. Unlike SendKeys (which
+// uses `send-keys -l`, literal mode, and would type the word "Escape"), this
+// passes "Escape" as a tmux key NAME so it registers as the Esc key. It is used
+// to dismiss an interactive selection menu (the /effort or /model picker, a
+// permission selector) and return the pane to a clean prompt — no Enter is
+// sent, so nothing in the menu is selected.
+func SendEscape(target string) error {
+	return DefaultClient.RunSilent("send-keys", "-t", target, "Escape")
+}
+
 // FormatPaneName formats a pane title according to NTM convention
 func FormatPaneName(session string, agentType string, index int, variant string) string {
 	normalizedType := strings.TrimSpace(agentType)


### PR DESCRIPTION
Four small, independent fixes to the agent lifecycle, each surfaced while running
`ntm assign --watch` autonomous dispatch against a live multi-agent swarm. Together they
close a failure chain that silently stalls a swarm, plus a dispatch race and a process
leak. **Every commit is atomic and independently cherry-pickable** — happy to split into
separate PRs if you'd prefer.

`+408 / −4` across 12 files; a new test accompanies every fix; fixes 1, 2 and 4 are verified
live end-to-end.

### The failure chain (why these belong together)

> spawn an agent at the wrong reasoning effort (fix 1) → operators reach for a post-spawn
> interactive `/effort`, which opens a picker menu → that menu state is invisible to the
> detector, so the agent is stranded and undispatchable (fix 2) → meanwhile auto-dispatch
> can double-assign a pane that's merely between turns (fix 3), and `ntm kill` leaks the
> agent processes on teardown (fix 4).

---

### 1 — Thread reasoning effort into the Claude command  (`f15d685`)  *(the root cause)*

`ntm spawn --cc=N:model:effort` parses the effort into the `AgentSpec` and passes it to the
command renderer, but the default **Claude** template (`internal/config/templates.go`) never
references `.ReasoningEffort` — while the **Codex** template threads `model_reasoning_effort`.
So Claude agents always launch at the saved CLI default, regardless of the requested effort.

`claude --effort <level>` is a real CLI flag; the template simply omitted it. One-line fix,
mirroring Codex:

```gotmpl
{{if .ReasoningEffort}} --effort {{shellQuote .ReasoningEffort}}{{end}}
```

Renders e.g. `claude --dangerously-skip-permissions --model claude-opus-4-8 --effort xhigh`;
omits the flag when effort is empty. Removes the need for the fragile post-spawn interactive
`/effort` workaround that causes the menu strand in fix 2.

*Follow-up (not in this PR): other hardcoded `claude --dangerously-skip-permissions` strings
in `internal/cli/setup.go` and `session_persist.go` may want the same threading.*

### 2 — Recognize + auto-recover the interactive-menu state  (`c81c809`)

A Claude Code pane parked at a selection menu (the `/effort` or `/model` picker, a permission
selector) classified as `UNKNOWN` — neither dispatchable nor recoverable. An agent stranded
there is invisible to `ntm assign`, which reports "0 idle agents" while agents sit
available-but-dead.

- New `AgentState.IsMenuBlocked` + `RECOVER_MENU` recommendation, surfaced in
  `--robot-is-working` as `is_menu_blocked`.
- `detectInteractiveMenu()` keys on the menu footer (a confirm/navigate hint **and**
  "Esc to cancel") within a bounded, newline-tolerant window of the live tail, so prose that
  merely mentions a phrase can't false-match. Covers the `/effort` list-picker footer
  (`Enter to select · Tab/Arrow keys to navigate · Esc to cancel`) and the `/model` footer
  (`Enter to set as default · s to use this session only · Esc to cancel`).
- `tmux.SendEscape()` sends a real **Esc key** — the existing `SendKeys` uses `send-keys -l`
  (literal), which would type the word "Escape".
- `recoverIfMenuBlocked()` Esc-recovers a strand to a clean prompt then dispatches; wired
  into all five dispatch / idle-scan paths in `assign.go`.

Verified live: open a `/model` menu → `menu_blocked=true, RECOVER_MENU` → `ntm assign --pane`
auto-recovers and dispatches.

### 3 — Exclude in-flight-assignment panes from the idle pool  (`c5fbb03`)

`ntm assign --watch` (and one-shot `--auto`) built the idle-agent pool purely from on-screen
state. A pane idle **between turns** of a bead it had already claimed was treated as available
and got a *second* bead piled on (observed: the watch dispatched a new bead to a pane already
working one).

`loadActiveAssignmentPanes()` reads the assignment store's `ListActive()`; the three
idle-collection paths now gate on `state == "idle" && !holdsActiveAssignment`. Safe against
stranding — the watch's completion detector marks an assignment completed when its bead
closes, so the pane is released the moment its work is genuinely done.

### 4 — Reap orphaned agent process trees on `ntm kill`  (`fd9f19f`)

`ntm kill` ran `tmux kill-session`, which terminates the pane **shells** but not their
detached children — node-based agents launched with `--dangerously-skip-permissions` survive
SIGHUP and reparent to init, leaking processes that hold agent-mail registrations and file
locks (observed: several `claude` processes survived a kill, needing manual `kill -9`).

- `collectProcessSubtree()`: **before** `kill-session`, walk each pane's full process tree via
  the existing `internal/process.GetChildPIDs` (the tree must be captured first — after the
  shells exit the children reparent and can't be found from the shell PID). Depth bound +
  per-level cap guard against runaway recursion.
- `reapOrphanedAgents()`: **after** `kill-session`, SIGTERM the captured trees → 750 ms grace →
  SIGKILL survivors (via `process.IsAlive`). Excludes `self`/parent/`pid<=1`, de-dupes, and
  prints `Reaped N orphaned agent process(es)`.

Cross-platform via the existing `internal/process` helpers (`/proc` on Linux, `pgrep`
fallback). Verified live: `ntm kill` now reports `Reaped 2 orphaned agent process(es)` and the
agent PID is gone (previously leaked); unrelated sessions are untouched (trees are rooted only
at the killed session's panes).

---

### Testing

- New unit tests per fix:
  - `internal/agent/menu_detect_test.go` — both real menu footers + wrapped-hint variant
    detected; clean-idle and prose **not** flagged (no false positives).
  - `internal/cli/assign_active_panes_test.go` — active pane included, no-assignment excluded,
    empty store → empty set.
  - `internal/config/claude_effort_test.go` — `--effort` present when set, absent when empty.
  - `internal/cli/kill_reap_test.go` — subtree collection + the reaper SIGTERM/SIGKILLing a
    **real** child process and leaving it dead; `pid<=1`/self exclusion.
- Existing `agent`, `robot`, `config`, and `cli` (kill / lifecycle / assign) suites pass.
- Fixes 1, 2, 4 verified live end-to-end. Fix 3 verified by unit + regression (the exact
  timing window — active assignment + idle screen — is hard to force live without disrupting
  a running swarm).

### Notes for review

- Each commit is atomic and self-contained; cherry-pick or split freely.
- Fix 4 reuses your existing `internal/process` package rather than adding a dependency.
- No changes to public CLI surface beyond an added `is_menu_blocked` field / `RECOVER_MENU`
  recommendation in `--robot-is-working` output, and the new `Reaped N …` line on `ntm kill`.

---
