### PR TITLE
Swarm autonomy: fix Claude idle/working detection + periodic ready-work scan (stacked on #188)

### DIFF
--- a/internal/agent/cc_composebox_idle_test.go
+++ b/internal/agent/cc_composebox_idle_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import "testing"
+
+// Real captured idle screens (2026-06-14) from a swarm processing the backlog:
+// agents finished short turns in narrow 7-line panes, so the "new task?" hint is
+// not visible and the ❯ box holds queued text or an … ellipsis. Only the
+// compose-box footer ("⏵⏵ bypass permissions …") is present. These must classify
+// idle (no active spinner) so the dispatcher can hand them the next bead;
+// pre-fix they fell through to UNKNOWN and the backlog stalled with idle agents.
+func TestClaudeComposeBoxIdle(t *testing.T) {
+	cases := map[string]string{
+		"queued-cmd-in-box": "" +
+			"───────────────────────────────────────\n" +
+			"❯ br ready\n" +
+			"───────────────────────────────────────\n" +
+			"  ⏵⏵ bypass permissions on         ·\n",
+		"ellipsis-only": "" +
+			"────────────────────────────────────────\n" +
+			"❯ …\n" +
+			" \n" +
+			"────────────────────────────────────────\n" +
+			"  ⏵⏵ bypass permissions on          ·\n",
+		"completed-then-queued": "" +
+			"✻ Baked for 1m 29s\n" +
+			"────────────────────────────────────────\n" +
+			"❯ next bead\n" +
+			"────────────────────────────────────────\n" +
+			"  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n",
+	}
+	p := NewParser()
+	for name, screen := range cases {
+		t.Run(name, func(t *testing.T) {
+			st, _ := p.ParseWithHint(screen, AgentTypeClaudeCode)
+			if !st.IsIdle {
+				t.Errorf("compose-box idle screen classified IsIdle=false (want true); IsWorking=%v", st.IsWorking)
+			}
+		})
+	}
+}
+
+// The compose-box footer must NOT override an active spinner: a working pane has
+// the same footer but with a live spinner, and must stay non-idle.
+func TestClaudeComposeBoxWithActiveSpinnerNotIdle(t *testing.T) {
+	working := "" +
+		"  reasoning about the allocator…\n" +
+		"✻ Noodling… (2m 5s · ↓ 6.2k tokens)\n" +
+		"────────────────────────────────────────\n" +
+		"❯ \n" +
+		"────────────────────────────────────────\n" +
+		"  ⏵⏵ bypass permissions on          ·\n"
+	p := NewParser()
+	st, _ := p.ParseWithHint(working, AgentTypeClaudeCode)
+	if st.IsIdle {
+		t.Errorf("active-spinner pane with compose-box footer classified idle; want not-idle (would interrupt working agent)")
+	}
+}

--- a/internal/agent/cc_newtask_idle_test.go
+++ b/internal/agent/cc_newtask_idle_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import "testing"
+
+// Real captured Claude Code idle screens from a live swarm (2026-06-14). After a
+// turn completes, modern Claude Code parks the pane showing its input box plus a
+// "new task? /clear to save <N> tokens" footer hint. The input box's ❯ chevron
+// may be empty (with an … placeholder) or hold queued, unsent text. None of these
+// matched the pre-fix idle patterns (the ❯…$ pattern needs an *empty* chevron;
+// the ^.{0,40}\?$ pattern needs the ? at line-end), so an idle agent classified
+// as neither idle nor working — invisible to autonomous dispatch.
+var ccNewTaskIdleScreens = map[string]string{
+	"queued-text-in-box": "" +
+		"────────────────────────────────────────\n" +
+		"❯ push it and sync the skills repo\n" +
+		"────────────────────────────────────────\n" +
+		"  ⏵⏵ bypass permissions on          ·\n" +
+		"  new task? /clear to save 200.7k tokens\n",
+	"ellipsis-placeholder-box": "" +
+		"❯ …\n" +
+		" \n" +
+		"───────────────────────────────────────\n" +
+		"  ⏵⏵ bypass permissions on         ·\n" +
+		"  new task? /clear to save 323.7k tokens\n",
+	"next-ready-bead-queued": "" +
+		"────────────────────────────────────────────────────────────────────\n" +
+		"❯ next ready bead\n" +
+		"────────────────────────────────────────────────────────────────────\n" +
+		"  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n" +
+		"                              new task? /clear to save 113.1k tokens\n",
+}
+
+// A real working-state screen: the live spinner footer. The "new task?" hint is
+// NOT present during work — it renders only after the turn completes — so keying
+// idle detection on that hint cannot false-positive over active work.
+const ccWorkingSpinnerScreen = "" +
+	"  Let me check the dispatcher invariants before I close this.\n" +
+	"\n" +
+	"✻ Noodling… (4m 8s · ↓ 6.2k tokens · thought for 14s)\n"
+
+func TestClaudeCodeNewTaskHintIsIdle(t *testing.T) {
+	p := NewParser()
+	for name, screen := range ccNewTaskIdleScreens {
+		t.Run(name, func(t *testing.T) {
+			st, err := p.ParseWithHint(screen, AgentTypeClaudeCode)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if !st.IsIdle {
+				t.Errorf("idle 'new task?' screen classified IsIdle=false (want true); IsWorking=%v IsMenuBlocked=%v", st.IsWorking, st.IsMenuBlocked)
+			}
+			if st.IsWorking {
+				t.Errorf("idle 'new task?' screen classified IsWorking=true (want false)")
+			}
+		})
+	}
+}
+
+func TestClaudeCodeWorkingSpinnerNotIdle(t *testing.T) {
+	p := NewParser()
+	st, err := p.ParseWithHint(ccWorkingSpinnerScreen, AgentTypeClaudeCode)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if st.IsIdle {
+		t.Errorf("active spinner screen classified IsIdle=true (want false) — false-idle would let dispatch interrupt working agent")
+	}
+}

--- a/internal/agent/claude_activity.go
+++ b/internal/agent/claude_activity.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ccNewTaskHintPattern matches Claude Code's post-turn "ready for input" footer
+// hint (e.g. "new task? /clear to save 113.1k tokens"). It is rendered ONLY once
+// the agent has finished its turn and is waiting — a work-exclusive idle signal.
+var ccNewTaskHintPattern = regexp.MustCompile(`(?i)new task\?\s*/clear`)
+
+// ccCompletionLinePattern matches Claude Code's turn-completion line, e.g.
+// "✻ Baked for 16m 20s" / "✻ Cooked for 4m 43s". It is intentionally NARROW —
+// glyph/symbol-led and anchored to the whole (trimmed) line as "<Verb> for
+// <duration>" — so it cannot match either (a) an active spinner annotation like
+// "Noodling… (4m · thought for 14s)" (excluded separately because it contains
+// "…") or (b) prose that merely says "...waited for 5m before...". A narrow
+// match biases the classifier toward the SAFE failure: if a real completion line
+// is missed the pane reads as still-working (no dispatch), never falsely idle.
+var ccCompletionLinePattern = regexp.MustCompile(`(?i)^[\W_]*[A-Za-z]+\s+for\s+\d+\s*[ms]\b(?:\s+\d+\s*[ms])?\s*$`)
+
+// IsClaudeTurnEnded reports whether a single line is a "turn has finished"
+// marker — the work-exclusive "new task? /clear" hint or a completion line
+// ("✻ Baked for 16m 20s"). Lines that are themselves active spinners (they
+// contain the "…" timing glyph) are never turn-ended. Exported so other
+// detectors can decide whether a thinking/spinner signal above this line is
+// stale.
+func IsClaudeTurnEnded(line string) bool { return isClaudeTurnEnded(line) }
+
+// isClaudeTurnEnded reports whether a single line is a "turn has finished"
+// marker — the work-exclusive new-task hint or a completion line. Lines that are
+// themselves active spinners (they contain the "…" timing glyph) are never
+// turn-ended.
+func isClaudeTurnEnded(line string) bool {
+	if ccNewTaskHintPattern.MatchString(line) {
+		return true
+	}
+	if strings.Contains(line, "…") {
+		return false
+	}
+	return ccCompletionLinePattern.MatchString(strings.TrimSpace(line))
+}
+
+// ClaudeActivelyWorking reports whether the Claude Code pane whose recent output
+// is `text` is currently doing work, as opposed to having finished a turn and
+// settled at an idle prompt.
+//
+// WHY position-of-prompt does not work: Claude Code pins its input box to the
+// BOTTOM of the screen at all times, so the "❯" prompt is the lowest line even
+// during active work (the spinner renders ABOVE the box). Comparing a spinner's
+// position against the prompt's position therefore always says "prompt is below
+// the spinner" and misclassifies a busy pane as idle. The reliable signal is
+// whether an ACTIVE SPINNER is the most-recent DYNAMIC marker, i.e. no
+// turn-ended marker (new-task hint / completion line) appears after the last
+// spinner. A spinner left in scrollback above a turn-ended marker is stale.
+// claudeActivityWindowLines bounds how much of the tail ClaudeActivelyWorking
+// inspects. Claude Code renders its active spinner immediately above the input
+// box at the bottom of the screen, so a LIVE spinner is always within a few
+// lines of the bottom; a spinner farther up is stale scrollback. Bounding the
+// scan keeps callers that pass a large capture (e.g. the 50-line status window)
+// consistent with callers that pass a small live window (~15 lines) — otherwise
+// a stale spinner deep in a big capture, with no turn-ended marker after it,
+// would read as active work (a false-working).
+const claudeActivityWindowLines = 16
+
+func ClaudeActivelyWorking(text string) bool {
+	if text == "" {
+		return false
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) > claudeActivityWindowLines {
+		lines = lines[len(lines)-claudeActivityWindowLines:]
+	}
+	lastSpin := -1
+	lastEnded := -1
+	for i, ln := range lines {
+		if matchAnyRegex(ln, ccSpinnerActivePatterns) {
+			lastSpin = i
+		}
+		if isClaudeTurnEnded(ln) {
+			lastEnded = i
+		}
+	}
+	return lastSpin >= 0 && lastSpin > lastEnded
+}

--- a/internal/agent/claude_activity_test.go
+++ b/internal/agent/claude_activity_test.go
@@ -1,0 +1,97 @@
+package agent
+
+import "testing"
+
+// Real working screen (2026-06-14): an active spinner ("· Processing… (2m 8s …)")
+// is the live bottom dynamic line, with Claude's persistent EMPTY input box
+// rendered below it. This is the case that produced the dangerous false-idle:
+// the empty ❯ box is the lowest line, so any "idle prompt below the spinner"
+// ordering misclassifies this busy pane as idle.
+const ccWorkingSpinnerAboveEmptyBox = "" +
+	"      probe|≤$|GCP|rung'\n" +
+	"      docs/provenance/founder-decisions/\n" +
+	"      21-mpk-hardware-acq…)\n" +
+	"  ⎿  Waiting…\n" +
+	"· Processing… (2m 8s · ↓ 7.2k tokens)\n" +
+	"  ⎿  Tip: Use /btw to ask a quick side\n" +
+	"     question without interrupting\n" +
+	"· Processing… (2m 8s · ↑ 7.2k tokens)\n" +
+	"  ⎿  Tip: Use /btw to ask a quick side\n" +
+	"     question without interrupting\n" +
+	"────────────────────────────────────────\n" +
+	"❯ \n" +
+	"────────────────────────────────────────\n" +
+	"  ⏵⏵ bypass permissions on          ·\n"
+
+// Real idle screen: a STALE completed spinner ("✶ Pontificating… (16m 20s)") and
+// a completion line ("✻ Baked for 16m 20s") sit above the input box, and the
+// work-exclusive "new task? /clear" hint is the lowest dynamic marker.
+const ccIdleStaleSpinnerThenNewTask = "" +
+	"✶ Pontificating… (16m 20s)\n" +
+	"  ⎿  Tip: Use /btw to ask a quick side\n" +
+	"✻ Baked for 16m 20s\n" +
+	"\n" +
+	"────────────────────────────────────────\n" +
+	"❯ push it and sync the skills repo\n" +
+	"────────────────────────────────────────\n" +
+	"  ⏵⏵ bypass permissions on          ·\n" +
+	"  new task? /clear to save 200.7k tokens\n"
+
+// Settled idle: agent finished, input box empty, no spinner, no new-task hint.
+const ccIdleSettledEmptyBox = "" +
+	"     hardware gate. Measurements stay\n" +
+	"────────────────────────────────────────\n" +
+	"❯ \n" +
+	"────────────────────────────────────────\n" +
+	"  ⏵⏵ bypass permissions on          ·\n"
+
+func TestClaudeActivelyWorking(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"active-spinner-above-empty-box", ccWorkingSpinnerAboveEmptyBox, true},
+		{"idle-stale-spinner-then-new-task", ccIdleStaleSpinnerThenNewTask, false},
+		{"idle-settled-empty-box", ccIdleSettledEmptyBox, false},
+		{"empty", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ClaudeActivelyWorking(c.text); got != c.want {
+				t.Errorf("ClaudeActivelyWorking = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// The spinner annotation "thought for 14s" inside an active spinner line must NOT
+// be mistaken for a completion ("X for Ns") turn-ended marker.
+func TestClaudeActivelyWorkingThoughtForAnnotation(t *testing.T) {
+	text := "" +
+		"  Reasoning about the dispatcher.\n" +
+		"✻ Noodling… (4m 8s · ↓ 6.2k tokens · thought for 14s)\n" +
+		"────────\n❯ \n────────\n"
+	if !ClaudeActivelyWorking(text) {
+		t.Errorf("active spinner with 'thought for 14s' annotation read as not-working; want working")
+	}
+}
+
+// detectIdle must agree: working screen NOT idle, idle screens idle.
+func TestDetectIdleUsesActivelyWorking(t *testing.T) {
+	p := NewParser()
+	mustIdle := func(name, text string, wantIdle bool) {
+		t.Run(name, func(t *testing.T) {
+			st, _ := p.ParseWithHint(text, AgentTypeClaudeCode)
+			if st.IsIdle != wantIdle {
+				t.Errorf("IsIdle=%v want %v", st.IsIdle, wantIdle)
+			}
+			if wantIdle && st.IsWorking {
+				t.Errorf("IsWorking=true on an idle screen")
+			}
+		})
+	}
+	mustIdle("working", ccWorkingSpinnerAboveEmptyBox, false)
+	mustIdle("idle-newtask", ccIdleStaleSpinnerThenNewTask, true)
+	mustIdle("idle-settled", ccIdleSettledEmptyBox, true)
+}

--- a/internal/agent/menu_detect_test.go
+++ b/internal/agent/menu_detect_test.go
@@ -1,0 +1,50 @@
+package agent
+import "testing"
+
+// realMenuFooters are footers captured live from Claude Code pickers. Each must
+// classify the pane as menu-blocked so autonomous dispatch can Esc-recover it.
+var realMenuFooters = map[string]string{
+	"effort/list picker": "  5. Chat about this\n\nEnter to select · Tab/Arrow keys to navigate · Esc to cancel\n",
+	"wrapped nav hint":   "  5. Chat about this\n\nEnter to select · Tab/Arrow keys to\nnavigate · Esc to cancel\n",
+	"/model picker":      "  ◐ Medium effort ←/→ to adjust\n  Enter to set as default · s to use\n  this session only · Esc to cancel\n",
+}
+
+func TestInteractiveMenuDetection(t *testing.T) {
+	for name, footer := range realMenuFooters {
+		body := "  Some agent output above.\n────────────────────────────────────────\n" + footer
+		st, _ := NewParser().ParseWithHint(body, AgentTypeClaudeCode)
+		if !st.IsMenuBlocked {
+			t.Errorf("[%s] IsMenuBlocked=false, want true", name)
+		}
+		if st.IsIdle || st.IsWorking {
+			t.Errorf("[%s] should be neither idle nor working; idle=%v working=%v", name, st.IsIdle, st.IsWorking)
+		}
+		if got := st.GetRecommendation(); got != RecommendRecoverMenu {
+			t.Errorf("[%s] recommendation=%v, want RECOVER_MENU", name, got)
+		}
+	}
+}
+
+func TestCleanIdleNotMenu(t *testing.T) {
+	idle := "✻ Baked for 16m 20s\n\n────────\n❯ \n────────\n  ⏵⏵ bypass permissions on          ·\n"
+	st, _ := NewParser().ParseWithHint(idle, AgentTypeClaudeCode)
+	if st.IsMenuBlocked {
+		t.Errorf("clean idle pane wrongly flagged IsMenuBlocked")
+	}
+	if !st.IsIdle {
+		t.Errorf("clean idle pane should be idle; got idle=%v", st.IsIdle)
+	}
+}
+
+func TestProseNotMenu(t *testing.T) {
+	// Prose mentioning one phrase but not the menu structure must not match.
+	for _, prose := range []string{
+		"I will let you select the option and press Enter when ready.\n❯ \n",
+		"Press Esc to cancel the operation if needed; otherwise continue.\n❯ \n",
+	} {
+		st, _ := NewParser().ParseWithHint(prose, AgentTypeClaudeCode)
+		if st.IsMenuBlocked {
+			t.Errorf("prose wrongly flagged as menu: %q", prose)
+		}
+	}
+}

--- a/internal/agent/parser.go
+++ b/internal/agent/parser.go
@@ -214,6 +214,21 @@ func (p *parserImpl) detectStateFlags(output string, state *AgentState) {
 		return
 	}
 
+	// Interactive-menu detection (checked before idle/working). When a Claude
+	// Code selection menu is the LIVE state — the /effort or /model picker, a
+	// permission selector — the pane is parked awaiting an Enter/arrow choice.
+	// It is neither a dispatchable text prompt (a sent prompt would be typed
+	// into the menu) nor active work, so we surface it as a distinct, recoverable
+	// state instead of letting it fall through to UNKNOWN. Autonomous dispatch
+	// can then Esc-recover the pane to a clean prompt before assigning.
+	if p.detectInteractiveMenu(output, state.Type) {
+		state.IsMenuBlocked = true
+		state.IsIdle = false
+		state.IsWorking = false
+		state.IsInError = p.detectError(output, state.Type)
+		return
+	}
+
 	// Idle detection
 	// We check this BEFORE trusting IsWorking, because IsWorking patterns
 	// (like "testing", "running") might still be present in the scrollback
@@ -270,6 +285,24 @@ func (p *parserImpl) detectRateLimit(output string, agentType AgentType) bool {
 			matchAny(recentOutput, aiderRateLimitPatterns) ||
 			matchAny(recentOutput, ollamaRateLimitPatterns)
 	}
+}
+
+// detectInteractiveMenu reports whether the live tail of the pane is showing a
+// Claude Code interactive selection menu (the /effort or /model picker, a
+// permission selector, etc.). It scans only the recent tail so a menu that was
+// dismissed earlier in the scrollback does not strand the pane: the
+// distinctive nav-hint footer ("Enter to select · Tab/Arrow keys to navigate ·
+// Esc to cancel") is only rendered while the menu is actually open. Menus are
+// currently a Claude-Code-only affordance; other concrete agent types return
+// false (Unknown is allowed through so content-detected CC panes still match).
+func (p *parserImpl) detectInteractiveMenu(output string, agentType AgentType) bool {
+	if agentType != AgentTypeClaudeCode && agentType != AgentTypeUnknown {
+		return false
+	}
+	// 8 lines is enough to catch the footer even when the hint wraps across
+	// two lines, while staying well clear of stale menus higher in scrollback.
+	lastLines := util.GetLastNLines(output, 8)
+	return matchAnyRegex(lastLines, ccMenuPatterns)
 }
 
 // detectWorking checks if the agent is actively producing output.

--- a/internal/agent/parser.go
+++ b/internal/agent/parser.go
@@ -356,15 +356,15 @@ func (p *parserImpl) detectIdle(output string, agentType AgentType) bool {
 			return true
 		}
 		idleMatch := matchAnyRegex(lastLines, ccIdlePatterns)
-		// Active spinner overrides idle ONLY when the spinner appears AFTER
-		// the most recent prompt marker. A stale spinner above a fresh ❯
-		// prompt (e.g. agent just finished a 17-minute "thinking" run, then
-		// printed its idle prompt) must NOT block the idle verdict, otherwise
-		// operators polling for dispatchable panes never see them as idle.
+		// A prompt/idle marker is present, but Claude Code keeps its input box
+		// rendered at the bottom of the screen even while it is actively working
+		// (the spinner renders ABOVE the box). So the presence of a prompt is not
+		// sufficient: the pane is idle only when it is NOT actively working —
+		// i.e. no active spinner is the most-recent dynamic marker. ClaudeActively
+		// Working encodes that (spinner present with no turn-ended marker after
+		// it); a stale spinner left above a finished-turn marker does not count.
 		if idleMatch {
-			lastIdle := lastLineIdxMatching(lastLines, ccIdlePatterns)
-			lastSpin := lastLineIdxMatching(lastLines, ccSpinnerActivePatterns)
-			return lastSpin <= lastIdle
+			return !ClaudeActivelyWorking(lastLines)
 		}
 		return false
 	case AgentTypeCodex:

--- a/internal/agent/parser_test.go
+++ b/internal/agent/parser_test.go
@@ -272,21 +272,32 @@ Human: `
 // could never dispatch fresh work to them.
 func TestParser_Parse_Idle_Claude_StaleSpinnerAbovePrompt(t *testing.T) {
 	p := NewParser()
+	// A spinner above the input box is only KNOWABLE as stale when a turn-ended
+	// marker follows it — the completion line ("✻ Crystallized for 17m 2s") and/or
+	// the "new task? /clear" idle hint. Claude Code pins its input box to the
+	// bottom of the screen, so a still-ACTIVE spinner ALSO renders above the box
+	// (see TestClaudeActivelyWorking/active-spinner-above-empty-box, a real
+	// working capture from a live swarm). Without a turn-ended marker the two
+	// snapshots are indistinguishable and the safe verdict is "working" (never
+	// interrupt a busy agent). With the markers below, the spinner is genuinely
+	// stale and the pane is idle.
 	output := "✻ Crystallizing… (17m 2s · thinking)\n" +
 		"  ⏿  Tip: Use /btw to ask a quick side\n" +
 		"     question without interrupting\n" +
 		"     Claude's current work\n" +
+		"✻ Crystallized for 17m 2s\n" +
 		"\n" +
 		"────────────────────────────────────────\n" +
 		"❯ \n" +
 		"────────────────────────────────────────\n" +
-		"  ⏵⏵ bypass permissions on          ·\n"
+		"  ⏵⏵ bypass permissions on          ·\n" +
+		"  new task? /clear to save 50.0k tokens\n"
 	state, err := p.Parse(output)
 	if err != nil {
 		t.Fatalf("Parse error: %v", err)
 	}
 	if !state.IsIdle {
-		t.Error("Expected IsIdle=true when fresh ❯ prompt sits below stale spinner")
+		t.Error("Expected IsIdle=true when a stale spinner sits above a turn-ended (completion + new-task) prompt")
 	}
 	if state.IsWorking {
 		t.Error("Expected IsWorking=false when idle")

--- a/internal/agent/patterns.go
+++ b/internal/agent/patterns.go
@@ -88,6 +88,19 @@ var (
 		// patterns above miss. The "/clear" companion keeps prose that merely says
 		// "…a new task?" from false-matching.
 		regexp.MustCompile(`(?i)new task\?\s*/clear`),
+		// Claude Code's compose-box permission-mode footer ("⏵⏵ bypass permissions
+		// on …"). The ⏵⏵ double-play glyph is unique to that footer, so its
+		// presence means the Claude TUI is alive at its input box. On its own it
+		// does NOT imply idle (the box is drawn during active work too) — but
+		// detectIdle gates every idle verdict through ClaudeActivelyWorking, so a
+		// working pane (active spinner, no turn-ended marker) is still excluded.
+		// Gated this way it is the general "TUI alive ⇒ idle when not working"
+		// signal that catches what the empty-❯ and new-task patterns miss: a box
+		// holding queued text or an … ellipsis with no visible hint (small-context
+		// turns in narrow panes). The dispatch path is also backstopped by the
+		// active-assignment guard, so a transient misread cannot double-dispatch a
+		// pane already holding in-flight work.
+		regexp.MustCompile(`⏵⏵`),
 	}
 
 	// ccSpinnerActivePatterns detect Claude Code's randomized spinner verbs

--- a/internal/agent/patterns.go
+++ b/internal/agent/patterns.go
@@ -90,6 +90,31 @@ var (
 		regexp.MustCompile(`Running…`),          // Explicit running spinner
 	}
 
+	// ccMenuPatterns detect Claude Code's interactive selection-menu footer
+	// (the /effort picker, /model picker, permission selectors, etc.). When one
+	// of these is the live state, the pane is parked waiting for an Enter/arrow
+	// selection — it is NOT a dispatchable text prompt and NOT actively working.
+	// An agent stranded here (e.g. a `/effort` send that opened the picker but
+	// never confirmed) otherwise classifies as UNKNOWN and is invisible to
+	// autonomous dispatch + recovery. We key on the highly distinctive nav hint
+	// rather than the menu body so normal prose can't false-match; the hint can
+	// wrap across two lines, so we tolerate the line break between phrases.
+	// The invariant across Claude Code's selection menus is a confirm/navigate
+	// hint paired with "Esc to cancel" in the (often line-wrapped) footer. The
+	// concrete footer text varies by picker, e.g.:
+	//   "Enter to select · Tab/Arrow keys to navigate · Esc to cancel"   (/effort, lists)
+	//   "Enter to set as default · s to use this session only · Esc to cancel"  (/model)
+	//   "◐ Medium effort ←/→ to adjust … Esc to cancel"                  (effort adjuster)
+	// We require BOTH halves within a bounded, newline-tolerant window so prose
+	// that merely mentions one phrase can't false-match. The bound keeps a stray
+	// "Esc to cancel" far from a hint (e.g. across unrelated output) from matching.
+	ccMenuPatterns = []*regexp.Regexp{
+		// "Enter to <verb> …  Esc to cancel"  (select / set as default / confirm / …)
+		regexp.MustCompile(`(?is)\benter\s+to\s+\S+.{0,160}?\besc\s+to\s+cancel\b`),
+		// Arrow-key navigation hint …  Esc to cancel
+		regexp.MustCompile(`(?is)(?:tab/arrow|arrow\s+keys|←/→|↑/↓|→/←).{0,160}?\besc\s+to\s+cancel\b`),
+	}
+
 	// ccErrorPatterns indicates an error condition.
 	ccErrorPatterns = []string{
 		"error:",

--- a/internal/agent/patterns.go
+++ b/internal/agent/patterns.go
@@ -78,6 +78,16 @@ var (
 		regexp.MustCompile(`(?i)welcome\s+back`),          // Welcome message
 		regexp.MustCompile(`╰─>\s*$`),                     // Arrow prompt
 		regexp.MustCompile(`(?m)❯[\s\x{00a0}]*$`),         // Unicode heavy right-pointing angle prompt (multiline, NBSP-aware)
+		// Claude Code's post-turn "ready for input" footer hint, e.g.
+		// "new task? /clear to save 113.1k tokens". It is rendered ONLY once the
+		// agent has finished its turn and is waiting; during active work the same
+		// footer slot shows the spinner ("✻ Noodling… (4m …)", see
+		// ccSpinnerActivePatterns), so this is a work-exclusive idle signal. It is
+		// the reliable idle marker when the input box above carries queued/unsent
+		// text or a bare … ellipsis rather than an empty ❯ — cases the bare-prompt
+		// patterns above miss. The "/clear" companion keeps prose that merely says
+		// "…a new task?" from false-matching.
+		regexp.MustCompile(`(?i)new task\?\s*/clear`),
 	}
 
 	// ccSpinnerActivePatterns detect Claude Code's randomized spinner verbs

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -171,6 +171,7 @@ type AgentState struct {
 	IsContextLow  bool `json:"context_low"`  // Below configured threshold
 	IsIdle        bool `json:"is_idle"`      // Waiting for user input (safe to restart)
 	IsInError     bool `json:"is_in_error"`  // Error state detected
+	IsMenuBlocked bool `json:"is_menu_blocked"` // Stuck at an interactive selection menu (e.g. /effort, /model picker); needs Esc to recover before it can take work
 
 	// Evidence for debugging and confidence calculation
 	WorkIndicators  []string `json:"work_indicators,omitempty"`  // Patterns that indicate working
@@ -204,6 +205,13 @@ const (
 	// RecommendErrorState means the agent is in an error state and may need intervention.
 	RecommendErrorState Recommendation = "ERROR_STATE"
 
+	// RecommendRecoverMenu means the agent is stuck at an interactive selection menu
+	// (e.g. the /effort or /model picker) and is not dispatchable as-is: sending a text
+	// prompt would be typed into the menu. An orchestrator should send Esc to return the
+	// pane to a clean prompt, after which it becomes idle and dispatchable. This is a
+	// recoverable, machine-actionable state — distinct from UNKNOWN, which is a dead end.
+	RecommendRecoverMenu Recommendation = "RECOVER_MENU"
+
 	// RecommendUnknown means we couldn't determine the agent state with confidence.
 	RecommendUnknown Recommendation = "UNKNOWN"
 )
@@ -233,6 +241,15 @@ func (s *AgentState) GetRecommendation() Recommendation {
 			return RecommendContextLowContinue
 		}
 		return RecommendDoNotInterrupt
+	}
+
+	// Priority 3.5: Menu-blocked - the agent is parked at an interactive selection
+	// menu (not generating, not a clean prompt). Surfaced over Idle because a text
+	// dispatch would be typed INTO the menu; the orchestrator must Esc-recover first.
+	// Placed after Working so a genuine in-flight turn is never interrupted on a
+	// false menu match (the parser also clears IsWorking when a live menu is seen).
+	if s.IsMenuBlocked {
+		return RecommendRecoverMenu
 	}
 
 	// Priority 4: Idle - safe to take action

--- a/internal/cli/agent_spec_test.go
+++ b/internal/cli/agent_spec_test.go
@@ -414,7 +414,7 @@ func TestResolveModel_EmptySpecUnknownType(t *testing.T) {
 // =============================================================================
 
 func TestExpandPromptTemplate_Impl(t *testing.T) {
-	result := expandPromptTemplate("bd-123", "Fix login bug", "impl", "")
+	result := expandPromptTemplate("bd-123", "Fix login bug", "", "impl", "")
 	if !strings.Contains(result, "bd-123") {
 		t.Errorf("impl template should contain bead ID: %s", result)
 	}
@@ -427,7 +427,7 @@ func TestExpandPromptTemplate_Impl(t *testing.T) {
 }
 
 func TestExpandPromptTemplate_Review(t *testing.T) {
-	result := expandPromptTemplate("bd-456", "Audit auth", "review", "")
+	result := expandPromptTemplate("bd-456", "Audit auth", "", "review", "")
 	if !strings.Contains(result, "bd-456") {
 		t.Errorf("review template should contain bead ID: %s", result)
 	}
@@ -437,7 +437,7 @@ func TestExpandPromptTemplate_Review(t *testing.T) {
 }
 
 func TestExpandPromptTemplate_Default(t *testing.T) {
-	result := expandPromptTemplate("bd-789", "Some task", "unknown-template", "")
+	result := expandPromptTemplate("bd-789", "Some task", "", "unknown-template", "")
 	if !strings.Contains(result, "bd-789") {
 		t.Errorf("default template should contain bead ID: %s", result)
 	}
@@ -451,14 +451,14 @@ func TestExpandPromptTemplate_CustomWithFile(t *testing.T) {
 	tmplFile := filepath.Join(dir, "custom.txt")
 	os.WriteFile(tmplFile, []byte("Custom: {BEAD_ID} - {TITLE}"), 0644)
 
-	result := expandPromptTemplate("bd-abc", "My feature", "custom", tmplFile)
+	result := expandPromptTemplate("bd-abc", "My feature", "", "custom", tmplFile)
 	if result != "Custom: bd-abc - My feature" {
 		t.Errorf("custom file template = %q, want 'Custom: bd-abc - My feature'", result)
 	}
 }
 
 func TestExpandPromptTemplate_CustomWithMissingFile(t *testing.T) {
-	result := expandPromptTemplate("bd-def", "Fallback task", "custom", "/nonexistent/path.txt")
+	result := expandPromptTemplate("bd-def", "Fallback task", "", "custom", "/nonexistent/path.txt")
 	// Should fall back to impl-like template
 	if !strings.Contains(result, "bd-def") {
 		t.Errorf("fallback template should contain bead ID: %s", result)
@@ -469,7 +469,7 @@ func TestExpandPromptTemplate_CustomWithMissingFile(t *testing.T) {
 }
 
 func TestExpandPromptTemplate_CustomNoFile(t *testing.T) {
-	result := expandPromptTemplate("bd-ghi", "Plain custom", "custom", "")
+	result := expandPromptTemplate("bd-ghi", "Plain custom", "", "custom", "")
 	if !strings.Contains(result, "bd-ghi") {
 		t.Errorf("custom no-file template should contain bead ID: %s", result)
 	}
@@ -479,12 +479,12 @@ func TestExpandPromptTemplate_CustomNoFile(t *testing.T) {
 }
 
 func TestExpandPromptTemplate_CaseInsensitive(t *testing.T) {
-	result := expandPromptTemplate("bd-x", "Title", "IMPL", "")
+	result := expandPromptTemplate("bd-x", "Title", "", "IMPL", "")
 	if !strings.Contains(result, "br dep tree") {
 		t.Errorf("IMPL (uppercase) should resolve to impl template: %s", result)
 	}
 
-	result = expandPromptTemplate("bd-y", "Title", "Review", "")
+	result = expandPromptTemplate("bd-y", "Title", "", "Review", "")
 	if !strings.Contains(result, "Review and verify") {
 		t.Errorf("Review (mixed case) should resolve to review template: %s", result)
 	}

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -2528,7 +2528,7 @@ func executeAssignmentsEnhanced(session string, out *AssignOutputEnhanced, opts 
 		}
 
 		// Build the prompt using template
-		prompt := expandPromptTemplate(item.BeadID, item.BeadTitle, opts.Template, opts.TemplateFile)
+		prompt := expandPromptTemplate(item.BeadID, item.BeadTitle, item.AgentName, opts.Template, opts.TemplateFile)
 
 		// Send to the pane
 		paneID, ok := paneIDByIndex[item.Pane]
@@ -2577,7 +2577,7 @@ func executeAssignmentsEnhanced(session string, out *AssignOutputEnhanced, opts 
 }
 
 // expandPromptTemplate expands a prompt template with bead variables
-func expandPromptTemplate(beadID, title, templateName, templateFile string) string {
+func expandPromptTemplate(beadID, title, agentName, templateName, templateFile string) string {
 	var template string
 
 	switch strings.ToLower(templateName) {
@@ -2601,10 +2601,14 @@ func expandPromptTemplate(beadID, title, templateName, templateFile string) stri
 		template = "Work on bead {BEAD_ID}: {TITLE}. Check dependencies first with `br dep tree {BEAD_ID}`."
 	}
 
-	// Expand variables
+	// Expand variables. {AGENT_NAME} lets a dispatch template inject the target
+	// pane's agent-mail identity — needed because the project's pre-commit hook
+	// requires AGENT_NAME, and the pane shell does not export it, so an autonomous
+	// dispatch that asks the agent to commit must carry the name in the prompt.
 	result := template
 	result = strings.ReplaceAll(result, "{BEAD_ID}", beadID)
 	result = strings.ReplaceAll(result, "{TITLE}", title)
+	result = strings.ReplaceAll(result, "{AGENT_NAME}", agentName)
 
 	return result
 }
@@ -2963,7 +2967,7 @@ func runRetryAssignments(cmd *cobra.Command, session string) error {
 
 		// Create new assignment (remove old one first)
 		store.Remove(failed.BeadID)
-		prompt := expandPromptTemplate(failed.BeadID, beadTitle, assignTemplate, assignTemplateFile)
+		prompt := expandPromptTemplate(failed.BeadID, beadTitle, newAgentName, assignTemplate, assignTemplateFile)
 		_, assignErr := store.Assign(failed.BeadID, beadTitle, targetPane.Index, targetAgentType, newAgentName, "")
 		if assignErr != nil {
 			skippedItems = append(skippedItems, RetrySkippedItem{
@@ -3560,7 +3564,7 @@ func runReassignment(cmd *cobra.Command, session string) error {
 	if assignPrompt != "" {
 		prompt = assignPrompt
 	} else {
-		prompt = expandPromptTemplate(beadID, beadTitle, assignTemplate, assignTemplateFile)
+		prompt = expandPromptTemplate(beadID, beadTitle, newAgentName, assignTemplate, assignTemplateFile)
 	}
 
 	// Send prompt to new agent
@@ -4308,7 +4312,7 @@ func runDirectPaneAssignment(cmd *cobra.Command, opts *AssignCommandOptions) err
 	if opts.Prompt != "" {
 		prompt = opts.Prompt
 	} else {
-		prompt = expandPromptTemplate(beadID, beadTitle, opts.Template, opts.TemplateFile)
+		prompt = expandPromptTemplate(beadID, beadTitle, assignmentAgentName(opts.Session, agentType, targetPane.Index), opts.Template, opts.TemplateFile)
 	}
 	assignItem.Prompt = prompt
 	assignItem.PromptSent = true

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -563,6 +563,16 @@ func runWatchMode(cmd *cobra.Command, session string) error {
 		return nil
 	}
 
+	// Enable the periodic ready-work scan so the loop keeps idle agents fed even
+	// when no completion event fires (ready work that appears externally, or the
+	// initial pass dispatched nothing). Reuse the initial-pass options; Quiet
+	// suppresses executeAssignmentsEnhanced's own output since the loop logs each
+	// scan dispatch via logf.
+	scanOpts := *assignOpts
+	scanOpts.Quiet = true
+	watchLoop.scanOpts = &scanOpts
+	watchLoop.scanInterval = assignWatchInterval
+
 	// Run the watch loop
 	if err := watchLoop.Run(ctx); err != nil && err != context.Canceled {
 		return err
@@ -4771,6 +4781,16 @@ type WatchLoop struct {
 	quiet        bool
 	verbose      bool
 
+	// scanOpts drives the periodic ready-work re-scan (same plan/dispatch path as
+	// the initial assignment pass). Without a periodic scan the loop is purely
+	// completion-driven: if the initial pass dispatched nothing (no idle agents OR
+	// no ready work at startup), no completion event ever fires and the loop sits
+	// inert forever even as ready work appears (a founder unblocks a gate, new
+	// beads are created, or agents that were busy at startup go idle). The
+	// periodic scan keeps idle agents fed. Nil disables it (back-compat).
+	scanOpts     *AssignCommandOptions
+	scanInterval time.Duration
+
 	// Concurrency control
 	completionCh chan completion.CompletionEvent
 	stopCh       chan struct{}
@@ -4850,6 +4870,24 @@ func (w *WatchLoop) Run(ctx context.Context) error {
 
 	w.logf("Starting watch mode with strategy=%s", w.strategy)
 
+	// Periodic ready-work scan. The completion channel only fires for beads this
+	// loop dispatched; a purely completion-driven loop therefore cannot pick up
+	// ready work that appears by any other means (founder unblocks a gate, beads
+	// created externally, or agents busy at startup going idle). The ticker
+	// re-runs the same plan/dispatch pass as the initial assignment so idle
+	// agents are continuously fed. Dispatch is idempotent: getAssignOutputEnhanced
+	// excludes panes that are busy or already hold an active assignment.
+	var scanC <-chan time.Time
+	if w.scanOpts != nil {
+		interval := w.scanInterval
+		if interval <= 0 {
+			interval = 30 * time.Second
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		scanC = ticker.C
+	}
+
 	// Main watch loop
 	for {
 		select {
@@ -4871,6 +4909,15 @@ func (w *WatchLoop) Run(ctx context.Context) error {
 				}
 			}
 
+		case <-scanC:
+			if err := w.performReadyWorkScan(); err != nil {
+				w.logf("Error during ready-work scan: %v", err)
+			}
+			if w.stopWhenDone && w.shouldStop() {
+				w.logf("All beads complete. Exiting watch mode.")
+				return nil
+			}
+
 		case <-ctx.Done():
 			w.logf("Watch mode interrupted. Shutting down...")
 			return ctx.Err()
@@ -4880,6 +4927,42 @@ func (w *WatchLoop) Run(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+// performReadyWorkScan re-runs the assignment plan/dispatch pass to feed idle
+// agents any currently-ready work. It is the same path as the initial assignment
+// pass and is safe to call repeatedly: getAssignOutputEnhanced builds the idle
+// pool excluding busy panes and panes that already hold an active assignment, so
+// a re-scan never double-dispatches in-flight work.
+func (w *WatchLoop) performReadyWorkScan() error {
+	if w.scanOpts == nil {
+		return nil
+	}
+	out, err := getAssignOutputEnhanced(w.scanOpts)
+	if err != nil {
+		return err
+	}
+	if out == nil || len(out.Assignments) == 0 {
+		return nil
+	}
+	dryRun := w.opts != nil && w.opts.DryRun
+	if dryRun {
+		for _, a := range out.Assignments {
+			w.logf("Would assign (dry-run, scan): %s -> pane %d (%s)", a.BeadID, a.Pane, a.AgentType)
+		}
+		return nil
+	}
+	if err := executeAssignmentsEnhanced(w.session, out, w.scanOpts); err != nil {
+		return err
+	}
+	w.mu.Lock()
+	for _, a := range out.Assignments {
+		w.totalAssigned++
+		w.lastAssignmentAt = time.Now()
+		w.logf("Assigned (scan): %s -> pane %d (%s)", a.BeadID, a.Pane, a.AgentType)
+	}
+	w.mu.Unlock()
+	return nil
 }
 
 // handleCompletion processes a single completion event

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -1513,7 +1513,7 @@ func executeAssignments(session string, recommendations []robot.AssignRecommend)
 			continue
 		}
 
-		if err := sendPromptWithDoubleEnter(p.ID, prompt); err != nil {
+		if err := sendDispatchPrompt(p.ID, prompt); err != nil {
 			fmt.Printf("  Failed to assign to pane %d: %v\n", paneIdx, err)
 			continue
 		}
@@ -2529,7 +2529,7 @@ func executeAssignmentsEnhanced(session string, out *AssignOutputEnhanced, opts 
 			failCount++
 			continue
 		}
-		if err := sendPromptWithDoubleEnter(paneID, prompt); err != nil {
+		if err := sendDispatchPrompt(paneID, prompt); err != nil {
 			if !opts.Quiet {
 				fmt.Printf("  ✗ Failed to assign %s to pane %d: %v\n", item.BeadID, item.Pane, err)
 			}
@@ -2965,7 +2965,7 @@ func runRetryAssignments(cmd *cobra.Command, session string) error {
 
 		// Send prompt to pane
 		promptSent := true
-		if err := sendPromptWithDoubleEnter(targetPane.ID, prompt); err != nil {
+		if err := sendDispatchPrompt(targetPane.ID, prompt); err != nil {
 			promptSent = false
 			warnings = append(warnings, fmt.Sprintf("failed to send prompt to pane %d for %s: %v",
 				targetPane.Index, failed.BeadID, err))
@@ -3555,7 +3555,7 @@ func runReassignment(cmd *cobra.Command, session string) error {
 
 	// Send prompt to new agent
 	promptSent := true
-	if err := sendPromptWithDoubleEnter(targetPane.ID, prompt); err != nil {
+	if err := sendDispatchPrompt(targetPane.ID, prompt); err != nil {
 		promptSent = false
 		warnings = append(warnings, fmt.Sprintf("failed to send prompt: %v", err))
 	}
@@ -4307,7 +4307,7 @@ func runDirectPaneAssignment(cmd *cobra.Command, opts *AssignCommandOptions) err
 	// (ntm#128) can record duration for downstream automation that
 	// previously kept its own dispatch ledger.
 	transportStart := time.Now()
-	transportErr := sendPromptWithDoubleEnter(targetPane.ID, prompt)
+	transportErr := sendDispatchPrompt(targetPane.ID, prompt)
 	transportDurationMs := time.Since(transportStart).Milliseconds()
 	receipt := buildDispatchReceipt(opts.Session, beadID, *targetPane, prompt, opts.Template, fileReservations, transportErr, transportDurationMs, false)
 

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -956,6 +956,9 @@ func getAssignOutput(opts robot.AssignOptions) (*robot.AssignOutput, error) {
 		// Capture state
 		scrollback, _ := tmux.CaptureForStatusDetection(pane.ID)
 		state := determineAgentState(scrollback, agentType)
+		// Self-heal a menu strand (e.g. a /effort picker left open) so the pane
+		// becomes dispatchable instead of being skipped as a dead UNKNOWN.
+		state = recoverIfMenuBlocked(pane.ID, agentType, state)
 		if state == "idle" {
 			idleAgentPanes = append(idleAgentPanes, fmt.Sprintf("%d", pane.Index))
 		}
@@ -1166,6 +1169,15 @@ func determineAgentState(scrollback, agentTypeStr string) string {
 		return "unknown"
 	}
 
+	// Menu-blocked is reported before the live-window working check: a pane
+	// parked at an interactive selection menu (e.g. the /effort picker) is not
+	// doing useful work and must be Esc-recovered before it can take a dispatch.
+	// A distinct state lets callers recover it instead of treating it as a dead
+	// "unknown" — the pre-fix behaviour that stranded /effort sends as UNKNOWN.
+	if state.IsMenuBlocked {
+		return "menu_blocked"
+	}
+
 	// Live-window THINKING check overrides any verdict — the legacy parser
 	// can miss in-flight work when the assignment store has no record.
 	if robot.IsLiveBusy(scrollback, agentTypeStr) {
@@ -1180,6 +1192,30 @@ func determineAgentState(scrollback, agentTypeStr string) string {
 	}
 
 	return "unknown"
+}
+
+// recoverIfMenuBlocked Esc-recovers a pane parked at an interactive selection
+// menu (the /effort or /model picker, a permission selector) and returns the
+// re-evaluated state. When the pane is not menu-blocked it returns the input
+// state unchanged and sends no keystroke, so it is safe to call on every pane
+// during an idle scan or a direct dispatch. This is what lets autonomous
+// dispatch self-heal a menu strand into a dispatchable idle pane instead of
+// skipping it as UNKNOWN — the failure that previously stalled the swarm when
+// an interactive `/effort` send opened a picker that nothing confirmed.
+func recoverIfMenuBlocked(paneTarget, agentType, state string) string {
+	if state != "menu_blocked" {
+		return state
+	}
+	if err := tmux.SendEscape(paneTarget); err != nil {
+		return state
+	}
+	// Brief settle so the TUI redraws the clean prompt before we re-read.
+	time.Sleep(200 * time.Millisecond)
+	scrollback, err := tmux.CaptureForStatusDetection(paneTarget)
+	if err != nil {
+		return state
+	}
+	return determineAgentState(scrollback, agentType)
 }
 
 func normalizedAssignAgentHint(agentTypeStr string) agent.AgentType {
@@ -1546,6 +1582,7 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 		model := detectModelFromTitle(at, pane.Title)
 		scrollback, _ := tmux.CaptureForStatusDetection(pane.ID)
 		state := determineAgentState(scrollback, at)
+		state = recoverIfMenuBlocked(pane.ID, at, state)
 
 		if state == "idle" {
 			idleAgents = append(idleAgents, assignAgentInfo{
@@ -3430,6 +3467,9 @@ func runReassignment(cmd *cobra.Command, session string) error {
 	// Check if target pane is busy (unless --force)
 	scrollback, _ := tmux.CapturePaneOutput(targetPane.ID, 10)
 	state := determineAgentState(scrollback, targetAgentType)
+	// If the pane is parked at an interactive menu, Esc-recover it to a clean
+	// prompt so a direct dispatch lands instead of being refused as busy.
+	state = recoverIfMenuBlocked(targetPane.ID, targetAgentType, state)
 
 	if state != "idle" && !assignForce {
 		// Check if pane has an existing assignment
@@ -4153,6 +4193,7 @@ func runDirectPaneAssignment(cmd *cobra.Command, opts *AssignCommandOptions) err
 
 	scrollback, _ := tmux.CapturePaneOutput(targetPane.ID, 10)
 	state := determineAgentState(scrollback, agentType)
+	state = recoverIfMenuBlocked(targetPane.ID, agentType, state)
 
 	// Build assignment item
 	assignItem := &DirectAssignItem{
@@ -4580,6 +4621,7 @@ func getIdleAgents(session, agentTypeFilter string, verbose bool) ([]assignAgent
 		model := detectModelFromTitle(agentType, pane.Title)
 		scrollback, _ := tmux.CaptureForStatusDetection(pane.ID)
 		state := determineAgentState(scrollback, agentType)
+		state = recoverIfMenuBlocked(pane.ID, agentType, state)
 
 		if state == "idle" {
 			idleAgents = append(idleAgents, assignAgentInfo{

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -776,6 +776,26 @@ func loadActiveAssignmentBeadIDs(session string) map[string]struct{} {
 	return active
 }
 
+// loadActiveAssignmentPanes returns the set of pane indices that currently hold
+// an active (assigned/working, not completed/failed) assignment. A pane in this
+// set is responsible for an in-flight bead and must NOT receive a second one,
+// even when its screen momentarily shows an idle prompt between turns — the
+// between-turns race that otherwise lets the watch loop pile a new bead onto a
+// pane already working one. The watch's completion detector marks assignments
+// completed when their bead closes, so a pane is released from this set the
+// moment its work is genuinely done; excluding it here cannot strand it.
+func loadActiveAssignmentPanes(session string) map[int]struct{} {
+	active := make(map[int]struct{})
+	store, err := assignment.LoadStore(session)
+	if err != nil {
+		return active
+	}
+	for _, item := range store.ListActive() {
+		active[item.Pane] = struct{}{}
+	}
+	return active
+}
+
 // countSkippedByReason counts SkippedItems matching a specific reason. Used to
 // keep BlockedCount in the assignment summary semantically narrow ("blocked by
 // a dependency") even after the broader skipped-reason taxonomy was added.
@@ -943,6 +963,7 @@ func getAssignOutput(opts robot.AssignOptions) (*robot.AssignOutput, error) {
 	}
 
 	// Build agent info similar to robot.PrintAssign
+	activePanes := loadActiveAssignmentPanes(opts.Session)
 	var idleAgentPanes []string
 	totalAgents := 0
 
@@ -959,7 +980,8 @@ func getAssignOutput(opts robot.AssignOptions) (*robot.AssignOutput, error) {
 		// Self-heal a menu strand (e.g. a /effort picker left open) so the pane
 		// becomes dispatchable instead of being skipped as a dead UNKNOWN.
 		state = recoverIfMenuBlocked(pane.ID, agentType, state)
-		if state == "idle" {
+		// Skip panes that already hold an in-flight assignment (between-turns race).
+		if _, busy := activePanes[pane.Index]; state == "idle" && !busy {
 			idleAgentPanes = append(idleAgentPanes, fmt.Sprintf("%d", pane.Index))
 		}
 	}
@@ -1566,6 +1588,11 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 	}
 
 	// Build agent info and filter by type if needed
+	// Panes already holding an in-flight assignment are not available for new
+	// work, even when their screen momentarily shows an idle prompt between
+	// turns — guarding against the between-turns race that otherwise piled a
+	// second bead onto a pane already working one.
+	activePanes := loadActiveAssignmentPanes(opts.Session)
 	var idleAgents []assignAgentInfo
 
 	for _, pane := range panes {
@@ -1584,7 +1611,7 @@ func getAssignOutputEnhanced(opts *AssignCommandOptions) (*AssignOutputEnhanced,
 		state := determineAgentState(scrollback, at)
 		state = recoverIfMenuBlocked(pane.ID, at, state)
 
-		if state == "idle" {
+		if _, busy := activePanes[pane.Index]; state == "idle" && !busy {
 			idleAgents = append(idleAgents, assignAgentInfo{
 				pane:       pane,
 				agentType:  at,
@@ -4605,6 +4632,8 @@ func getIdleAgents(session, agentTypeFilter string, verbose bool) ([]assignAgent
 		return nil, fmt.Errorf("failed to get panes: %w", err)
 	}
 
+	// Exclude panes already holding an in-flight assignment (between-turns race).
+	activePanes := loadActiveAssignmentPanes(session)
 	var idleAgents []assignAgentInfo
 
 	for _, pane := range panes {
@@ -4623,7 +4652,7 @@ func getIdleAgents(session, agentTypeFilter string, verbose bool) ([]assignAgent
 		state := determineAgentState(scrollback, agentType)
 		state = recoverIfMenuBlocked(pane.ID, agentType, state)
 
-		if state == "idle" {
+		if _, busy := activePanes[pane.Index]; state == "idle" && !busy {
 			idleAgents = append(idleAgents, assignAgentInfo{
 				pane:       pane,
 				agentType:  agentType,

--- a/internal/cli/assign_active_panes_test.go
+++ b/internal/cli/assign_active_panes_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/Dicklesworthstone/ntm/internal/assignment"
+)
+
+// A pane holding an active assignment must appear in the active-pane set so the
+// idle-collection paths exclude it from new dispatch (the between-turns race fix).
+func TestLoadActiveAssignmentPanes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store := assignment.NewStore("race-test")
+	if _, err := store.Assign("bead-A", "Some title", 3, "claude", "Agent", "prompt"); err != nil {
+		t.Fatalf("Assign failed: %v", err)
+	}
+
+	active := loadActiveAssignmentPanes("race-test")
+	if _, ok := active[3]; !ok {
+		t.Errorf("pane 3 (active assignment) missing from active set: %v", active)
+	}
+	if _, ok := active[5]; ok {
+		t.Errorf("pane 5 (no assignment) wrongly present in active set")
+	}
+}
+
+// An empty/missing store must yield an empty set (no panes excluded) so a fresh
+// session with no assignments dispatches normally.
+func TestLoadActiveAssignmentPanes_Empty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if active := loadActiveAssignmentPanes("nonexistent-session"); len(active) != 0 {
+		t.Errorf("expected empty active set for fresh session, got %v", active)
+	}
+}

--- a/internal/cli/assign_reassign_test.go
+++ b/internal/cli/assign_reassign_test.go
@@ -303,7 +303,7 @@ func TestRunRetryAssignments_PreservesPreviousFailReasonAndMetadata(t *testing.T
 		t.Fatalf("expected prompt to be sent")
 	}
 
-	expectedPrompt := expandPromptTemplate("bd-131", "Test bead 131", assignTemplate, assignTemplateFile)
+	expectedPrompt := expandPromptTemplate("bd-131", "Test bead 131", "", assignTemplate, assignTemplateFile)
 	storeAfter, _ := assignment.LoadStore(sessionName)
 	assignmentAfter := storeAfter.Get("bd-131")
 	if assignmentAfter == nil {

--- a/internal/cli/dispatch_idle_repro_test.go
+++ b/internal/cli/dispatch_idle_repro_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// TestDetermineAgentStateOnRealIdleCaptures feeds determineAgentState the exact
+// 20-line scrollback the dispatch path captures (LinesStatusDetection) from real
+// idle Claude panes (2026-06-14 live swarm). Each pane has finished its turn —
+// a completed spinner ("✶ Pontificating… (16m 20s)" / "✻ Baked for 16m 20s") is
+// still in the window, with the idle "new task? /clear to save …" prompt below
+// it. The correct verdict is "idle": the agent is waiting for work. Before the
+// fix, IsLiveBusy matched the stale spinner and returned "working", so
+// autonomous dispatch saw 0 idle agents and the swarm stalled.
+func TestDetermineAgentStateOnRealIdleCaptures(t *testing.T) {
+	for _, p := range []string{"2", "3", "4", "5"} {
+		data, err := os.ReadFile("/tmp/ntm-fix-disp" + p + ".txt")
+		if err != nil {
+			t.Skipf("no capture for pane %s: %v", p, err)
+		}
+		got := determineAgentState(string(data), "claude")
+		if got != "idle" {
+			t.Errorf("pane %s: determineAgentState = %q, want \"idle\" (stale completed spinner above a fresh idle prompt must not read as busy)", p, got)
+		}
+	}
+}

--- a/internal/cli/get_all_session_text.go
+++ b/internal/cli/get_all_session_text.go
@@ -218,10 +218,20 @@ func isOnlyWhitespaceOrControl(s string) bool {
 func detectPaneState(output, agentType string) string {
 	// Use robot pattern library
 	match := robot.MatchFirstPattern(output, agentType)
-	if match != nil {
-		return string(match.State)
+	if match == nil {
+		return "UNKNOWN"
 	}
-	return "UNKNOWN"
+	// MatchFirstPattern returns the highest-PRIORITY pattern anywhere in the
+	// output, so a stale, completed spinner left in scrollback (thinking priority
+	// ~110) outranks the current idle prompt (~100) even after the turn finished.
+	// IsLiveBusy applies the spinner-vs-prompt ordering guard (a thinking marker
+	// only counts when it sits below the most-recent idle prompt in the live
+	// tail). So when MatchFirstPattern says THINKING but the pane is not actually
+	// live-busy, the spinner is stale and the pane is waiting for input.
+	if match.Category == robot.CategoryThinking && !robot.IsLiveBusy(output, agentType) {
+		return string(robot.StateWaiting)
+	}
+	return string(match.State)
 }
 
 // Rate limit patterns

--- a/internal/cli/helpers_batch3_test.go
+++ b/internal/cli/helpers_batch3_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -83,13 +84,34 @@ func TestExpandPromptTemplate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := expandPromptTemplate(tc.beadID, tc.title, tc.templateName, "")
+			got := expandPromptTemplate(tc.beadID, tc.title, "", tc.templateName, "")
 			for _, want := range tc.wantContains {
 				if !strings.Contains(got, want) {
-					t.Errorf("expandPromptTemplate(%q, %q, %q, \"\") = %q, want to contain %q", tc.beadID, tc.title, tc.templateName, got, want)
+					t.Errorf("expandPromptTemplate(%q, %q, \"\", %q, \"\") = %q, want to contain %q", tc.beadID, tc.title, tc.templateName, got, want)
 				}
 			}
 		})
+	}
+}
+
+// A custom template with an {AGENT_NAME} placeholder gets the agent's agent-mail
+// identity substituted — needed so an autonomous dispatch can satisfy a
+// pre-commit hook that requires AGENT_NAME (the pane shell does not export it).
+func TestExpandPromptTemplate_AgentName(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "tmpl-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`Bead {BEAD_ID}: {TITLE}. Commit as AGENT_NAME="{AGENT_NAME}".`); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	got := expandPromptTemplate("bd-1", "Do thing", "WildSwan", "custom", f.Name())
+	if !strings.Contains(got, `AGENT_NAME="WildSwan"`) {
+		t.Errorf("expected {AGENT_NAME} substituted to WildSwan, got: %q", got)
+	}
+	if strings.Contains(got, "{AGENT_NAME}") {
+		t.Errorf("placeholder left unexpanded: %q", got)
 	}
 }
 

--- a/internal/cli/kill_reap_test.go
+++ b/internal/cli/kill_reap_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	procpkg "github.com/Dicklesworthstone/ntm/internal/process"
+)
+
+// collectProcessSubtree must include a real child process under a parent.
+func TestCollectProcessSubtree(t *testing.T) {
+	// sh -c 'sleep 30 & wait' → sh has a child sleep
+	parent := exec.Command("sh", "-c", "sleep 30")
+	if err := parent.Start(); err != nil {
+		t.Fatalf("start parent: %v", err)
+	}
+	defer func() { _ = parent.Process.Kill(); _, _ = parent.Process.Wait() }()
+	time.Sleep(200 * time.Millisecond)
+
+	tree := collectProcessSubtree(parent.Process.Pid, 0)
+	if len(tree) == 0 || tree[0] != parent.Process.Pid {
+		t.Fatalf("subtree must start with parent pid; got %v", tree)
+	}
+}
+
+// reapOrphanedAgents must SIGTERM/SIGKILL a real orphan and leave it dead.
+func TestReapOrphanedAgents(t *testing.T) {
+	victim := exec.Command("sleep", "300")
+	if err := victim.Start(); err != nil {
+		t.Fatalf("start victim: %v", err)
+	}
+	pid := victim.Process.Pid
+	go func() { _, _ = victim.Process.Wait() }() // reap zombie after kill
+	time.Sleep(150 * time.Millisecond)
+
+	if !procpkg.IsAlive(pid) {
+		t.Fatalf("victim should be alive before reap")
+	}
+	if n := reapOrphanedAgents([]int{pid}); n != 1 {
+		t.Errorf("expected 1 signalled, got %d", n)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if procpkg.IsAlive(pid) {
+		t.Errorf("victim still alive after reap")
+	}
+}
+
+// Safety: self and pid<=1 must never be signalled.
+func TestReapExcludesSelfAndInit(t *testing.T) {
+	if n := reapOrphanedAgents([]int{1, 0, -5}); n != 0 {
+		t.Errorf("pid<=1 must be excluded; got %d", n)
+	}
+}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/integrations/dcg"
 	"github.com/Dicklesworthstone/ntm/internal/kernel"
 	"github.com/Dicklesworthstone/ntm/internal/output"
+	procpkg "github.com/Dicklesworthstone/ntm/internal/process"
 	"github.com/Dicklesworthstone/ntm/internal/prompt"
 	"github.com/Dicklesworthstone/ntm/internal/redaction"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
@@ -2220,10 +2221,30 @@ func runKill(w io.Writer, session string, force bool, tags []string, noHooks boo
 		_ = output
 	}
 
+	// Capture each pane's agent process subtree BEFORE the shells die. tmux
+	// kill-session terminates the pane shells but detached agent children
+	// (node-based claude/codex/gemini launched with --dangerously-skip-permissions)
+	// survive SIGHUP and reparent to init — leaking processes that hold agent-mail
+	// registrations and file locks. The tree must be walked now, because after the
+	// shells exit the children reparent and can no longer be found from the shell PID.
+	var agentPIDs []int
+	for _, p := range panesForStop {
+		if p.PID > 0 {
+			agentPIDs = append(agentPIDs, collectProcessSubtree(p.PID, 0)...)
+		}
+	}
+
 	if err := tmux.KillSession(session); err != nil {
 		return err
 	}
 	auditKilled = true
+
+	// Reap any agent processes orphaned by kill-session. Shells are already gone
+	// (SIGTERM on them is a harmless no-op); the surviving agents get a graceful
+	// SIGTERM then a SIGKILL backstop. self/parent are excluded defensively.
+	if reaped := reapOrphanedAgents(agentPIDs); reaped > 0 {
+		fmt.Printf("Reaped %d orphaned agent process(es)\n", reaped)
+	}
 
 	fmt.Printf("Killed session '%s'\n", session)
 
@@ -2248,6 +2269,55 @@ func runKill(w io.Writer, session string, force bool, tags []string, noHooks boo
 	}
 
 	return nil
+}
+
+// collectProcessSubtree returns pid plus all of its transitive descendants,
+// recursing through process.GetChildPIDs (which reads /proc on Linux and falls
+// back to pgrep elsewhere). The depth bound guards against cycles / runaway
+// recursion; the per-level child cap keeps a fork-bombed pane from exploding the
+// walk. Used to capture a pane's full agent process tree before the shell dies.
+func collectProcessSubtree(pid, depth int) []int {
+	if pid <= 1 || depth > 6 {
+		return nil
+	}
+	out := []int{pid}
+	for _, child := range procpkg.GetChildPIDs(pid, 64) {
+		out = append(out, collectProcessSubtree(child, depth+1)...)
+	}
+	return out
+}
+
+// reapOrphanedAgents terminates the given PIDs (a session's captured agent
+// process trees) after the tmux session has been killed. It sends SIGTERM, waits
+// a short grace period, then SIGKILLs any survivor. The current process and its
+// parent are excluded defensively, as are pid<=1; duplicates are de-duped.
+// Returns the number of distinct live processes that were signalled.
+func reapOrphanedAgents(pids []int) int {
+	self := os.Getpid()
+	parent := os.Getppid()
+	seen := make(map[int]bool, len(pids))
+	var signalled []int
+	for _, pid := range pids {
+		if pid <= 1 || pid == self || pid == parent || seen[pid] {
+			continue
+		}
+		seen[pid] = true
+		// SIGTERM; ESRCH (already-dead shells) is a harmless no-op.
+		if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
+			signalled = append(signalled, pid)
+		}
+	}
+	if len(signalled) == 0 {
+		return 0
+	}
+	// Grace period for clean shutdown, then a SIGKILL backstop for survivors.
+	time.Sleep(750 * time.Millisecond)
+	for _, pid := range signalled {
+		if procpkg.IsAlive(pid) {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	}
+	return len(signalled)
 }
 
 // runKillProject kills all sessions matching a base project name (bd-3cu02.14).

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -3063,6 +3063,21 @@ func sendPromptWithDoubleEnterForAgent(paneID, prompt string, agentType tmux.Age
 	return tmux.SendKeysForAgentDoubleEnter(paneID, prompt, agentType)
 }
 
+// sendDispatchPrompt sends a bead/task prompt as part of autonomous (or
+// operator-triggered) ASSIGNMENT dispatch. Unlike a plain follow-up `ntm send`,
+// a dispatch must own the whole input line: if the target pane's input box still
+// holds leftover, never-submitted text (a queued prompt an operator left behind,
+// or an agent's half-typed line), a raw send would concatenate the bead prompt
+// onto that junk and submit a corrupted instruction. So we clear the input box
+// first (best-effort; a failed clear must not abort the dispatch), then send
+// with the normal double-Enter submission protocol. Idle boxes are the common
+// case and the clear is a harmless no-op there.
+func sendDispatchPrompt(paneID, prompt string) error {
+	_ = tmux.ClearPaneInput(paneID)
+	time.Sleep(120 * time.Millisecond) // let the TUI redraw the emptied box
+	return sendPromptWithDoubleEnter(paneID, prompt)
+}
+
 func addTimelinePromptMarker(session string, p tmux.Pane, prompt string) {
 	if strings.Compare(session, "") == 0 {
 		return

--- a/internal/config/claude_effort_test.go
+++ b/internal/config/claude_effort_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// The default Claude command template must thread ReasoningEffort into claude's
+// --effort flag (which the CLI supports), mirroring the Codex template's
+// model_reasoning_effort. Regression for the silent effort-drop: spawning a
+// Claude agent with an effort previously rendered no flag, forcing a fragile
+// interactive /effort send that could strand the agent at the picker menu.
+func TestClaudeTemplateThreadsEffort(t *testing.T) {
+	fm := template.FuncMap{
+		"memLimitPrefix": func() string { return "" },
+		"shellQuote":     func(s string) string { return s },
+	}
+	tp := template.Must(template.New("claude").Funcs(fm).Parse(DefaultAgentTemplates().Claude))
+
+	render := func(vars map[string]interface{}) string {
+		var b strings.Builder
+		if err := tp.Execute(&b, vars); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		return b.String()
+	}
+
+	withEffort := render(map[string]interface{}{"Model": "claude-opus-4-8", "ReasoningEffort": "xhigh"})
+	if !strings.Contains(withEffort, "--effort xhigh") {
+		t.Errorf("Claude template dropped effort; got: %s", withEffort)
+	}
+	noEffort := render(map[string]interface{}{"Model": "claude-opus-4-8"})
+	if strings.Contains(noEffort, "--effort") {
+		t.Errorf("empty effort must omit --effort; got: %s", noEffort)
+	}
+}

--- a/internal/config/templates.go
+++ b/internal/config/templates.go
@@ -229,7 +229,7 @@ func IsTemplateCommand(cmd string) bool {
 // System prompt injection is supported via SystemPromptFile for persona agents.
 func DefaultAgentTemplates() AgentConfig {
 	return AgentConfig{
-		Claude: `{{memLimitPrefix}} claude --dangerously-skip-permissions{{if .Model}} --model {{shellQuote .Model}}{{end}}{{if .SystemPromptFile}} --system-prompt-file {{shellQuote .SystemPromptFile}}{{end}}`,
+		Claude: `{{memLimitPrefix}} claude --dangerously-skip-permissions{{if .Model}} --model {{shellQuote .Model}}{{end}}{{if .ReasoningEffort}} --effort {{shellQuote .ReasoningEffort}}{{end}}{{if .SystemPromptFile}} --system-prompt-file {{shellQuote .SystemPromptFile}}{{end}}`,
 		Codex:  `{{if .SystemPromptFile}}CODEX_SYSTEM_PROMPT="$(cat {{shellQuote .SystemPromptFile}})" {{end}}codex --dangerously-bypass-approvals-and-sandbox -m {{shellQuote (.Model | default "gpt-5.5")}} -c model_reasoning_effort={{shellQuote (.ReasoningEffort | default "xhigh")}} -c model_reasoning_summary_format=experimental --search`,
 		Gemini: `gemini{{if .Model}} --model {{shellQuote .Model}}{{end}} --yolo`,
 		// Antigravity (agy): the model is hard-pinned to "Gemini 3.1 Pro (High)"

--- a/internal/robot/activity.go
+++ b/internal/robot/activity.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/Dicklesworthstone/ntm/internal/agent"
 	"github.com/Dicklesworthstone/ntm/internal/state"
 	"github.com/Dicklesworthstone/ntm/internal/status"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
@@ -766,6 +767,7 @@ func (sc *StateClassifier) classifyInternal(sample *VelocitySample) (*AgentActiv
 	liveMatches := sc.patternLibrary.Match(liveContent, sc.agentType)
 	effectiveMatches := filterThinkingToLive(matches, liveMatches)
 	effectiveMatches = filterErrorToLiveWhenIdle(effectiveMatches, liveMatches)
+	effectiveMatches = filterStaleThinkingBelowIdle(liveContent, effectiveMatches, sc.agentType)
 
 	// Calculate proposed state and confidence
 	proposedState, confidence, trigger := sc.classifyState(velocity, effectiveMatches)
@@ -846,8 +848,44 @@ func IsLiveBusy(scrollback string, agentType string) bool {
 	if live == "" {
 		return false
 	}
-	matches := DefaultLibrary.MatchByCategory(live, agentType, CategoryThinking)
-	return len(matches) > 0
+	// Claude Code pins its input box to the bottom of the screen, so a prompt is
+	// always below the spinner even during active work — position-based ordering
+	// misclassifies a busy pane as idle. agent.ClaudeActivelyWorking handles this
+	// correctly (an active spinner counts only when no turn-ended marker — the
+	// completion line or "new task? /clear" hint — follows it).
+	if agent.AgentType(agentType).Canonical() == agent.AgentTypeClaudeCode {
+		return agent.ClaudeActivelyWorking(live)
+	}
+	if len(DefaultLibrary.MatchByCategory(live, agentType, CategoryThinking)) == 0 {
+		return false
+	}
+	// For non-Claude agents a thinking pattern may still be a STALE completed
+	// spinner left in scrollback above a now-current idle prompt. The pane is
+	// only genuinely busy when its most-recent thinking marker sits BELOW its
+	// most-recent idle prompt (no idle prompt has appeared since the spinner).
+	lines := strings.Split(live, "\n")
+	lastThink := lastLineIdxByCategory(lines, agentType, CategoryThinking)
+	if lastThink < 0 {
+		return false
+	}
+	lastIdle := lastLineIdxByCategory(lines, agentType, CategoryIdle)
+	return lastThink > lastIdle
+}
+
+// lastLineIdxByCategory returns the index of the last line in `lines` that
+// matches any pattern of the given category for `agentType`, or -1 if none do.
+// It is used to compare the vertical ordering of competing live-window markers
+// (e.g. a stale spinner above a fresh idle prompt) so the most-recent state
+// wins instead of a category match anywhere in the window winning
+// unconditionally.
+func lastLineIdxByCategory(lines []string, agentType string, cat PatternCategory) int {
+	last := -1
+	for i, ln := range lines {
+		if len(DefaultLibrary.MatchByCategory(ln, agentType, cat)) > 0 {
+			last = i
+		}
+	}
+	return last
 }
 
 // lastNLines returns the last n non-empty-slice lines of s, preserving
@@ -863,6 +901,61 @@ func lastNLines(s string, n int) string {
 		return s
 	}
 	return strings.Join(lines[len(lines)-n:], "\n")
+}
+
+// filterStaleThinkingBelowIdle drops CategoryThinking matches when, within the
+// live window, a CategoryIdle prompt sits on a line BELOW the last thinking
+// marker. That ordering is the signature of a completed spinner the TUI left on
+// screen above a now-current idle prompt — e.g. "✶ Pontificating… (16m 20s)" /
+// "✻ Baked for 16m 20s" rendered above "new task? /clear to save …". Without
+// this, classifyState's rule that thinking outranks an idle prompt would pin a
+// finished, waiting pane to THINKING (and `ntm activity` would report it busy
+// while it is actually idle and dispatchable). When the spinner is the lower
+// line — the agent is genuinely working — nothing is dropped. This mirrors the
+// ordering guard in agent.detectIdle and IsLiveBusy.
+func filterStaleThinkingBelowIdle(liveContent string, matches []PatternMatch, agentType string) []PatternMatch {
+	hasThinking := false
+	for _, m := range matches {
+		if m.Category == CategoryThinking {
+			hasThinking = true
+			break
+		}
+	}
+	if !hasThinking {
+		return matches
+	}
+	lines := strings.Split(liveContent, "\n")
+	lastThink := lastLineIdxByCategory(lines, agentType, CategoryThinking)
+	if lastThink < 0 {
+		return matches
+	}
+	// A thinking match is STALE only when a turn-ended marker appears AFTER it.
+	// For Claude the turn-ended markers are the "new task?" hint and the
+	// completion line (NOT the always-present empty input box); for other agents
+	// fall back to the idle-prompt category. A thinking indicator with nothing
+	// after it (e.g. a live "Thinking…") is NOT stale and must be kept.
+	lastEnded := -1
+	if agent.AgentType(agentType).Canonical() == agent.AgentTypeClaudeCode {
+		for i, ln := range lines {
+			if agent.IsClaudeTurnEnded(ln) {
+				lastEnded = i
+			}
+		}
+	} else {
+		lastEnded = lastLineIdxByCategory(lines, agentType, CategoryIdle)
+	}
+	if lastEnded <= lastThink {
+		// Most-recent thinking marker is live (no turn-ended marker after it).
+		return matches
+	}
+	out := make([]PatternMatch, 0, len(matches))
+	for _, m := range matches {
+		if m.Category == CategoryThinking {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // filterThinkingToLive returns a match slice equivalent to `full` but with

--- a/internal/robot/is_working.go
+++ b/internal/robot/is_working.go
@@ -57,6 +57,7 @@ type PaneWorkStatus struct {
 	AgentType            string         `json:"agent_type"`
 	IsWorking            bool           `json:"is_working"`
 	IsIdle               bool           `json:"is_idle"`
+	IsMenuBlocked        bool           `json:"is_menu_blocked"`
 	IsRateLimited        bool           `json:"is_rate_limited"`
 	IsContextLow         bool           `json:"is_context_low"`
 	ContextRemaining     *float64       `json:"context_remaining,omitempty"`
@@ -260,6 +261,7 @@ func GetIsWorking(opts IsWorkingOptions) (*IsWorkingOutput, error) {
 			AgentType:        string(state.Type),
 			IsWorking:        state.IsWorking,
 			IsIdle:           state.IsIdle,
+			IsMenuBlocked:    state.IsMenuBlocked,
 			IsRateLimited:    state.IsRateLimited,
 			IsContextLow:     state.IsContextLow,
 			ContextRemaining: state.ContextRemaining,

--- a/internal/robot/livebusy_ordering_test.go
+++ b/internal/robot/livebusy_ordering_test.go
@@ -1,0 +1,60 @@
+package robot
+
+import "testing"
+
+// realIdleScrollback is the exact 20-line window the dispatch/status path
+// captures (LinesStatusDetection) from a real idle Claude pane on 2026-06-14.
+// The turn finished long ago — a completed spinner ("✶ Pontificating… (16m 20s)"
+// / "✻ Baked for 16m 20s") is still in the window, with the idle input box and
+// the "new task? /clear to save …" footer hint below it.
+const realIdleScrollback = "" +
+	"  thing, which also deconflicted it from\n" +
+	"  the live GentleCompass pane. All\n" +
+	"  commits are on local main, committed\n" +
+	"  as GentleCompass — not pushed (you\n" +
+	"  didn't ask to sync). Say the word and\n" +
+	"  I'll run the push + the skills-repo\n" +
+	"  sync.\n" +
+	"\n" +
+	"✶ Pontificating… (16m 20s)\n" +
+	"  ⎿  Tip: Use /btw to ask a quick side\n" +
+	"     question without interrupting\n" +
+	"✻ Baked for 16m 20s\n" +
+	"\n" +
+	"────────────────────────────────────────\n" +
+	"❯ push it and sync the skills repo\n" +
+	"────────────────────────────────────────\n" +
+	"  ⏵⏵ bypass permissions on          ·\n" +
+	"  new task? /clear to save 200.7k tokens\n"
+
+// genuinelyWorkingScrollback: the active spinner is the lowest meaningful line —
+// the agent is really working. IsLiveBusy must stay true here.
+const genuinelyWorkingScrollback = "" +
+	"  Let me check the dispatcher invariants before closing this out.\n" +
+	"────────────────────────────────────────\n" +
+	"❯ \n" +
+	"────────────────────────────────────────\n" +
+	"✻ Noodling… (2m 5s · ↓ 6.2k tokens · thought for 7s)\n"
+
+func TestIsLiveBusyStaleSpinnerAboveIdle(t *testing.T) {
+	if IsLiveBusy(realIdleScrollback, "claude") {
+		t.Errorf("IsLiveBusy=true for a finished pane whose idle 'new task?' prompt is below a stale spinner; want false (this stalled autonomous dispatch)")
+	}
+}
+
+func TestIsLiveBusyGenuineWork(t *testing.T) {
+	if !IsLiveBusy(genuinelyWorkingScrollback, "claude") {
+		t.Errorf("IsLiveBusy=false for an active spinner below the prompt; want true (must not dispatch into a busy pane)")
+	}
+}
+
+func TestClassifyIdleNotThinking(t *testing.T) {
+	sc := NewStateClassifier("test", nil)
+	act, err := sc.ClassifyWithOutput(realIdleScrollback)
+	if err != nil {
+		t.Fatalf("classify: %v", err)
+	}
+	if act.State == StateThinking {
+		t.Errorf("ntm activity would report THINKING for a finished idle pane; want non-thinking (got %v)", act.State)
+	}
+}

--- a/internal/robot/patterns.go
+++ b/internal/robot/patterns.go
@@ -96,6 +96,13 @@ func defaultPatterns() []Pattern {
 		// bare-chevron prompt patterns miss. The "/clear" companion keeps prose
 		// that merely says "…a new task?" from false-matching.
 		{Name: "claude_new_task_hint", RegexStr: `(?i)new task\?\s*/clear`, Agent: "claude", State: StateWaiting, Category: CategoryIdle, Priority: 101, Description: "Claude Code post-turn 'new task? /clear to save …' idle hint"},
+		// Claude's compose-box permission-mode footer ("⏵⏵ bypass permissions …").
+		// The ⏵⏵ glyph is unique to that footer ⇒ the TUI is alive at its input
+		// box. Lower priority than the spinner patterns so an active spinner still
+		// wins; consumers that need the working/idle split additionally gate on
+		// IsLiveBusy (which uses agent.ClaudeActivelyWorking). Catches idle boxes
+		// holding queued text / an … ellipsis with no visible hint.
+		{Name: "claude_compose_box", RegexStr: `⏵⏵`, Agent: "claude", State: StateWaiting, Category: CategoryIdle, Priority: 60, Description: "Claude Code compose-box footer (TUI alive at input box)"},
 
 		// Claude Code spinner detection (active work indicators)
 		{Name: "claude_spinner_timing", RegexStr: `\S+…\s+\(`, Agent: "claude", State: StateThinking, Category: CategoryThinking, Priority: 110, Description: "Claude Code timing spinner (e.g. Bunning… (3s))"},

--- a/internal/robot/patterns.go
+++ b/internal/robot/patterns.go
@@ -88,6 +88,14 @@ func defaultPatterns() []Pattern {
 		{Name: "claude_welcome", RegexStr: `(?i)welcome\s+back`, Agent: "claude", State: StateWaiting, Category: CategoryIdle, Priority: 102, Description: "Claude Code welcome message"},
 		{Name: "claude_try_prompt", RegexStr: `❯\s*Try\s+"`, Agent: "claude", State: StateWaiting, Category: CategoryIdle, Priority: 102, Description: "Claude Code try prompt"},
 		{Name: "claude_unicode_prompt", RegexStr: `(?m)❯[\s\x{00a0}]*$`, Agent: "claude", State: StateWaiting, Category: CategoryIdle, Priority: 101, Description: "Claude Code unicode angle prompt (multiline, NBSP-aware)"},
+		// Claude Code's post-turn "ready for input" footer hint, e.g. "new task?
+		// /clear to save 113.1k tokens". Rendered only once the turn is finished
+		// and the agent is waiting; during active work the same footer slot shows
+		// the spinner instead. This is the reliable idle marker when the ❯ box
+		// above carries queued/unsent text or a bare … ellipsis, which the
+		// bare-chevron prompt patterns miss. The "/clear" companion keeps prose
+		// that merely says "…a new task?" from false-matching.
+		{Name: "claude_new_task_hint", RegexStr: `(?i)new task\?\s*/clear`, Agent: "claude", State: StateWaiting, Category: CategoryIdle, Priority: 101, Description: "Claude Code post-turn 'new task? /clear to save …' idle hint"},
 
 		// Claude Code spinner detection (active work indicators)
 		{Name: "claude_spinner_timing", RegexStr: `\S+…\s+\(`, Agent: "claude", State: StateThinking, Category: CategoryThinking, Priority: 110, Description: "Claude Code timing spinner (e.g. Bunning… (3s))"},

--- a/internal/status/newtask_idle_test.go
+++ b/internal/status/newtask_idle_test.go
@@ -1,0 +1,47 @@
+package status
+
+import "testing"
+
+// Real captured idle Claude screens (2026-06-14). The turn is finished — a
+// completed spinner sits above an idle input box whose ❯ chevron holds queued
+// text or an … placeholder, followed by the "new task? /clear to save …" footer
+// hint. Before the fix, DetectIdleFromOutput returned false (no prompt pattern
+// matched the queued-text box), so `ntm status` reported these idle panes as
+// "working".
+func TestDetectIdleNewTaskHint(t *testing.T) {
+	cases := map[string]string{
+		"queued-text-box": "" +
+			"✶ Pontificating… (16m 20s)\n" +
+			"✻ Baked for 16m 20s\n" +
+			"\n" +
+			"────────────────────────────────────────\n" +
+			"❯ push it and sync the skills repo\n" +
+			"────────────────────────────────────────\n" +
+			"  ⏵⏵ bypass permissions on          ·\n" +
+			"  new task? /clear to save 200.7k tokens\n",
+		"ellipsis-box": "" +
+			"❯ …\n" +
+			"───────────────────────────────────────\n" +
+			"  ⏵⏵ bypass permissions on         ·\n" +
+			"  new task? /clear to save 323.7k tokens\n",
+	}
+	for name, screen := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !DetectIdleFromOutput(screen, "cc") {
+				t.Errorf("DetectIdleFromOutput=false, want true for idle 'new task?' screen")
+			}
+		})
+	}
+}
+
+// A genuinely working screen: the active spinner is the lowest line. Must NOT
+// classify as idle, or status would mislabel a busy agent as available.
+func TestDetectIdleActiveSpinnerNotIdle(t *testing.T) {
+	working := "" +
+		"  Working through the dispatcher invariants.\n" +
+		"❯ \n" +
+		"✻ Noodling… (4m 8s · ↓ 6.2k tokens · thought for 14s)\n"
+	if DetectIdleFromOutput(working, "cc") {
+		t.Errorf("DetectIdleFromOutput=true for active-spinner screen, want false")
+	}
+}

--- a/internal/status/patterns.go
+++ b/internal/status/patterns.go
@@ -51,6 +51,12 @@ var promptPatterns = []PromptPattern{
 	// that merely says "…a new task?" from false-matching. activeWorkBelow still
 	// guards against a spinner rendered below this line.
 	{AgentType: "cc", Regex: regexp.MustCompile(`(?i)new task\?\s*/clear`), Description: "Claude Code post-turn 'new task? /clear to save …' idle hint"},
+	// Claude's compose-box permission-mode footer ("⏵⏵ bypass permissions …"). The
+	// ⏵⏵ glyph is unique to that footer ⇒ the TUI is alive at its input box.
+	// DetectIdleFromOutput routes cc through ClaudeActivelyWorking, so a working
+	// pane (active spinner) is still excluded; this catches idle boxes holding
+	// queued text or an … ellipsis with no visible hint.
+	{AgentType: "cc", Regex: regexp.MustCompile(`⏵⏵`), Description: "Claude Code compose-box footer (TUI alive at input box)"},
 
 	// Codex CLI patterns
 	{AgentType: "cod", Regex: regexp.MustCompile(`(?i)codex>?\s*$`), Description: "Codex prompt"},

--- a/internal/status/patterns.go
+++ b/internal/status/patterns.go
@@ -44,6 +44,13 @@ var promptPatterns = []PromptPattern{
 	{AgentType: "cc", Regex: regexp.MustCompile(`(?i)welcome\s+back`), Description: "Claude Code welcome message"},
 	{AgentType: "cc", Regex: regexp.MustCompile(`╰─>\s*$`), Description: "Claude Code arrow prompt"},
 	{AgentType: "cc", Regex: regexp.MustCompile(`(?m)❯[\s\x{00a0}]*$`), Description: "Claude Code unicode angle prompt (multiline, NBSP-aware)"},
+	// Claude Code's post-turn "ready for input" footer hint, e.g. "new task?
+	// /clear to save 113.1k tokens". Reliable idle marker when the ❯ box above
+	// holds queued/unsent text or a bare … ellipsis rather than an empty chevron.
+	// Rendered only when the turn is finished; the "/clear" companion keeps prose
+	// that merely says "…a new task?" from false-matching. activeWorkBelow still
+	// guards against a spinner rendered below this line.
+	{AgentType: "cc", Regex: regexp.MustCompile(`(?i)new task\?\s*/clear`), Description: "Claude Code post-turn 'new task? /clear to save …' idle hint"},
 
 	// Codex CLI patterns
 	{AgentType: "cod", Regex: regexp.MustCompile(`(?i)codex>?\s*$`), Description: "Codex prompt"},
@@ -214,10 +221,15 @@ func DetectIdleFromOutput(output string, agentType string) bool {
 		}
 		linesChecked++
 		if IsPromptLine(line, agentType) {
-			// Guard against false idle: if the agent is actively working its
-			// input box is still drawn, but a spinner sits below the prompt.
-			// Only treat the prompt as authoritative when nothing below it
-			// indicates ongoing work.
+			// Guard against false idle. Claude Code pins its input box to the
+			// BOTTOM of the screen, so during active work the spinner renders
+			// ABOVE the prompt — activeWorkBelow (which only scans below the
+			// prompt) would miss it and report a busy pane as idle. Use the
+			// turn-ended-aware whole-capture check for Claude; keep the
+			// below-the-prompt scan for agents whose spinner trails the prompt.
+			if agentType == "cc" {
+				return !agent.ClaudeActivelyWorking(clean)
+			}
 			if activeWorkBelow(lines, i) {
 				return false
 			}

--- a/internal/status/repaint_idle_test.go
+++ b/internal/status/repaint_idle_test.go
@@ -1,0 +1,44 @@
+package status
+
+import (
+	"testing"
+	"time"
+)
+
+// A live Claude Code pane that has finished its turn but keeps repainting its
+// idle input box (cursor, "new task? /clear to save …" footer) has a FRESH tmux
+// pane-activity timestamp even though no work is happening. determineState must
+// report idle on the structural idle-prompt signal, not WORKING on the repaint.
+func TestDetermineStateIdleDespiteFreshActivity(t *testing.T) {
+	d := NewDetectorWithConfig(DefaultConfig())
+	idleScreen := "" +
+		"✶ Pontificating… (16m 20s)\n" +
+		"✻ Baked for 16m 20s\n" +
+		"\n" +
+		"────────────────────────────────────────\n" +
+		"❯ push it and sync the skills repo\n" +
+		"────────────────────────────────────────\n" +
+		"  ⏵⏵ bypass permissions on          ·\n" +
+		"  new task? /clear to save 200.7k tokens\n"
+
+	// lastActivity = now → NOT low velocity (the repaint case).
+	state, _ := d.determineState(idleScreen, "cc", time.Now())
+	if state != StateIdle {
+		t.Errorf("determineState = %v with fresh activity; want StateIdle (TUI repaint must not mask a genuine idle prompt)", state)
+	}
+}
+
+// Sanity: a genuinely working pane (active spinner below the prompt, fresh
+// activity) must still report working, not idle.
+func TestDetermineStateWorkingWithSpinnerBelowPrompt(t *testing.T) {
+	d := NewDetectorWithConfig(DefaultConfig())
+	working := "" +
+		"────────────────────────────────────────\n" +
+		"❯ \n" +
+		"────────────────────────────────────────\n" +
+		"✻ Noodling… (2m 5s · ↓ 6.2k tokens · thought for 7s)\n"
+	state, _ := d.determineState(working, "cc", time.Now())
+	if state == StateIdle {
+		t.Errorf("determineState = StateIdle for an active-spinner pane; want working/non-idle")
+	}
+}

--- a/internal/status/unified.go
+++ b/internal/status/unified.go
@@ -103,10 +103,19 @@ func (d *UnifiedDetector) determineState(output, agentType string, lastActivity 
 		}
 	}
 
-	// Recent activity means the agent is producing output — trust that
-	// signal over prompt-like patterns, since agents often print >, ❯,
-	// etc. as part of active work (code examples, progress lines).
+	// Recent tmux pane-activity usually means the agent is producing output.
+	// But it is NOT reliable for agents whose TUI repaints while idle: Claude
+	// Code keeps redrawing its input box (cursor, the "new task? /clear to save"
+	// footer) with no real work happening, which keeps pane_activity fresh and
+	// would pin every live agent to WORKING forever. So when the scrollback shows
+	// a genuine idle prompt — DetectIdleFromOutput already requires a prompt with
+	// NO active-work spinner below it — trust that structural signal over the
+	// repaint and report idle. Only fall through to WORKING when there is recent
+	// activity AND no idle prompt (the agent really is mid-output).
 	if !isLowVelocity {
+		if isAtPrompt {
+			return StateIdle, ErrorNone
+		}
 		return StateWorking, ErrorNone
 	}
 

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -909,6 +909,16 @@ func (c *Client) SendKeysWithDelay(target, keys string, enter bool, enterDelay t
 	return nil
 }
 
+// SendEscape sends a single Escape key press to a pane. Unlike SendKeys (which
+// uses `send-keys -l`, literal mode, and would type the word "Escape"), this
+// passes "Escape" as a tmux key NAME so it registers as the Esc key. It is used
+// to dismiss an interactive selection menu (the /effort or /model picker, a
+// permission selector) and return the pane to a clean prompt — no Enter is
+// sent, so nothing in the menu is selected.
+func SendEscape(target string) error {
+	return DefaultClient.RunSilent("send-keys", "-t", target, "Escape")
+}
+
 // FormatPaneName formats a pane title according to NTM convention
 func FormatPaneName(session string, agentType string, index int, variant string) string {
 	normalizedType := strings.TrimSpace(agentType)

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -1151,6 +1151,23 @@ func SendKeysForAgentDoubleEnter(target, keys string, agentType AgentType) error
 	return nil
 }
 
+// ClearPaneInput clears any unsent text sitting in an agent's input box before
+// a fresh prompt is typed, so a dispatch is not corrupted by leftover content
+// (e.g. a queued, never-submitted prompt an operator left in the box, or an
+// agent's own half-typed line). It sends Ctrl-U (readline kill-line-backward),
+// which Claude Code's input box and shell readline both honor. Safe to call on
+// an empty box — it is a no-op there. This is a best-effort cleanup: callers in
+// the dispatch path ignore the error and proceed, because the worst case is the
+// pre-existing (already-broken) behavior of appending to leftover text.
+func (c *Client) ClearPaneInput(target string) error {
+	return c.RunSilent("send-keys", "-t", target, "C-u")
+}
+
+// ClearPaneInput clears an agent's input box (default client).
+func ClearPaneInput(target string) error {
+	return DefaultClient.ClearPaneInput(target)
+}
+
 // SendInterrupt sends Ctrl+C to a pane
 func (c *Client) SendInterrupt(target string) error {
 	return c.RunSilent("send-keys", "-t", target, "C-c")


### PR DESCRIPTION
## Swarm autonomy: correct Claude idle/working detection + add a periodic ready-work scan

Two fixes that, together, are the difference between an autonomous-dispatch loop that **looks** like it's working and one that actually keeps idle agents fed. Found and verified while running `ntm assign --watch` against a live multi-agent Claude swarm that had silently stalled — four agents idle for ~2 hours while every status surface reported them busy and the watch loop dispatched nothing.

> **Stacked on #188.** This branch builds on #188 (commits `c81c809..fd9f19f`) — the new code uses the `IsMenuBlocked` state and the active-assignment idle-pool guard introduced there. The **two commits unique to this PR** are `4ede0d1` and `88631aa`; review them in isolation here: `compare/fd9f19f...fix/claude-idle-detection`. Please merge #188 first (or merge this after it).

`+~480 / −~30` for the two new commits; a test accompanies every fix; the cycle and restart behavior were verified live end-to-end.

---

### 1 — Correct Claude idle/working classification (`4ede0d1`)

**The bug.** Claude Code pins its input box to the **bottom** of the screen at all times, so the `❯` prompt is the lowest line *even during active work* (the spinner renders above the box). Two failures followed:

- **Idle agents were invisible.** After a turn, Claude parks the pane at a `new task? /clear to save … tokens` footer with the input box holding queued text or an `…` placeholder. No detector recognized that — the idle patterns only matched an *empty* `❯` — so idle agents classified as not-idle and the watch never dispatched to them. This is what stalled the swarm.
- **A dangerous false-idle.** The detectors used a "spinner-above-prompt ⇒ idle" ordering. Since the prompt is *always* below the spinner, this misclassified **busy** panes as idle — a pane actively running (`· Processing… (2m 8s)`) read as idle, which would let autonomous dispatch inject a second bead into a working agent.

**The fix.** A single shared helper, `agent.ClaudeActivelyWorking`, reused by every detector:

> A pane is *working* iff an active spinner is the most-recent **dynamic** marker — i.e. no turn-ended marker (the `new task?` hint or a completion line like `✻ Baked for 16m 20s`) appears after the last spinner. A spinner above a turn-ended marker is stale scrollback.

The scan is window-bounded (the live spinner is always just above the box) and the completion-line pattern is deliberately narrow (glyph-led, whole-line, excludes `…`) so it can't match a `thought for 14s` annotation or prose. The classifier is **biased to the safe failure** (false-*working*, never false-idle). Wired into all four state-detection paths — `agent.detectIdle`, `robot.IsLiveBusy` + the activity classifier, `status.DetectIdleFromOutput`/`determineState`, and `get-all-session-text` — plus a status `pane_activity`-recency fix (a live TUI repaints its idle box, which otherwise pins it to WORKING) and a `ClearPaneInput`/`sendDispatchPrompt` guard so a dispatch clears leftover queued text before typing.

This updates one fixture in `TestParser_Parse_Idle_Claude_StaleSpinnerAbovePrompt` (added in #187): its premise — an active-tense spinner above an empty box ⇒ idle — is the exact false-idle this corrects. The fixture is changed to a realistic finished-turn screen (a spinner *with* a completion + `new task?` marker below it).

### 2 — Periodic ready-work scan in the watch loop (`88631aa`)

**The bug.** `WatchLoop.Run` was **purely completion-driven**: its main `select` waited only on completion events, which the detector fires only for beads *this loop dispatched*. There was no periodic re-scan for idle agents + ready work. So if the initial assignment pass dispatched nothing — no idle agents *or* no ready work at startup (exactly the stall condition above) — **no completion event would ever fire and the loop sat inert forever**, even as ready work appeared (a gate unblocks, beads are created, startup-busy agents go idle). The 30s `watch-interval` only polled for *completions*.

**The fix.** A periodic ready-work scan: `WatchLoop` gains `scanOpts`/`scanInterval`, and the main loop a `case <-ticker.C:` that re-runs the same plan/dispatch pass as the initial assignment (`getAssignOutputEnhanced` + `executeAssignmentsEnhanced`) every `watch-interval`. Idempotent by construction — the idle pool already excludes busy panes and panes holding an active assignment (#188), so a re-scan never double-dispatches in-flight work.

---

### Testing & live verification

- New unit tests: `internal/agent/{cc_newtask_idle,claude_activity}_test.go`, `internal/cli/dispatch_idle_repro_test.go`, `internal/robot/livebusy_ordering_test.go`, `internal/status/{newtask_idle,repaint_idle}_test.go` — all reproduced RED-first from real captured screens (working *and* idle), with explicit guards that a genuinely-working pane is never read as idle. Full `agent`/`robot`/`status`/`cli`/`tmux` suites pass.
- **Live, end-to-end:** all five status surfaces (`status`/`activity`/`health`/`get-all-session-text`/`assign`) agree with reality for both idle and working agents. With a controlled dependency chain of throwaway beads, the loop **cycled unattended** — `a → b → c` dispatched sequentially via the periodic scan, each after the prior closed and unblocked the next — and a **freshly-restarted** loop picked up work that became ready while no dispatcher was running.

### Known limitation

A Claude turn that finishes with a **tiny context** renders neither a completion line nor the `new task?` hint — just an empty box and a *frozen* spinner. A single snapshot cannot distinguish a frozen spinner from a live one (telling them apart needs a second timed sample — velocity). Such a pane reads as **false-working** — the safe direction (no double-dispatch) — and does not occur in real work, where a finished turn accumulates context and renders the hint. Velocity-based liveness in the dispatch path is the robust closure; noted as follow-up, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
