### PR TITLE
Add plugin default model resolution

### DIFF
--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -552,7 +552,7 @@ func runAdd(opts AddOptions) error {
 		}
 
 		// Resolve model alias to full model name
-		resolvedModel := ResolveModel(agent.Type, agent.Model)
+		resolvedModel := ResolveModelWithPlugins(agent.Type, agent.Model, opts.PluginMap)
 		modelRequested := strings.TrimSpace(agent.Model) != ""
 		// Reasoning effort comes from the direct spec (`--cc=N:model:effort`)
 		// parsed onto the FlatAgent, and is overridden by the persona below when
@@ -582,7 +582,7 @@ func runAdd(opts AddOptions) error {
 					systemPromptFile = promptFile
 				}
 				// For persona agents, resolve the model from the persona config
-				resolvedModel = ResolveModel(agent.Type, p.Model)
+				resolvedModel = ResolveModelWithPlugins(agent.Type, p.Model, opts.PluginMap)
 			}
 		}
 

--- a/internal/cli/agent_spec.go
+++ b/internal/cli/agent_spec.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Dicklesworthstone/ntm/internal/persona"
+	"github.com/Dicklesworthstone/ntm/internal/plugins"
 )
 
 var (
@@ -194,6 +195,22 @@ func ResolveModel(agentType AgentType, modelSpec string) string {
 		return modelSpec
 	}
 	return cfg.Models.GetModelName(string(agentType), modelSpec)
+}
+
+// ResolveModelWithPlugins resolves a model alias and, for plugin agent types
+// with no per-spawn model, falls back to the plugin's default model.
+func ResolveModelWithPlugins(agentType AgentType, modelSpec string, pluginMap map[string]plugins.AgentPlugin) string {
+	resolved := ResolveModel(agentType, modelSpec)
+	if strings.TrimSpace(modelSpec) != "" || strings.TrimSpace(resolved) != "" {
+		return resolved
+	}
+	if pluginMap == nil {
+		return resolved
+	}
+	if p, ok := pluginMap[string(agentType)]; ok {
+		return strings.TrimSpace(p.Defaults.Model)
+	}
+	return resolved
 }
 
 // ValidateModelAlias checks if a model alias exists in config

--- a/internal/cli/agent_spec_test.go
+++ b/internal/cli/agent_spec_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Dicklesworthstone/ntm/internal/config"
+	"github.com/Dicklesworthstone/ntm/internal/plugins"
 )
 
 func TestParseAgentSpec_ModelValidation(t *testing.T) {
@@ -191,6 +192,34 @@ func TestResolveModel_EmptySpecReturnsDefault(t *testing.T) {
 	got := ResolveModel(AgentTypeClaude, "")
 	// Just verify it doesn't panic; the result depends on whether cfg is set
 	_ = got
+}
+
+func TestResolveModelWithPlugins_DefaultModel(t *testing.T) {
+	oldCfg := cfg
+	defer func() { cfg = oldCfg }()
+	cfg = config.Default()
+
+	pluginMap := map[string]plugins.AgentPlugin{
+		"hermes": {
+			Name: "hermes",
+			Defaults: struct {
+				Model string   `toml:"model"`
+				Tags  []string `toml:"tags"`
+			}{
+				Model: "google/gemini-2.5-flash",
+			},
+		},
+	}
+
+	if got := ResolveModelWithPlugins(AgentType("hermes"), "", pluginMap); got != "google/gemini-2.5-flash" {
+		t.Fatalf("plugin default model = %q, want google/gemini-2.5-flash", got)
+	}
+	if got := ResolveModelWithPlugins(AgentType("hermes"), "anthropic/claude-opus-4", pluginMap); got != "anthropic/claude-opus-4" {
+		t.Fatalf("explicit plugin model = %q, want explicit value", got)
+	}
+	if got := ResolveModelWithPlugins(AgentType("other-plugin"), "", pluginMap); got != "" {
+		t.Fatalf("missing plugin default model = %q, want empty", got)
+	}
 }
 
 func TestValidateModelAlias_EmptyAlias(t *testing.T) {

--- a/internal/cli/spawn.go
+++ b/internal/cli/spawn.go
@@ -2044,7 +2044,7 @@ func spawnSessionLogic(opts SpawnOptions) (err error) {
 		}
 
 		// Resolve model alias to full model name
-		resolvedModel := ResolveModel(agent.Type, agent.Model)
+		resolvedModel := ResolveModelWithPlugins(agent.Type, agent.Model, opts.PluginMap)
 		modelRequested := strings.TrimSpace(agent.Model) != ""
 		// agy is hard-pinned: ResolveModel always returns the required model. If
 		// the user explicitly requested a different one, surface that it was
@@ -2089,7 +2089,7 @@ func spawnSessionLogic(opts SpawnOptions) (err error) {
 					systemPromptFile = promptFile
 				}
 				// For persona agents, resolve the model from the persona config
-				resolvedModel = ResolveModel(agent.Type, p.Model)
+				resolvedModel = ResolveModelWithPlugins(agent.Type, p.Model, opts.PluginMap)
 			}
 		}
 
@@ -2103,7 +2103,7 @@ func spawnSessionLogic(opts SpawnOptions) (err error) {
 			personaName = profile.Name
 			if strings.TrimSpace(profile.Model) != "" {
 				modelRequested = true
-				resolvedModel = ResolveModel(agent.Type, profile.Model)
+				resolvedModel = ResolveModelWithPlugins(agent.Type, profile.Model, opts.PluginMap)
 			}
 			if strings.TrimSpace(profile.ReasoningEffort) != "" {
 				resolvedReasoningEffort = profile.ReasoningEffort

--- a/internal/plugins/agent.go
+++ b/internal/plugins/agent.go
@@ -21,7 +21,8 @@ type AgentPlugin struct {
 	Description string            `toml:"description"`
 	Env         map[string]string `toml:"env"`
 	Defaults    struct {
-		Tags []string `toml:"tags"`
+		Model string   `toml:"model"`
+		Tags  []string `toml:"tags"`
 	} `toml:"defaults"`
 }
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -319,9 +319,10 @@ command = "my-agent-binary"
 description = "My custom agent"
 
 [agent.env]
-API_KEY = "secret"
+CUSTOM_ENV = "present"
 
 [agent.defaults]
+model = "google/gemini-2.5-flash"
 tags = ["custom", "test"]
 `
 	path := filepath.Join(dir, "my-agent.toml")
@@ -350,8 +351,11 @@ tags = ["custom", "test"]
 	if p.Description != "My custom agent" {
 		t.Errorf("expected description 'My custom agent', got: %s", p.Description)
 	}
-	if p.Env["API_KEY"] != "secret" {
-		t.Errorf("expected env API_KEY='secret', got: %v", p.Env)
+	if p.Env["CUSTOM_ENV"] != "present" {
+		t.Errorf("expected env CUSTOM_ENV='present', got: %v", p.Env)
+	}
+	if p.Defaults.Model != "google/gemini-2.5-flash" {
+		t.Errorf("expected default model 'google/gemini-2.5-flash', got: %q", p.Defaults.Model)
 	}
 	if len(p.Defaults.Tags) != 2 || p.Defaults.Tags[0] != "custom" {
 		t.Errorf("expected tags [custom, test], got: %v", p.Defaults.Tags)


### PR DESCRIPTION
## Summary
- add plugin-aware default model resolution for agent specs that omit an explicit model
- load `agent.defaults.model` from agent plugin TOML and use it in both `spawn` and `add`
- keep explicit `--agent=1:model` values and global config defaults higher precedence than plugin defaults

## Problem
Agent plugins can declare default environment/working-directory/template behavior, but Hermes-style plugin specs without an explicit model were still spawned with an empty model. That made bare plugin invocations such as `--hermes=1` fail registration even when the plugin configuration carried the right model default.

## Fix
This patch adds a general resolver in `internal/cli` that applies precedence in this order:

1. explicit model in the agent spec (`--agent=1:model`)
2. global defaults for the agent type
3. plugin default model from `agent.defaults.model`

The plugin TOML loader now reads the `model` field, and both `spawn` and `add` call the same resolver.

## Precedent / proof
This follows the Opencode default-model precedent from ntm#193: a plugin should be able to provide the default model while still allowing CLI/global config overrides.

Local A/B proof with a Hermes plugin that declares `agent.defaults.model = "google/gemini-2.5-flash"`:

- unpatched v1.18.3 bare `--hermes=1`: `agents_registered=0`, failed because model was empty
- patched side build bare `--hermes=1`: `agents_registered=1`, model resolved to `google/gemini-2.5-flash`

## Tests
- `gofmt -l internal/cli/add.go internal/cli/agent_spec.go internal/cli/agent_spec_test.go internal/cli/spawn.go internal/plugins/agent.go internal/plugins/plugins_test.go` produced no output
- `go test ./internal/plugins ./internal/cli -run 'TestLoadAgentPlugins_LoadsValidTOML|TestResolveModelWithPlugins_DefaultModel|TestSpawnAndAddPluginFlagsUseGlobalConfigFlag' -count=1`
- `go build ./cmd/ntm`

Posted by Codex on behalf of profplum700.
