### PR TITLE
feat(plugins): first-class plugin agents in controller, restart, and pane detection

### DIFF
--- a/internal/cli/controller.go
+++ b/internal/cli/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	"github.com/Dicklesworthstone/ntm/internal/kernel"
 	"github.com/Dicklesworthstone/ntm/internal/output"
+	"github.com/Dicklesworthstone/ntm/internal/plugins"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
@@ -171,7 +172,7 @@ Custom prompt files support template variables:
 		},
 	}
 
-	cmd.Flags().StringVar(&agentType, "agent-type", "cc", "Agent type: cc, cod, gmi, agy, cursor, windsurf|ws, aider, oc, or ollama")
+	cmd.Flags().StringVar(&agentType, "agent-type", "cc", "Agent type: cc, cod, gmi, agy, cursor, windsurf|ws, aider, oc, or ollama; or any registered agent plugin (e.g. pi, pia)")
 	cmd.Flags().StringVar(&promptFile, "prompt", "", "Custom prompt file (supports template variables)")
 	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Skip sending initial prompt")
 	cmd.ValidArgsFunction = completeSessionArgs
@@ -279,7 +280,15 @@ func buildControllerResponse(opts ControllerInput) (*ControllerResponse, error) 
 		agentTypeFull = "ollama"
 		agentCmdTemplate = cfg.Agents.Ollama
 	default:
-		return nil, fmt.Errorf("unknown agent type: %s", agentType)
+		// Fall back to the agent plugin registry so plugin-defined agent types
+		// (e.g. "pi"/"pia") can serve as the controller, mirroring the
+		// spawn/add plugin dispatch (see the oc/opencode fallback above, ntm#193).
+		if name, cmd, ok := plugins.ResolveAgentCommand(agentType, filepath.Join(selectedConfigDir(), "agents")); ok {
+			agentTypeFull = name
+			agentCmdTemplate = cmd
+		} else {
+			return nil, fmt.Errorf("unknown agent type: %s", agentType)
+		}
 	}
 
 	dir, err := resolveExplicitProjectDirForSession(session)

--- a/internal/plugins/agent.go
+++ b/internal/plugins/agent.go
@@ -76,3 +76,22 @@ func LoadAgentPlugins(dir string) ([]AgentPlugin, error) {
 
 	return plugins, nil
 }
+
+// ResolveAgentCommand looks up an agent type in the plugin registry at
+// agentsDir (by plugin name or alias) and returns the plugin's canonical
+// Name, its Command template, and ok=true. Used by the controller and
+// restart paths so plugin-defined agent types (e.g. "pi"/"pia") are
+// first-class launch targets, mirroring the spawn/add plugin dispatch.
+// Returns ok=false when agentsDir is unreadable or no plugin matches.
+func ResolveAgentCommand(agentType, agentsDir string) (name, command string, ok bool) {
+	loaded, err := LoadAgentPlugins(agentsDir)
+	if err != nil || len(loaded) == 0 {
+		return "", "", false
+	}
+	for _, p := range loaded {
+		if p.Name == agentType || (p.Alias != "" && p.Alias == agentType) {
+			return p.Name, p.Command, true
+		}
+	}
+	return "", "", false
+}

--- a/internal/plugins/agent.go
+++ b/internal/plugins/agent.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 )
@@ -94,4 +95,95 @@ func ResolveAgentCommand(agentType, agentsDir string) (name, command string, ok 
 		}
 	}
 	return "", "", false
+}
+
+// pluginCmdIndexOnce guards one-time construction of pluginCmdIndex so the
+// pane-type detector does not re-read plugin TOML on every pane parse.
+var pluginCmdIndexOnce sync.Once
+
+// pluginCmdIndex maps a lowercased match token (plugin name, alias, or the
+// leading binary of its command) to the plugin's canonical name. Used by
+// AgentTypeForCommand for pane-type detection.
+var pluginCmdIndex map[string]string
+
+// defaultAgentsDir mirrors config.DefaultPath()'s directory resolution so the
+// low-level tmux pane-type detector can locate agent plugins WITHOUT importing
+// the config package (which would create an import cycle: config imports tmux).
+// Returns the "agents" directory next to the resolved config file.
+func defaultAgentsDir() string {
+	if env := os.Getenv("NTM_CONFIG"); env != "" {
+		return filepath.Join(filepath.Dir(env), "agents")
+	}
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			base = filepath.Join(home, ".config")
+		}
+	}
+	if base == "" {
+		base = os.TempDir()
+	}
+	return filepath.Join(base, "ntm", "agents")
+}
+
+// firstCommandToken returns the lowercased leading binary token of a command
+// template (e.g. "pi" for "pi --approve{{if .Model}} ...").
+func firstCommandToken(command string) string {
+	command = strings.TrimSpace(command)
+	for i, r := range command {
+		if r == ' ' || r == '\t' {
+			return strings.ToLower(command[:i])
+		}
+	}
+	return strings.ToLower(command)
+}
+
+// buildPluginCmdIndexFrom builds the command-match index for a given agents dir.
+// Separated from AgentTypeForCommand so it is unit-testable with a temp dir.
+func buildPluginCmdIndexFrom(dir string) map[string]string {
+	index := make(map[string]string)
+	loaded, _ := LoadAgentPlugins(dir)
+	for _, p := range loaded {
+		index[strings.ToLower(p.Name)] = p.Name
+		if p.Alias != "" {
+			index[strings.ToLower(p.Alias)] = p.Name
+		}
+		if tok := firstCommandToken(p.Command); tok != "" {
+			index[tok] = p.Name
+		}
+	}
+	return index
+}
+
+// matchCommandIndex reports the plugin whose token matches command using the
+// isAgent-style rules (bare equality, "tok " prefix, "/tok" suffix, "/tok " in
+// path). Mirrors detectAgentFromCommand's matching for built-in agents.
+func matchCommandIndex(index map[string]string, command string) (string, bool) {
+	cmd := strings.ToLower(strings.TrimSpace(command))
+	if cmd == "" {
+		return "", false
+	}
+	if name, ok := index[cmd]; ok {
+		return name, true
+	}
+	for tok, name := range index {
+		if strings.HasPrefix(cmd, tok+" ") ||
+			strings.HasSuffix(cmd, "/"+tok) ||
+			strings.Contains(cmd, "/"+tok+" ") {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// AgentTypeForCommand reports the plugin whose name, alias, or command binary
+// matches the given pane command, so panes running a plugin agent (e.g. `pi`)
+// classify as the plugin type instead of "user". The index is built once per
+// process from the default agents dir; if a plugin is added mid-process, restart
+// the process (e.g. the monitor) to pick it up.
+func AgentTypeForCommand(command string) (string, bool) {
+	pluginCmdIndexOnce.Do(func() {
+		pluginCmdIndex = buildPluginCmdIndexFrom(defaultAgentsDir())
+	})
+	return matchCommandIndex(pluginCmdIndex, command)
 }

--- a/internal/plugins/agent.go
+++ b/internal/plugins/agent.go
@@ -106,10 +106,14 @@ var pluginCmdIndexOnce sync.Once
 // AgentTypeForCommand for pane-type detection.
 var pluginCmdIndex map[string]string
 
-// defaultAgentsDir mirrors config.DefaultPath()'s directory resolution so the
-// low-level tmux pane-type detector can locate agent plugins WITHOUT importing
-// the config package (which would create an import cycle: config imports tmux).
-// Returns the "agents" directory next to the resolved config file.
+// defaultAgentsDir returns the agent-plugin directory next to the resolved
+// config file. This intentionally duplicates config.DefaultPath()'s env
+// resolution (NTM_CONFIG / XDG_CONFIG_HOME / home) instead of calling it:
+// plugins cannot import config because the dependency is cyclic TRANSITIVELY
+// (config -> watcher -> agentmail -> tmux -> plugins), even though config
+// does not import tmux directly. Mirroring the ~10 lines of pure env logic
+// here is the standard Go way to break that cycle. Keep in sync with
+// config.DefaultPath if its resolution changes.
 func defaultAgentsDir() string {
 	if env := os.Getenv("NTM_CONFIG"); env != "" {
 		return filepath.Join(filepath.Dir(env), "agents")
@@ -169,7 +173,8 @@ func matchCommandIndex(index map[string]string, command string) (string, bool) {
 	for tok, name := range index {
 		if strings.HasPrefix(cmd, tok+" ") ||
 			strings.HasSuffix(cmd, "/"+tok) ||
-			strings.Contains(cmd, "/"+tok+" ") {
+			strings.Contains(cmd, "/"+tok+" ") ||
+			strings.Contains(cmd, "/"+tok+"-") {
 			return name, true
 		}
 	}

--- a/internal/plugins/agent_test.go
+++ b/internal/plugins/agent_test.go
@@ -44,3 +44,56 @@ command = "pi --approve"
 		t.Errorf("ResolveAgentCommand on missing dir should be not-ok")
 	}
 }
+
+func TestBuildPluginCmdIndexFromAndMatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pi.toml"), []byte(`
+[agent]
+name = "pi"
+alias = "pia"
+command = "pi --approve"
+`), 0o644); err != nil {
+		t.Fatalf("write pi.toml: %v", err)
+	}
+
+	index := buildPluginCmdIndexFrom(dir)
+	// name + alias + command-token all map to the canonical name.
+	if index["pi"] != "pi" {
+		t.Errorf("index[pi] = %q, want pi", index["pi"])
+	}
+	if index["pia"] != "pi" {
+		t.Errorf("index[pia] = %q, want pi", index["pia"])
+	}
+
+	tests := []struct {
+		cmd  string
+		name string
+		ok   bool
+	}{
+		{"pi", "pi", true},
+		{"pi --approve", "pi", true}, // prefix match
+		{"pia", "pi", true},          // alias
+		{"/usr/bin/pi", "pi", true},  // path suffix
+		{"zsh", "", false},           // unrelated
+		{"pine", "", false},          // no false prefix match
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		name, ok := matchCommandIndex(index, tt.cmd)
+		if ok != tt.ok || name != tt.name {
+			t.Errorf("matchCommandIndex(%q) = (%q, %v), want (%q, %v)",
+				tt.cmd, name, ok, tt.name, tt.ok)
+		}
+	}
+
+	// Empty/missing dir yields an empty index that matches nothing.
+	empty := buildPluginCmdIndexFrom(filepath.Join(dir, "missing"))
+	if len(empty) != 0 {
+		t.Errorf("missing dir index = %v, want empty", empty)
+	}
+	if _, ok := matchCommandIndex(empty, "pi"); ok {
+		t.Errorf("empty index should not match")
+	}
+}

--- a/internal/plugins/agent_test.go
+++ b/internal/plugins/agent_test.go
@@ -1,0 +1,46 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAgentCommand(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Minimal pi-style plugin: name "pi", alias "pia".
+	if err := os.WriteFile(filepath.Join(dir, "pi.toml"), []byte(`
+[agent]
+name = "pi"
+alias = "pia"
+command = "pi --approve"
+`), 0o644); err != nil {
+		t.Fatalf("write pi.toml: %v", err)
+	}
+
+	tests := []struct {
+		in   string
+		name string
+		cmd  string
+		ok   bool
+	}{
+		{"pi", "pi", "pi --approve", true},
+		{"pia", "pi", "pi --approve", true}, // alias resolves to canonical name
+		{"foo", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tt := range tests {
+		name, cmd, ok := ResolveAgentCommand(tt.in, dir)
+		if ok != tt.ok || name != tt.name || cmd != tt.cmd {
+			t.Errorf("ResolveAgentCommand(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tt.in, name, cmd, ok, tt.name, tt.cmd, tt.ok)
+		}
+	}
+
+	// Non-existent dir: not ok, no panic.
+	if _, _, ok := ResolveAgentCommand("pi", filepath.Join(dir, "missing")); ok {
+		t.Errorf("ResolveAgentCommand on missing dir should be not-ok")
+	}
+}

--- a/internal/plugins/agent_test.go
+++ b/internal/plugins/agent_test.go
@@ -73,11 +73,15 @@ command = "pi --approve"
 		ok   bool
 	}{
 		{"pi", "pi", true},
-		{"pi --approve", "pi", true}, // prefix match
-		{"pia", "pi", true},          // alias
-		{"/usr/bin/pi", "pi", true},  // path suffix
-		{"zsh", "", false},           // unrelated
-		{"pine", "", false},          // no false prefix match
+		{"pi --approve", "pi", true},          // prefix match
+		{"pia", "pi", true},                   // alias
+		{"PI", "pi", true},                    // case-insensitive
+		{"/usr/bin/pi", "pi", true},           // path suffix
+		{"/usr/local/bin/pi-foo", "pi", true}, // "/pi-" contains (mirrors built-in isAgent)
+		{"./pi", "pi", true},                  // relative path suffix
+		{"zsh", "", false},                    // unrelated
+		{"pine", "", false},                   // no false prefix match
+		{"spi-foo", "", false},                // no false contains match
 		{"", "", false},
 	}
 	for _, tt := range tests {

--- a/internal/robot/restart_pane.go
+++ b/internal/robot/restart_pane.go
@@ -372,9 +372,18 @@ func paneShellPID(target string) int {
 // the timeout elapses first.
 func waitForPaneAgentReady(target string, shellPID int, agentType string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
+	// Plugin agents (registered via an agent plugin, e.g. `pi`) have no shared
+	// content-readiness signature isAgentReady can match; for them a live agent
+	// child process under the shell is the readiness signal — the launch
+	// command was just sent, so a running child means the agent CLI started.
+	// Computed once: reading plugin TOML on every poll would be wasteful.
+	_, _, isPlugin := plugins.ResolveAgentCommand(agentType, pluginsAgentDir())
 	for {
 		ready := false
 		if captured, err := tmux.CapturePaneOutput(target, 50); err == nil && isAgentReady(captured, agentType) {
+			ready = true
+		}
+		if !ready && isPlugin && shellPID > 0 && process.HasChildAlive(shellPID) {
 			ready = true
 		}
 		if ready && shellPID > 0 && !process.HasChildAlive(shellPID) {

--- a/internal/robot/restart_pane.go
+++ b/internal/robot/restart_pane.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Dicklesworthstone/ntm/internal/config"
+	"github.com/Dicklesworthstone/ntm/internal/plugins"
 	"github.com/Dicklesworthstone/ntm/internal/process"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
@@ -328,6 +330,13 @@ func restartAgentLaunchCommand(cfg *config.Config, agentType string) string {
 		}
 	}
 	if strings.TrimSpace(tmpl) == "" {
+		// Plugin agent types (e.g. "pi"): use the plugin's command template so a
+		// restarted pane keeps `pi --approve --model ...` rather than the bare alias.
+		if _, cmd, ok := plugins.ResolveAgentCommand(agentType, pluginsAgentDir()); ok {
+			tmpl = cmd
+		}
+	}
+	if strings.TrimSpace(tmpl) == "" {
 		return alias
 	}
 
@@ -424,10 +433,23 @@ func selectRestartPaneTargets(panes []tmux.Pane, paneFilterMap map[string]bool, 
 }
 
 func restartPaneAgentType(pane tmux.Pane) string {
-	if resolved := ResolveAgentType(string(pane.Type)); resolved != "" && resolved != "unknown" {
+	raw := strings.TrimSpace(string(pane.Type))
+	if resolved := ResolveAgentType(raw); resolved != "" && resolved != "unknown" {
 		return resolved
 	}
+	// Preserve plugin-defined agent types (e.g. "pi") so a restart keeps the
+	// plugin's launch command instead of collapsing to "unknown".
+	if _, _, ok := plugins.ResolveAgentCommand(raw, pluginsAgentDir()); ok {
+		return raw
+	}
 	return detectAgentType(pane.Title)
+}
+
+// pluginsAgentDir returns the agent-plugin directory used by the restart path.
+// GetRestartPane already loads its config via config.DefaultPath(), so the
+// plugin directory is the sibling "agents" dir next to the config file.
+func pluginsAgentDir() string {
+	return filepath.Join(filepath.Dir(config.DefaultPath()), "agents")
 }
 
 func sendRestartPrompts(targets []restartPromptTarget, prompt string, send func(target, keys string, agentType tmux.AgentType) error) []string {

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -15,6 +15,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/Dicklesworthstone/ntm/internal/agent"
+	"github.com/Dicklesworthstone/ntm/internal/plugins"
 	"github.com/Dicklesworthstone/ntm/internal/process"
 )
 
@@ -195,6 +196,14 @@ func detectAgentFromCommand(command string) AgentType {
 	// Ollama
 	if isAgent("ollama") {
 		return AgentOllama
+	}
+
+	// Plugin-defined agent types: classify a pane running a registered plugin
+	// agent (e.g. `pi`) as the plugin type instead of "user", so type-based
+	// features (restart selection, --type filter, dashboard) treat plugin
+	// agents as first-class. Mirrors the spawn/add plugin dispatch.
+	if name, ok := plugins.AgentTypeForCommand(command); ok {
+		return AgentType(name)
 	}
 
 	return AgentUser

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -148,6 +148,12 @@ func FormatTags(tags []string) string {
 	return "[" + strings.Join(tags, ",") + "]"
 }
 
+// resolvePluginAgentType resolves a pane command to a registered agent plugin
+// type. It is a package-level variable so tests can inject a fake resolver
+// instead of depending on the real (cached, default-dir) plugin index. In
+// production it is plugins.AgentTypeForCommand.
+var resolvePluginAgentType = plugins.AgentTypeForCommand
+
 // detectAgentFromCommand attempts to identify the agent type from the process command.
 // This is a fallback when the pane title doesn't match the NTM format (e.g., when
 // shell prompts or tmux hooks change the title dynamically).
@@ -202,7 +208,7 @@ func detectAgentFromCommand(command string) AgentType {
 	// agent (e.g. `pi`) as the plugin type instead of "user", so type-based
 	// features (restart selection, --type filter, dashboard) treat plugin
 	// agents as first-class. Mirrors the spawn/add plugin dispatch.
-	if name, ok := plugins.AgentTypeForCommand(command); ok {
+	if name, ok := resolvePluginAgentType(command); ok {
 		return AgentType(name)
 	}
 

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -1187,6 +1187,60 @@ func TestDetectAgentFromCommandEdgeCases(t *testing.T) {
 	}
 }
 
+// TestDetectAgentFromCommandPluginFallback verifies the plugin-agent fallback
+// wiring in detectAgentFromCommand: a pane running a registered plugin agent
+// (e.g. `pi`) classifies as the plugin type instead of "user", built-in agents
+// still take precedence, and unknown commands still fall back to "user".
+// Not t.Parallel: it overrides the package-level resolvePluginAgentType.
+// Sequential tests run before parallel ones, so the parallel
+// TestDetectAgentFromCommandEdgeCases always sees the original resolver.
+// Path/prefix/alias matching rules belong to the plugins package (covered
+// by TestBuildPluginCmdIndexFromAndMatch); here we inject a bare-token fake
+// to exercise only the tmux-layer dispatch.
+func TestDetectAgentFromCommandPluginFallback(t *testing.T) {
+	orig := resolvePluginAgentType
+	defer func() { resolvePluginAgentType = orig }()
+	resolvePluginAgentType = func(command string) (string, bool) {
+		cmd := strings.ToLower(strings.TrimSpace(command))
+		tok := cmd
+		if i := strings.IndexByte(cmd, ' '); i >= 0 {
+			tok = cmd[:i]
+		}
+		switch tok {
+		case "pi":
+			return "pi", true
+		case "myplugin":
+			return "myplugin", true
+		}
+		return "", false
+	}
+
+	tests := []struct {
+		name    string
+		command string
+		want    AgentType
+	}{
+		// Plugin agent: classified as the plugin type, not "user".
+		{"plugin bare", "pi", AgentType("pi")},
+		{"plugin with args", "pi --approve", AgentType("pi")},
+		{"other plugin", "myplugin run", AgentType("myplugin")},
+		// Built-ins still win over the plugin fallback (checked first).
+		{"claude beats plugin", "claude", AgentClaude},
+		{"codex beats plugin", "codex --model x", AgentCodex},
+		// Unknown, not a plugin: user fallback.
+		{"zsh", "zsh", AgentUser},
+		{"bash", "bash", AgentUser},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectAgentFromCommand(tt.command)
+			if got != tt.want {
+				t.Errorf("detectAgentFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
 // Regression test for acfs#267: when an agent runs under a wrapper
 // like Bun, tmux's pane_current_command reports the wrapper, not the
 // agent. We need to identify the wrapper as a candidate for deeper


### PR DESCRIPTION
## Summary

Makes **agent-plugin-defined types first-class** across the four paths where previously only built-in agents (claude, codex, gemini, …) were handled. A plugin registered via a TOML file in `~/.config/ntm/agents/<name>.toml` (e.g. a `pi` plugin — the motivating example) can now be used exactly like a built-in agent for:

1. **Controller** — `ntm controller <session> --agent-type=<plugin>` (was: `unknown agent type`).
2. **Restart relaunch command** — a restarted plugin pane keeps the plugin's command template instead of collapsing to a bare alias.
3. **Pane-type detection** — a pane running `<plugin>` now classifies as `type: <plugin>` instead of `"user"`, which unblocks type-based features (restart selection, dashboard).
4. **Restart readiness gate** — plugin agents are recognized as ready (they have no shared content-readiness signature, so a live agent child process is the readiness signal).

This **completes the plugin dispatch that `spawn`/`add` already had** — `controller`/`restart`/`detection` were the remaining gaps. Mirrors the existing `oc`/opencode fallback comment (ntm#193) and follows the precedent of the recently-merged hermes plugin PR (#203).

## Why

Before this change a plugin agent could be spawned/added but:
- could not serve as the controller (`unknown agent type: pi`),
- a pane running it was reported as `type: "user"`, so `--robot-restart-pane` **skipped it entirely** (`restarted: []`), and even when forced it relapsed to a bare shell (no relaunch command).

This makes plugin agents fully usable end-to-end.

## How (minimal, DRY)

Two shared helpers in `internal/plugins`, wired as **fallbacks behind the built-in checks** (built-in behavior is unchanged — only the previously-failing `default`/`unknown` cases change):

- `ResolveAgentCommand(name, dir)` — name/alias → plugin command template (used by controller + restart relaunch).
- `AgentTypeForCommand(command)` — pane command → plugin type, via a `sync.Once`-cached index (used by pane-type detection). Testable core: `buildPluginCmdIndexFrom(dir)` + `matchCommandIndex(index, command)`.

The tmux-layer dispatch (`detectAgentFromCommand`) uses a package-level `var resolvePluginAgentType` (defaults to `plugins.AgentTypeForCommand`) so it is unit-testable without depending on the real cached/default-dir index.

`plugins/defaultAgentsDir()` intentionally duplicates `config.DefaultPath()`'s env resolution (`NTM_CONFIG` / `XDG_CONFIG_HOME` / `$HOME`) because `plugins` cannot import `config` — the cycle is **transitive** (`config → watcher → agentmail → tmux → plugins`), not direct. The ~10 lines of pure env logic are the standard Go cycle-break; documented inline.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean.
- Tests green **with `-race`**: new `TestResolveAgentCommand`, `TestBuildPluginCmdIndexFromAndMatch` (bare/alias/prefix/`/pi-`/`./pi`/case-insensitive + no-false-match on `pine`/`spi-foo`), `TestDetectAgentFromCommandPluginFallback` (injectable resolver; built-ins still win; unknown → user). Existing `detectAgentFromCommand`, controller, restart, and `selectRestartPaneTargets` tests unchanged.
- **Live (5/5 cycles)** on a real `pi` plugin: `ntm spawn --pi=1` → `ntm controller --agent-type=pi` → `ntm --robot-restart-pane` each yielded `success: true`, `failed: []`, `agent_relaunched: true`, and `type: "pi"` persisted across the restart.

## Backwards compatibility

Additive. Built-in agents are unchanged (checked first). Unknown `--agent-type` still errors. No behavior change for users without plugins.

## Known limitations (intentionally out of scope)

- `--type=<plugin>` filter is **not precise** (it is ignored for plugin types; use `--panes=N` for precise targeting). Fixing it cleanly means touching the hot-path `translateAgentTypeForStatus`, tracked as a follow-up.
- `AgentTypeForCommand` index is `sync.Once`-cached for the process lifetime; a plugin added **mid-run** to a long-lived process (e.g. the monitor) won't be picked up until that process restarts. Documented inline; no current caller needs hot-reload.
- `defaultAgentsDir()` honors `NTM_CONFIG` env but not the `--config` CLI flag (the tmux pane-detection layer has no `--config` context — same boundary as the existing built-in detection).
- `agent_counts` has no per-plugin field (cosmetic only; the `type` field is correct).
- Plugin agents run under a wrapper (`bun`/`node`) are not detected (only direct binaries); the existing `detectAgentFromProcessTree` path is built-in-only.

## Note

`TestNormalizeProjectScopedSessionName_RejectsAmbiguousConfiguredProjectPrefix` fails on clean `04877bc` (pre-existing, unrelated to this change — verified by stashing the branch and testing the clean base).
