### PR TITLE
fix: add --robot-send-pane flag for atomic single-pane robot sends

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1362,6 +1362,13 @@ Shell Integration:
 			if robotPanes != "" {
 				paneFilter = strings.Split(robotPanes, ",")
 			}
+			if robotSendPane != "" {
+				if robotPanes != "" {
+					fmt.Fprintf(os.Stderr, "Error: --pane and --panes are mutually exclusive\n")
+					os.Exit(1)
+				}
+				paneFilter = []string{robotSendPane}
+			}
 			// Parse exclude list
 			var excludeList []string
 			if robotSendExclude != "" {
@@ -2808,6 +2815,7 @@ var (
 	robotSendType    string // filter by agent type (e.g., "claude")
 	robotSendExclude string // comma-separated panes to exclude
 	robotSendDelay   int    // delay between sends in ms
+	robotSendPane    string // single pane index for atomic single-pane send
 
 	// Robot-assign flags for work distribution
 	robotAssign         string // session name for work assignment
@@ -3386,6 +3394,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&robotSendAll, "all", false, "Include user pane (default: agents only). Optional with --robot-send, --robot-interrupt, --robot-restart-pane, and --robot-support-bundle")
 	rootCmd.Flags().StringVar(&robotSendType, "type", "", "Filter by agent type: claude|cc, codex|cod, antigravity|agy, gemini|gmi (legacy), cursor, windsurf, aider. Works with --robot-history, --robot-wait, --robot-route, --robot-send, --robot-ack, --robot-interrupt, --robot-errors, and --robot-restart-pane")
 	rootCmd.Flags().StringVar(&robotSendExclude, "exclude", "", "Exclude pane indices (comma-separated). Optional with --robot-send and --robot-route. Example: --exclude=0,3")
+	rootCmd.Flags().StringVar(&robotSendPane, "robot-send-pane", "", "Send to a single pane index. Convenience alias for --panes=<n> for robots. Optional with --robot-send. Example: --robot-send-pane=2")
 	rootCmd.Flags().IntVar(&robotSendDelay, "delay-ms", 0, "Delay between sends (ms). Optional with --robot-send. Example: --delay-ms=500 for 0.5s between panes")
 
 	// Robot-assign flags for work distribution


### PR DESCRIPTION
### Summary

Issue #217 asks for robots to target a single agent pane atomically when using `ntm --robot-send`, instead of only the human-oriented `--panes` filter. This adds a `--robot-send-pane` flag that sets the single pane index and feeds the same `SendOptions.Panes` filter the rest of the send path already honors.

### Changes

- Added `robotSendPane` var and registered `--robot-send-pane` on the root command (the bare `--pane` name is already taken by `--robot-history` on the root command and by subcommands, so a scoped name avoids a flag collision).
- In the `robot-send` path, when `--robot-send-pane` is set it populates the pane filter with that single index and errors if combined with `--panes`.
- Builds and the existing `go build ./cmd/ntm` pass; full `go test -short` requires the `tmux` binary which isn't present in this environment.

### Testing
- [x] `go build ./cmd/ntm` passes
- [ ] `go test -short ./...` (blocked: tmux not installed in sandbox)
