### PR TITLE
fix(agentmail): stabilize remote project health

### DIFF
--- a/internal/agentmail/client.go
+++ b/internal/agentmail/client.go
@@ -33,7 +33,8 @@ const (
 	HealthCheckPath = "health"
 
 	// AvailabilityCacheTTL is how long to cache IsAvailable() results.
-	AvailabilityCacheTTL = 30 * time.Second
+	AvailabilityCacheTTL       = 30 * time.Second
+	defaultAvailabilityRetries = 0
 )
 
 // Client provides methods to interact with the Agent Mail API.
@@ -56,9 +57,11 @@ type Client struct {
 	registrationTokens   map[string]string
 
 	// Availability cache (30s TTL)
-	healthCheckMu      sync.Mutex
-	availableCache     atomic.Bool
-	availableCacheTime atomic.Int64 // Unix timestamp in seconds
+	healthCheckMu       sync.Mutex
+	availableCache      atomic.Bool
+	availableCacheTime  atomic.Int64 // Unix timestamp in seconds
+	availabilityTimeout time.Duration
+	availabilityRetries int
 }
 
 // tokenKey builds the cache key for the registration-token map. Using
@@ -153,6 +156,19 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithAvailabilityPolicy configures the bounded health probe used by
+// CheckAvailability. Defaults remain one 2-second attempt for local servers.
+func WithAvailabilityPolicy(timeout time.Duration, retries int) Option {
+	return func(c *Client) {
+		if timeout > 0 {
+			c.availabilityTimeout = timeout
+		}
+		if retries >= 0 {
+			c.availabilityRetries = retries
+		}
+	}
+}
+
 // NewClient creates a new Agent Mail client with the given options.
 func NewClient(opts ...Option) *Client {
 	c := &Client{
@@ -166,6 +182,8 @@ func NewClient(opts ...Option) *Client {
 				IdleConnTimeout:     90 * time.Second,
 			},
 		},
+		availabilityTimeout: 2 * time.Second,
+		availabilityRetries: defaultAvailabilityRetries,
 	}
 
 	// Check environment variables
@@ -192,10 +210,19 @@ func NewClient(opts ...Option) *Client {
 // IsAvailable checks if the Agent Mail server is reachable.
 // Results are cached for 30 seconds to avoid repeated health checks.
 func (c *Client) IsAvailable() bool {
+	return c.CheckAvailability() == nil
+}
+
+// CheckAvailability checks server health and returns the terminal error. Only
+// timeouts and server-unavailable errors are retried.
+func (c *Client) CheckAvailability() error {
 	// Optimistic check (lock-free)
 	cacheTime := c.availableCacheTime.Load()
 	if cacheTime > 0 && time.Now().Unix()-cacheTime < int64(AvailabilityCacheTTL.Seconds()) {
-		return c.availableCache.Load()
+		if c.availableCache.Load() {
+			return nil
+		}
+		return ErrServerUnavailable
 	}
 
 	// Acquire lock to prevent thundering herd
@@ -205,14 +232,27 @@ func (c *Client) IsAvailable() bool {
 	// Double-check after acquiring lock
 	cacheTime = c.availableCacheTime.Load()
 	if cacheTime > 0 && time.Now().Unix()-cacheTime < int64(AvailabilityCacheTTL.Seconds()) {
-		return c.availableCache.Load()
+		if c.availableCache.Load() {
+			return nil
+		}
+		return ErrServerUnavailable
 	}
 
-	// Perform health check
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	_, err := c.HealthCheck(ctx)
+	var err error
+	backoff := 100 * time.Millisecond
+	for attempt := 0; attempt <= c.availabilityRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), c.availabilityTimeout)
+		_, err = c.HealthCheck(ctx)
+		cancel()
+		if err == nil {
+			break
+		}
+		if attempt == c.availabilityRetries || (!IsTimeout(err) && !IsServerUnavailable(err)) {
+			break
+		}
+		time.Sleep(backoff)
+		backoff *= 2
+	}
 	available := err == nil
 
 	// Cache the result
@@ -224,7 +264,7 @@ func (c *Client) IsAvailable() bool {
 		c.availableCacheTime.Store(time.Now().Unix() - int64(AvailabilityCacheTTL.Seconds()) + 2)
 	}
 
-	return available
+	return err
 }
 
 // InvalidateCache clears the availability cache, forcing the next IsAvailable() call

--- a/internal/agentmail/client_test.go
+++ b/internal/agentmail/client_test.go
@@ -114,6 +114,52 @@ func TestIsAvailable(t *testing.T) {
 	}
 }
 
+func TestCheckAvailabilityRetriesDelayedSuccess(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			time.Sleep(40 * time.Millisecond)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"status":"ok"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithAvailabilityPolicy(20*time.Millisecond, 1),
+	)
+	if err := client.CheckAvailability(); err != nil {
+		t.Fatalf("CheckAvailability() error = %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("health calls = %d, want 2", calls)
+	}
+}
+
+func TestCheckAvailabilityDoesNotRetryTerminalFailure(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithAvailabilityPolicy(100*time.Millisecond, 3),
+	)
+	err := client.CheckAvailability()
+	if !IsUnauthorized(err) {
+		t.Fatalf("CheckAvailability() error = %v, want unauthorized", err)
+	}
+	if calls != 1 {
+		t.Fatalf("health calls = %d, want 1", calls)
+	}
+}
+
 func TestCallTool(t *testing.T) {
 	// Mock JSON-RPC server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -678,7 +678,7 @@ Shell Integration:
 				projectKey = resolvedProjectKey
 			}
 
-			if err := robot.PrintMail(sessionName, projectKey); err != nil {
+			if err := robot.PrintMail(sessionName, projectKey, loadSelectedConfigOrDefault()); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1318,6 +1318,14 @@ type AgentMailConfig struct {
 	Token        string `toml:"token"`         // Bearer token
 	AutoRegister bool   `toml:"auto_register"` // Auto-register sessions as agents
 	ProgramName  string `toml:"program_name"`  // Program identifier for registration
+	// ProjectKeys maps local project roots (including stable symlink paths) to
+	// host-independent Agent Mail project keys. Sources are canonicalized before
+	// matching so a configured symlink survives os.Getwd/git realpath resolution.
+	ProjectKeys map[string]string `toml:"project_keys"`
+	// AvailabilityTimeout and AvailabilityRetries tune only the lightweight
+	// health gate. Local defaults preserve the historical single 2s probe.
+	AvailabilityTimeout time.Duration `toml:"availability_timeout"`
+	AvailabilityRetries int           `toml:"availability_retries"`
 	// SupervisorEnabled controls whether ntm spawns and manages the
 	// `am serve-http` daemon under its supervisor. Default false keeps
 	// Agent Mail ownership external: ntm may use the configured MCP URL,
@@ -1334,6 +1342,21 @@ func (a AgentMailConfig) SupervisorEnabledOrDefault() bool {
 		return false
 	}
 	return *a.SupervisorEnabled
+}
+
+func ValidateAgentMailConfig(cfg *AgentMailConfig) error {
+	if cfg.AvailabilityTimeout <= 0 || cfg.AvailabilityTimeout > 30*time.Second {
+		return fmt.Errorf("availability_timeout must be greater than 0 and at most 30s, got %s", cfg.AvailabilityTimeout)
+	}
+	if cfg.AvailabilityRetries < 0 || cfg.AvailabilityRetries > 5 {
+		return fmt.Errorf("availability_retries must be between 0 and 5, got %d", cfg.AvailabilityRetries)
+	}
+	for source, target := range cfg.ProjectKeys {
+		if _, err := ResolveAgentMailProjectKey(source, map[string]string{source: target}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // IntegrationsConfig holds external tool integration settings.
@@ -2528,11 +2551,13 @@ func Default() *Config {
 		},
 		Robot: DefaultRobotConfig(),
 		AgentMail: AgentMailConfig{
-			Enabled:      true,
-			URL:          DefaultAgentMailURL,
-			Token:        "",
-			AutoRegister: true,
-			ProgramName:  "ntm",
+			Enabled:             true,
+			URL:                 DefaultAgentMailURL,
+			Token:               "",
+			AutoRegister:        true,
+			ProgramName:         "ntm",
+			AvailabilityTimeout: 2 * time.Second,
+			AvailabilityRetries: 0,
 		},
 		Integrations:    DefaultIntegrationsConfig(),
 		Models:          DefaultModels(),
@@ -3176,6 +3201,8 @@ func Print(cfg *Config, w io.Writer) error {
 	}
 	fmt.Fprintf(w, "auto_register = %t\n", cfg.AgentMail.AutoRegister)
 	fmt.Fprintf(w, "program_name = %q\n", cfg.AgentMail.ProgramName)
+	fmt.Fprintf(w, "availability_timeout = %q\n", cfg.AgentMail.AvailabilityTimeout.String())
+	fmt.Fprintf(w, "availability_retries = %d\n", cfg.AgentMail.AvailabilityRetries)
 	fmt.Fprintln(w, "# If true, ntm starts/stops `am serve-http` for session monitors.")
 	fmt.Fprintln(w, "# Default false prevents ntm from hijacking a user-owned Agent Mail server.")
 	fmt.Fprintf(w, "supervisor_enabled = %t\n", cfg.AgentMail.SupervisorEnabledOrDefault())
@@ -5748,6 +5775,9 @@ func Validate(cfg *Config) []error {
 	}
 
 	var errs []error
+	if err := ValidateAgentMailConfig(&cfg.AgentMail); err != nil {
+		errs = append(errs, fmt.Errorf("agent_mail: %w", err))
+	}
 
 	// Validate context rotation
 	if err := ValidateContextRotationConfig(&cfg.ContextRotation); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -529,6 +529,19 @@ func TestAgentMailDefaults(t *testing.T) {
 	}
 }
 
+func TestValidateAgentMailConfigBounds(t *testing.T) {
+	cfg := Default().AgentMail
+	cfg.AvailabilityTimeout = 31 * time.Second
+	if err := ValidateAgentMailConfig(&cfg); err == nil {
+		t.Fatal("expected timeout validation error")
+	}
+	cfg = Default().AgentMail
+	cfg.AvailabilityRetries = 6
+	if err := ValidateAgentMailConfig(&cfg); err == nil {
+		t.Fatal("expected retry validation error")
+	}
+}
+
 func TestAgentMailEnvOverrides(t *testing.T) {
 	origURL := os.Getenv("AGENT_MAIL_URL")
 	origToken := os.Getenv("AGENT_MAIL_TOKEN")

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -79,6 +79,12 @@ func MergeConfig(global *Config, project *ProjectConfig, projectDir string) *Con
 	if project.Integrations.AgentMail != nil {
 		global.AgentMail.Enabled = *project.Integrations.AgentMail
 	}
+	if project.Integrations.AgentMailProjectKey != "" {
+		if global.AgentMail.ProjectKeys == nil {
+			global.AgentMail.ProjectKeys = make(map[string]string)
+		}
+		global.AgentMail.ProjectKeys[projectDir] = project.Integrations.AgentMailProjectKey
+	}
 	if project.Integrations.CASS != nil {
 		global.CASS.Enabled = *project.Integrations.CASS
 	}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -120,6 +120,50 @@ func LoadProjectConfig(path string) (*ProjectConfig, error) {
 	return &cfg, nil
 }
 
+// ResolveAgentMailProjectKey applies an explicit local-root mapping to a
+// discovered project directory. Invalid mappings fail closed: callers must not
+// silently fall back to a path-derived mailbox when an operator attempted to
+// configure a canonical key.
+func ResolveAgentMailProjectKey(projectDir string, mappings map[string]string) (string, error) {
+	projectDir = strings.TrimSpace(projectDir)
+	if projectDir == "" || len(mappings) == 0 {
+		return projectDir, nil
+	}
+
+	canonicalizeSource := func(path string) (string, error) {
+		path = strings.TrimSpace(path)
+		if !filepath.IsAbs(path) {
+			return "", fmt.Errorf("Agent Mail project mapping source must be absolute: %q", path)
+		}
+		path = filepath.Clean(path)
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			path = filepath.Clean(resolved)
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("resolve Agent Mail project mapping source %q: %w", path, err)
+		}
+		return path, nil
+	}
+
+	discovered, err := canonicalizeSource(projectDir)
+	if err != nil {
+		return "", err
+	}
+	for source, target := range mappings {
+		canonicalSource, err := canonicalizeSource(source)
+		if err != nil {
+			return "", err
+		}
+		target = strings.TrimSpace(target)
+		if !filepath.IsAbs(target) || filepath.Clean(target) != target {
+			return "", fmt.Errorf("Agent Mail project mapping target must be a clean absolute key: %q", target)
+		}
+		if canonicalSource == discovered {
+			return target, nil
+		}
+	}
+	return projectDir, nil
+}
+
 func undecodedProjectConfigFields(md toml.MetaData) []string {
 	keys := md.Undecoded()
 	if len(keys) == 0 {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -623,6 +623,34 @@ func TestProjectIntegrations(t *testing.T) {
 	}
 }
 
+func TestResolveAgentMailProjectKeyMatchesSymlinkRealpath(t *testing.T) {
+	realProject := t.TempDir()
+	stableParent := t.TempDir()
+	stablePath := filepath.Join(stableParent, "current")
+	if err := os.Symlink(realProject, stablePath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveAgentMailProjectKey(realProject, map[string]string{
+		stablePath: "/mereka-lms-72359cad09",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAgentMailProjectKey() error = %v", err)
+	}
+	if got != "/mereka-lms-72359cad09" {
+		t.Fatalf("ResolveAgentMailProjectKey() = %q", got)
+	}
+}
+
+func TestResolveAgentMailProjectKeyRejectsInvalidMapping(t *testing.T) {
+	_, err := ResolveAgentMailProjectKey(t.TempDir(), map[string]string{
+		"relative/source": "relative-target",
+	})
+	if err == nil {
+		t.Fatal("expected invalid mapping error")
+	}
+}
+
 // TestProjectInitResult verifies ProjectInitResult structure
 func TestProjectInitResult(t *testing.T) {
 	t.Parallel()

--- a/internal/robot/robot.go
+++ b/internal/robot/robot.go
@@ -2839,6 +2839,7 @@ func appendConflicts(output *StatusOutput) {
 type MailOptions struct {
 	Session    string
 	ProjectKey string
+	Config     *config.Config
 }
 
 // MailOutput represents the output for --robot-mail.
@@ -2865,7 +2866,6 @@ func GetMail(opts MailOptions) (*MailOutput, error) {
 	if cwdProject := util.ResolveProjectDir(""); cwdProject != "" {
 		projectKey = util.BestProjectDir(projectKey, cwdProject)
 	}
-
 	sessionAgent, err := func() (*agentmail.SessionAgentInfo, error) {
 		if opts.Session == "" {
 			return nil, nil
@@ -2885,11 +2885,22 @@ func GetMail(opts MailOptions) (*MailOutput, error) {
 		}
 		projectKey = resolvedProjectKey
 	}
+	if opts.Config != nil {
+		mapped, mapErr := config.ResolveAgentMailProjectKey(projectKey, opts.Config.AgentMail.ProjectKeys)
+		if mapErr != nil {
+			return &MailOutput{RobotResponse: NewRobotResponse(true), GeneratedAt: time.Now().UTC(), Session: opts.Session, ProjectKey: projectKey, Available: false, Warnings: []string{mapErr.Error()}}, nil
+		}
+		projectKey = mapped
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
 	defer cancel()
 
-	client := agentmail.NewClient(agentmail.WithProjectKey(projectKey))
+	clientOptions := []agentmail.Option{agentmail.WithProjectKey(projectKey)}
+	if opts.Config != nil {
+		clientOptions = append(clientOptions, agentmail.WithAvailabilityPolicy(opts.Config.AgentMail.AvailabilityTimeout, opts.Config.AgentMail.AvailabilityRetries))
+	}
+	client := agentmail.NewClient(clientOptions...)
 	serverURL := client.BaseURL()
 
 	output := &MailOutput{
@@ -2902,7 +2913,8 @@ func GetMail(opts MailOptions) (*MailOutput, error) {
 		SessionAgent:  sessionAgent,
 	}
 
-	if !client.IsAvailable() {
+	if err := client.CheckAvailability(); err != nil {
+		output.Warnings = append(output.Warnings, fmt.Sprintf("health_check failed: %v", err))
 		return output, nil
 	}
 	output.Available = true
@@ -3021,10 +3033,11 @@ func GetMail(opts MailOptions) (*MailOutput, error) {
 
 // PrintMail outputs detailed Agent Mail state for AI orchestrators.
 // This is a thin wrapper around GetMail() for CLI output.
-func PrintMail(sessionName, projectKey string) error {
+func PrintMail(sessionName, projectKey string, cfg *config.Config) error {
 	output, err := GetMail(MailOptions{
 		Session:    sessionName,
 		ProjectKey: projectKey,
+		Config:     cfg,
 	})
 	if err != nil {
 		return err
@@ -4235,10 +4248,17 @@ func splitLines(s string) []string {
 // fetchAgentMailData retrieves Agent Mail state for the project.
 // Returns the summary, raw agent list, and per-agent stats map.
 func fetchAgentMailData(projectKey string) (*SnapshotAgentMail, []agentmail.Agent, map[string]SnapshotAgentMailStats) {
-	client := agentmail.NewClient(agentmail.WithProjectKey(projectKey))
+	return fetchAgentMailDataWithPolicy(projectKey, 2*time.Second, 0)
+}
 
-	if !client.IsAvailable() {
-		return nil, nil, nil
+func fetchAgentMailDataWithPolicy(projectKey string, availabilityTimeout time.Duration, availabilityRetries int) (*SnapshotAgentMail, []agentmail.Agent, map[string]SnapshotAgentMailStats) {
+	client := agentmail.NewClient(
+		agentmail.WithProjectKey(projectKey),
+		agentmail.WithAvailabilityPolicy(availabilityTimeout, availabilityRetries),
+	)
+
+	if err := client.CheckAvailability(); err != nil {
+		return &SnapshotAgentMail{Available: false, Reason: fmt.Sprintf("health_check failed: %v", err), Project: projectKey}, nil, nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -4615,12 +4635,18 @@ func GetSnapshotWithOptions(cfg *config.Config, opts PaginationOptions) (*Snapsh
 		} else {
 			projectKey = cwd
 		}
-		// Build initial mail summary without pane mapping
-		if summary, agents, stats := fetchAgentMailData(projectKey); summary != nil {
-			output.AgentMail = summary
-			output.MailUnread = summary.TotalUnread
-			mailAgents = agents
-			mailStats = stats
+		mappedProjectKey, mapErr := config.ResolveAgentMailProjectKey(projectKey, cfg.AgentMail.ProjectKeys)
+		if mapErr != nil {
+			output.AgentMail = &SnapshotAgentMail{Available: false, Reason: mapErr.Error(), Project: projectKey}
+		} else {
+			projectKey = mappedProjectKey
+			// Build initial mail summary without pane mapping.
+			if summary, agents, stats := fetchAgentMailDataWithPolicy(projectKey, cfg.AgentMail.AvailabilityTimeout, cfg.AgentMail.AvailabilityRetries); summary != nil {
+				output.AgentMail = summary
+				output.MailUnread = summary.TotalUnread
+				mailAgents = agents
+				mailStats = stats
+			}
 		}
 	}
 
@@ -4790,6 +4816,7 @@ func GetSnapshotWithOptions(cfg *config.Config, opts PaginationOptions) (*Snapsh
 		}
 		if coordinationRows, err := store.ListFreshRuntimeCoordination(""); err == nil {
 			output.Coordination = snapshotCoordinationFromRuntime(coordinationRows, handoffRow)
+			promoteLiveAgentMailCoordination(output)
 		}
 		if quotaRows, err := store.ListFreshRuntimeQuota(""); err == nil {
 			output.Quota = snapshotQuotaFromRuntime(quotaRows)
@@ -4829,6 +4856,7 @@ func buildProjectionBackedSnapshot(
 	}
 	if coordinationRows, err := store.ListFreshRuntimeCoordination(""); err == nil {
 		output.Coordination = snapshotCoordinationFromRuntime(coordinationRows, handoffRow)
+		promoteLiveAgentMailCoordination(output)
 	}
 	if quotaRows, err := store.ListFreshRuntimeQuota(""); err == nil {
 		output.Quota = snapshotQuotaFromRuntime(quotaRows)
@@ -5084,6 +5112,23 @@ func snapshotCoordinationFromRuntime(rows []state.RuntimeCoordination, handoff *
 		summary.HandoffStatus = strings.TrimSpace(handoff.Status)
 	}
 	return summary
+}
+
+// promoteLiveAgentMailCoordination prevents an empty cached projection from
+// hiding a successful live Agent Mail read. Runtime rows still provide richer
+// per-agent counts when present.
+func promoteLiveAgentMailCoordination(output *SnapshotOutput) {
+	if output == nil || output.AgentMail == nil || !output.AgentMail.Available {
+		return
+	}
+	if output.Coordination == nil {
+		output.Coordination = &SnapshotCoordinationSummary{}
+	}
+	if output.Coordination.Available {
+		return
+	}
+	output.Coordination.Available = true
+	output.Coordination.MailUnread = output.AgentMail.TotalUnread
 }
 
 func snapshotWorkFromRuntime(rows []state.RuntimeWork, limit int) *adapters.WorkSection {

--- a/internal/robot/robot_test.go
+++ b/internal/robot/robot_test.go
@@ -145,6 +145,51 @@ func TestGetMail_PrefersUsableWorkspaceProjectKey(t *testing.T) {
 	}
 }
 
+func TestGetMailAppliesCanonicalProjectMappingAcrossSymlink(t *testing.T) {
+	origDir, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	realProject := tempDirCanonical(t)
+	if err := os.MkdirAll(filepath.Join(realProject, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stablePath := filepath.Join(t.TempDir(), "current")
+	if err := os.Symlink(realProject, stablePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(realProject); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Default()
+	cfg.AgentMail.ProjectKeys = map[string]string{stablePath: "/mereka-lms-72359cad09"}
+	t.Setenv("AGENT_MAIL_URL", "http://127.0.0.1:1/mcp/")
+	output, err := GetMail(MailOptions{Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.ProjectKey != "/mereka-lms-72359cad09" {
+		t.Fatalf("ProjectKey = %q", output.ProjectKey)
+	}
+	if output.Available {
+		t.Fatal("expected unavailable test server")
+	}
+	if len(output.Warnings) == 0 || !strings.Contains(output.Warnings[0], "health_check failed") {
+		t.Fatalf("Warnings = %v, want terminal health warning", output.Warnings)
+	}
+}
+
+func TestPromoteLiveAgentMailCoordination(t *testing.T) {
+	output := &SnapshotOutput{
+		AgentMail:    &SnapshotAgentMail{Available: true, TotalUnread: 7},
+		Coordination: &SnapshotCoordinationSummary{Available: false},
+	}
+	promoteLiveAgentMailCoordination(output)
+	if !output.Coordination.Available || output.Coordination.MailUnread != 7 {
+		t.Fatalf("Coordination = %+v", output.Coordination)
+	}
+}
+
 func TestGetMail_DropsStaleSessionAgentFromDifferentProject(t *testing.T) {
 	origDir, _ := os.Getwd()
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

- retry bounded transient Agent Mail availability failures while preserving the local one-attempt default
- surface terminal health errors in robot mail/snapshot output
- map stable local project roots to canonical Agent Mail keys across symlink realpath resolution
- promote a successful live mail read over an empty cached coordination projection

## Configuration

```toml
[agent_mail]
availability_timeout = "5s"
availability_retries = 2
project_keys = { "/stable/local/project" = "/canonical-agent-mail-key" }
```

Invalid relative/unclean mappings fail closed. The defaults remain a single two-second availability attempt.

## Proof

Focused tests:

```text
go test ./internal/agentmail ./internal/config
ok github.com/Dicklesworthstone/ntm/internal/agentmail
ok github.com/Dicklesworthstone/ntm/internal/config

go test ./internal/robot ./internal/cli
PASS

go build ./cmd/ntm
PASS
```

Exact controller command from a stable symlink before the patch:

```json
{"agent_mail":{"available":true,"project":"/tmp/kali-lms-team-20260708T0928Z/worktrees/current-main-20260708T215449Z"},"coordination":{"available":false},"sources":{"all_fresh":true,"sources":{"work_coordination":{"available":true,"fresh":true}}}}
```

Same command with the isolated canary and persistent config above:

```json
{"agent_mail":{"available":true,"project":"/mereka-lms-72359cad09","total_unread":25},"coordination":{"available":true,"mail_unread":25},"sources":{"all_fresh":true,"sources":{"work_coordination":{"available":true,"fresh":true}}}}
```

Three sequential canary `--robot-mail` calls returned the canonical key with `available=true`. Reservation enumeration can still warn independently when that best-effort resource read times out.

The repository-wide short suite also encounters pre-existing environment/fixture failures: ignored `internal/cli/outputs` parser captures are absent, and inherited `AGENT_MAIL_URL` changes tests that assume the localhost default.

## Non-claims

- the shared installed NTM binary was not replaced
- no running panes or sessions were restarted
- no mailbox data was migrated or deleted
