### PR TITLE
test: isolate tmux-backed suites from host server

### DIFF
--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -32,6 +33,11 @@ func newTmuxIntegrationTestConfig(projectsBase string) *config.Config {
 }
 
 func TestMain(m *testing.M) {
+	cleanup, err := testutil.SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		os.Exit(1)
+	}
 	// Clean up any orphan test sessions from previous runs before starting.
 	// This catches sessions left behind when tests are interrupted (Ctrl+C, timeout, etc.)
 	testutil.KillAllTestSessionsSilent()
@@ -40,6 +46,10 @@ func TestMain(m *testing.M) {
 
 	// Clean up after all tests complete
 	testutil.KillAllTestSessionsSilent()
+	if err := cleanup(); err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		code = 1
+	}
 
 	os.Exit(code)
 }

--- a/internal/robot/testmain_test.go
+++ b/internal/robot/testmain_test.go
@@ -1,0 +1,24 @@
+package robot
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/ntm/tests/testutil"
+)
+
+func TestMain(m *testing.M) {
+	cleanup, err := testutil.SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	if err := cleanup(); err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		code = 1
+	}
+	os.Exit(code)
+}

--- a/internal/status/testmain_test.go
+++ b/internal/status/testmain_test.go
@@ -1,0 +1,24 @@
+package status
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/ntm/tests/testutil"
+)
+
+func TestMain(m *testing.M) {
+	cleanup, err := testutil.SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	if err := cleanup(); err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		code = 1
+	}
+	os.Exit(code)
+}

--- a/scripts/test-tmux-isolation.sh
+++ b/scripts/test-tmux-isolation.sh
@@ -2,22 +2,38 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-host_before=$(tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
+host_before=$(env -u TMUX -u TMUX_TMPDIR \
+  tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
 sentinel_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-sentinel-tmux.XXXXXX")
 test_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-test-tmux.XXXXXX")
+poison_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-poison-tmux.XXXXXX")
 sentinel_socket="ntm-sentinel-$$"
 sentinel_session="ntm-sentinel-$$"
+poison_socket="ntm-poison-$$"
+poison_session="ntm-poison-$$"
 
 cleanup() {
   env -u TMUX TMUX_TMPDIR="$sentinel_root" \
     tmux -L "$sentinel_socket" kill-session -t "$sentinel_session" \
     2>/dev/null || true
-  rm -rf "$sentinel_root" "$test_root"
+  env -u TMUX TMUX_TMPDIR="$poison_root" \
+    tmux -L "$poison_socket" kill-session -t "$poison_session" \
+    2>/dev/null || true
+  rm -rf "$sentinel_root" "$test_root" "$poison_root"
 }
 trap cleanup EXIT
 
 env -u TMUX TMUX_TMPDIR="$sentinel_root" \
   tmux -L "$sentinel_socket" new-session -d -s "$sentinel_session"
+env -u TMUX TMUX_TMPDIR="$poison_root" \
+  tmux -L "$poison_socket" new-session -d -s "$poison_session"
+
+# Poison the inherited routing environment. Guarded tests and host inventory
+# checks must ignore this server without killing its sentinel session.
+export TMUX_TMPDIR="$poison_root"
+export TMUX=$(env -u TMUX TMUX_TMPDIR="$poison_root" \
+  tmux -L "$poison_socket" display-message -p -t "$poison_session" \
+    '#{socket_path},#{pid},0')
 
 env -u TMUX TMUX_TMPDIR="$test_root" \
   go test ./internal/cli ./internal/robot ./internal/status \
@@ -25,12 +41,15 @@ env -u TMUX TMUX_TMPDIR="$test_root" \
 
 env -u TMUX TMUX_TMPDIR="$sentinel_root" \
   tmux -L "$sentinel_socket" has-session -t "$sentinel_session"
+env -u TMUX TMUX_TMPDIR="$poison_root" \
+  tmux -L "$poison_socket" has-session -t "$poison_session"
 
-host_after=$(tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
+host_after=$(env -u TMUX -u TMUX_TMPDIR \
+  tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
 if [[ "$host_before" != "$host_after" ]]; then
   printf 'host default tmux inventory changed\nbefore:\n%s\nafter:\n%s\n' \
     "$host_before" "$host_after" >&2
   exit 1
 fi
 
-printf 'PASS: private sentinel survived; host default tmux inventory unchanged\n'
+printf 'PASS: private and poisoned sentinels survived; host default tmux inventory unchanged\n'

--- a/scripts/test-tmux-isolation.sh
+++ b/scripts/test-tmux-isolation.sh
@@ -2,13 +2,14 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+inventory_format='#{session_name}\t#{session_id}\t#{session_created}\t#{session_windows}\t#{session_attached}'
 host_before=$(env -u TMUX -u TMUX_TMPDIR \
-  tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
+  tmux list-sessions -F "$inventory_format" 2>&1 | sort || true)
 sentinel_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-sentinel-tmux.XXXXXX")
-test_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-test-tmux.XXXXXX")
 poison_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-poison-tmux.XXXXXX")
 sentinel_socket="ntm-sentinel-$$"
 sentinel_session="ntm-sentinel-$$"
+sentinel_anchor="ntm-sentinel-anchor-$$"
 poison_socket="ntm-poison-$$"
 poison_session="ntm-poison-$$"
 
@@ -16,15 +17,34 @@ cleanup() {
   env -u TMUX TMUX_TMPDIR="$sentinel_root" \
     tmux -L "$sentinel_socket" kill-session -t "$sentinel_session" \
     2>/dev/null || true
+  env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+    tmux -L "$sentinel_socket" kill-session -t "$sentinel_anchor" \
+    2>/dev/null || true
   env -u TMUX TMUX_TMPDIR="$poison_root" \
     tmux -L "$poison_socket" kill-session -t "$poison_session" \
     2>/dev/null || true
-  rm -rf "$sentinel_root" "$test_root" "$poison_root"
+  rm -rf "$sentinel_root" "$poison_root"
 }
 trap cleanup EXIT
 
 env -u TMUX TMUX_TMPDIR="$sentinel_root" \
   tmux -L "$sentinel_socket" new-session -d -s "$sentinel_session"
+env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+  tmux -L "$sentinel_socket" new-session -d -s "$sentinel_anchor"
+
+# Prove the identity-bearing oracle detects a same-name replacement.
+sentinel_before=$(env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+  tmux -L "$sentinel_socket" list-sessions -F "$inventory_format")
+env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+  tmux -L "$sentinel_socket" kill-session -t "$sentinel_session"
+env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+  tmux -L "$sentinel_socket" new-session -d -s "$sentinel_session"
+sentinel_after=$(env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+  tmux -L "$sentinel_socket" list-sessions -F "$inventory_format")
+if [[ "$sentinel_before" == "$sentinel_after" ]]; then
+  printf 'identity inventory missed same-name replacement\n' >&2
+  exit 1
+fi
 env -u TMUX TMUX_TMPDIR="$poison_root" \
   tmux -L "$poison_socket" new-session -d -s "$poison_session"
 
@@ -35,9 +55,10 @@ export TMUX=$(env -u TMUX TMUX_TMPDIR="$poison_root" \
   tmux -L "$poison_socket" display-message -p -t "$poison_session" \
     '#{socket_path},#{pid},0')
 
-env -u TMUX TMUX_TMPDIR="$test_root" \
-  go test ./internal/cli ./internal/robot ./internal/status \
-    ./tests/testutil -run 'TestPrintSnapshotWithSession|^$' -count=1
+# Preserve the poisoned inherited routing here. Each guarded TestMain must
+# replace it with its own process-owned private root before any tmux mutation.
+go test ./internal/cli ./internal/robot ./internal/status \
+  ./tests/testutil -run 'TestPrintSnapshotWithSession|TestIsolation' -count=1
 
 env -u TMUX TMUX_TMPDIR="$sentinel_root" \
   tmux -L "$sentinel_socket" has-session -t "$sentinel_session"
@@ -45,7 +66,7 @@ env -u TMUX TMUX_TMPDIR="$poison_root" \
   tmux -L "$poison_socket" has-session -t "$poison_session"
 
 host_after=$(env -u TMUX -u TMUX_TMPDIR \
-  tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
+  tmux list-sessions -F "$inventory_format" 2>&1 | sort || true)
 if [[ "$host_before" != "$host_after" ]]; then
   printf 'host default tmux inventory changed\nbefore:\n%s\nafter:\n%s\n' \
     "$host_before" "$host_after" >&2

--- a/scripts/test-tmux-isolation.sh
+++ b/scripts/test-tmux-isolation.sh
@@ -57,8 +57,15 @@ export TMUX=$(env -u TMUX TMUX_TMPDIR="$poison_root" \
 
 # Preserve the poisoned inherited routing here. Each guarded TestMain must
 # replace it with its own process-owned private root before any tmux mutation.
-go test ./internal/cli ./internal/robot ./internal/status \
-  ./tests/testutil -run 'TestPrintSnapshotWithSession|TestIsolation' -count=1
+test_output=$(go test -v ./internal/cli ./internal/robot ./internal/status \
+  ./tests/testutil \
+  -run 'TestPrintSnapshotWithSession|TestIsolation|TestSharedHelpersIgnoreRouteSwap' \
+  -count=1)
+printf '%s\n' "$test_output"
+if ! grep -q -- '--- PASS: TestSharedHelpersIgnoreRouteSwap' <<<"$test_output"; then
+  printf 'canonical harness did not run TestSharedHelpersIgnoreRouteSwap\n' >&2
+  exit 1
+fi
 
 env -u TMUX TMUX_TMPDIR="$sentinel_root" \
   tmux -L "$sentinel_socket" has-session -t "$sentinel_session"

--- a/scripts/test-tmux-isolation.sh
+++ b/scripts/test-tmux-isolation.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+host_before=$(tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
+sentinel_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-sentinel-tmux.XXXXXX")
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/ntm-test-tmux.XXXXXX")
+sentinel_socket="ntm-sentinel-$$"
+sentinel_session="ntm-sentinel-$$"
+
+cleanup() {
+  env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+    tmux -L "$sentinel_socket" kill-session -t "$sentinel_session" \
+    2>/dev/null || true
+  rm -rf "$sentinel_root" "$test_root"
+}
+trap cleanup EXIT
+
+env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+  tmux -L "$sentinel_socket" new-session -d -s "$sentinel_session"
+
+env -u TMUX TMUX_TMPDIR="$test_root" \
+  go test ./internal/cli ./internal/robot ./internal/status \
+    ./tests/testutil -run 'TestPrintSnapshotWithSession|^$' -count=1
+
+env -u TMUX TMUX_TMPDIR="$sentinel_root" \
+  tmux -L "$sentinel_socket" has-session -t "$sentinel_session"
+
+host_after=$(tmux list-sessions -F '#{session_name}' 2>&1 | sort || true)
+if [[ "$host_before" != "$host_after" ]]; then
+  printf 'host default tmux inventory changed\nbefore:\n%s\nafter:\n%s\n' \
+    "$host_before" "$host_after" >&2
+  exit 1
+fi
+
+printf 'PASS: private sentinel survived; host default tmux inventory unchanged\n'

--- a/tests/e2e/robot_mode_test.go
+++ b/tests/e2e/robot_mode_test.go
@@ -2199,6 +2199,11 @@ func TestMain(m *testing.M) {
 		// ntm binary not on PATH; skip suite gracefully
 		return
 	}
+	cleanup, err := testutil.SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Clean up any orphan test sessions from previous runs
 	testutil.KillAllTestSessionsSilent()
@@ -2207,6 +2212,10 @@ func TestMain(m *testing.M) {
 
 	// Clean up after all tests complete
 	testutil.KillAllTestSessionsSilent()
+	if err := cleanup(); err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		code = 1
+	}
 
 	os.Exit(code)
 }

--- a/tests/integration/status_test.go
+++ b/tests/integration/status_test.go
@@ -21,6 +21,11 @@ func TestMain(m *testing.M) {
 		// tmux is required for these integration tests
 		return
 	}
+	cleanup, err := testutil.SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Clean up any orphan test sessions from previous runs
 	testutil.KillAllTestSessionsSilent()
@@ -29,6 +34,10 @@ func TestMain(m *testing.M) {
 
 	// Clean up after all tests complete
 	testutil.KillAllTestSessionsSilent()
+	if err := cleanup(); err != nil {
+		fmt.Fprintf(os.Stderr, "tmux test isolation failed: %v\n", err)
+		code = 1
+	}
 
 	os.Exit(code)
 }

--- a/tests/testutil/assertions.go
+++ b/tests/testutil/assertions.go
@@ -15,7 +15,11 @@ func AssertSessionExists(t *testing.T, logger *TestLogger, name string) {
 	t.Helper()
 	logger.Log("VERIFY: Session %s exists", name)
 
-	err := exec.Command(tmux.BinaryPath(), "has-session", "-t", name).Run()
+	cmd := exec.Command(tmux.BinaryPath(), "has-session", "-t", name)
+	if err := bindIsolatedTmuxCommand(tmux.BinaryPath(), cmd); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.Run()
 	if err != nil {
 		logger.Log("FAIL: Session %s does not exist", name)
 		t.Errorf("session %s should exist, but it does not", name)
@@ -29,7 +33,11 @@ func AssertSessionNotExists(t *testing.T, logger *TestLogger, name string) {
 	t.Helper()
 	logger.Log("VERIFY: Session %s does not exist", name)
 
-	err := exec.Command(tmux.BinaryPath(), "has-session", "-t", name).Run()
+	cmd := exec.Command(tmux.BinaryPath(), "has-session", "-t", name)
+	if err := bindIsolatedTmuxCommand(tmux.BinaryPath(), cmd); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.Run()
 	if err == nil {
 		logger.Log("FAIL: Session %s exists but should not", name)
 		t.Errorf("session %s should not exist, but it does", name)

--- a/tests/testutil/logger.go
+++ b/tests/testutil/logger.go
@@ -94,6 +94,10 @@ func (l *TestLogger) Exec(cmd string, args ...string) ([]byte, error) {
 	l.Log("EXEC: %s %s", cmd, strings.Join(args, " "))
 
 	c := exec.Command(cmd, args...)
+	if err := bindIsolatedTmuxCommand(cmd, c); err != nil {
+		l.Log("EXIT: refused: %v", err)
+		return nil, err
+	}
 	out, err := c.CombinedOutput()
 
 	// Log output (truncate if very long)
@@ -119,6 +123,10 @@ func (l *TestLogger) ExecContext(timeout time.Duration, cmd string, args ...stri
 	l.Log("EXEC (timeout=%s): %s %s", timeout, cmd, strings.Join(args, " "))
 
 	c := exec.Command(cmd, args...)
+	if err := bindIsolatedTmuxCommand(cmd, c); err != nil {
+		l.Log("EXIT: refused: %v", err)
+		return nil, err
+	}
 
 	// Create a channel for the result
 	type result struct {

--- a/tests/testutil/session.go
+++ b/tests/testutil/session.go
@@ -128,6 +128,10 @@ func CreateTestSessionSimple(t *testing.T, logger *TestLogger, agents map[string
 
 // killSession forcefully kills an ntm session.
 func killSession(logger *TestLogger, name string) {
+	if !isolatedTmuxReady() {
+		logger.Log("Refusing tmux session cleanup without the process-owned isolated server")
+		return
+	}
 	// Try ntm kill first
 	out, err := exec.Command("ntm", "kill", "-f", name).CombinedOutput()
 	if err != nil {

--- a/tests/testutil/session.go
+++ b/tests/testutil/session.go
@@ -36,7 +36,8 @@ type SessionConfig struct {
 // directory within it, named after the session.
 func CreateTestSession(t *testing.T, logger *TestLogger, config SessionConfig) string {
 	t.Helper()
-	if !isolatedTmuxReady() {
+	commandEnv, ok := isolatedTmuxCommandEnv()
+	if !ok {
 		t.Fatal("tmux-backed test refused: call SetupIsolatedTmuxTestProcess from TestMain")
 	}
 
@@ -78,7 +79,7 @@ func CreateTestSession(t *testing.T, logger *TestLogger, config SessionConfig) s
 	// Create command with NTM_PROJECTS_BASE properly set
 	// We need to filter out any existing NTM_PROJECTS_BASE and add our own
 	cmd := exec.Command("ntm", args...)
-	env := filterEnv(os.Environ(), "NTM_PROJECTS_BASE")
+	env := filterEnv(commandEnv, "NTM_PROJECTS_BASE")
 	env = append(env, "NTM_PROJECTS_BASE="+projectsBase)
 	cmd.Env = env
 
@@ -128,16 +129,21 @@ func CreateTestSessionSimple(t *testing.T, logger *TestLogger, agents map[string
 
 // killSession forcefully kills an ntm session.
 func killSession(logger *TestLogger, name string) {
-	if !isolatedTmuxReady() {
+	commandEnv, ok := isolatedTmuxCommandEnv()
+	if !ok {
 		logger.Log("Refusing tmux session cleanup without the process-owned isolated server")
 		return
 	}
 	// Try ntm kill first
-	out, err := exec.Command("ntm", "kill", "-f", name).CombinedOutput()
+	cmd := exec.Command("ntm", "kill", "-f", name)
+	cmd.Env = commandEnv
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		logger.Log("ntm kill failed: %v, output: %s", err, string(out))
 		// Fallback to tmux kill-session
-		exec.Command(tmux.BinaryPath(), "kill-session", "-t", name).Run()
+		fallback := exec.Command(tmux.BinaryPath(), "kill-session", "-t", name)
+		fallback.Env = commandEnv
+		_ = fallback.Run()
 	} else {
 		logger.Log("Session %s killed successfully", name)
 	}
@@ -147,15 +153,18 @@ func killSession(logger *TestLogger, name string) {
 // Matches both naming conventions: "ntm_test_*" (underscore) and "ntm-test-*" (hyphen).
 // Useful for cleanup in TestMain or after failed tests.
 func KillAllTestSessions(logger *TestLogger) {
-	if !isolatedTmuxReady() {
-		logger.Log("Refusing tmux cleanup without an isolated test server")
-		return
-	}
 	logger.LogSection("Killing All Test Sessions")
 
 	withGlobalTmuxTestLock(func() {
+		commandEnv, ok := isolatedTmuxCommandEnv()
+		if !ok {
+			logger.Log("Refusing tmux cleanup without an isolated test server")
+			return
+		}
 		// List all tmux sessions
-		out, err := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}").Output()
+		listCmd := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}")
+		listCmd.Env = commandEnv
+		out, err := listCmd.Output()
 		if err != nil {
 			logger.Log("Failed to list tmux sessions: %v", err)
 			return
@@ -167,7 +176,9 @@ func KillAllTestSessions(logger *TestLogger) {
 			// Match both naming conventions used in tests
 			if strings.HasPrefix(session, "ntm_test_") || strings.HasPrefix(session, "ntm-test-") {
 				logger.Log("Killing orphan test session: %s", session)
-				exec.Command(tmux.BinaryPath(), "kill-session", "-t", session).Run()
+				killCmd := exec.Command(tmux.BinaryPath(), "kill-session", "-t", session)
+				killCmd.Env = commandEnv
+				_ = killCmd.Run()
 				killed++
 			}
 		}
@@ -181,12 +192,15 @@ func KillAllTestSessions(logger *TestLogger) {
 // best-effort and intentionally avoids blocking on the global tmux test lock so
 // concurrent package startup can continue under multi-agent test runs.
 func KillAllTestSessionsSilent() int {
-	if !isolatedTmuxReady() {
-		return 0
-	}
 	killed := 0
 	if !tryWithGlobalTmuxTestLock(func() {
-		out, err := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}").Output()
+		commandEnv, ok := isolatedTmuxCommandEnv()
+		if !ok {
+			return
+		}
+		listCmd := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}")
+		listCmd.Env = commandEnv
+		out, err := listCmd.Output()
 		if err != nil {
 			return
 		}
@@ -194,7 +208,9 @@ func KillAllTestSessionsSilent() int {
 		sessions := strings.Split(strings.TrimSpace(string(out)), "\n")
 		for _, session := range sessions {
 			if strings.HasPrefix(session, "ntm_test_") || strings.HasPrefix(session, "ntm-test-") {
-				exec.Command(tmux.BinaryPath(), "kill-session", "-t", session).Run()
+				killCmd := exec.Command(tmux.BinaryPath(), "kill-session", "-t", session)
+				killCmd.Env = commandEnv
+				_ = killCmd.Run()
 				killed++
 			}
 		}
@@ -206,13 +222,25 @@ func KillAllTestSessionsSilent() int {
 
 // SessionExists checks if a tmux session exists.
 func SessionExists(name string) bool {
-	err := exec.Command(tmux.BinaryPath(), "has-session", "-t", name).Run()
+	commandEnv, ok := isolatedTmuxCommandEnv()
+	if !ok {
+		return false
+	}
+	cmd := exec.Command(tmux.BinaryPath(), "has-session", "-t", name)
+	cmd.Env = commandEnv
+	err := cmd.Run()
 	return err == nil
 }
 
 // GetSessionPaneCount returns the number of panes in a session.
 func GetSessionPaneCount(name string) (int, error) {
-	out, err := exec.Command(tmux.BinaryPath(), "list-panes", "-t", name, "-F", "#{pane_id}").Output()
+	commandEnv, ok := isolatedTmuxCommandEnv()
+	if !ok {
+		return 0, fmt.Errorf("tmux test isolation is not configured")
+	}
+	cmd := exec.Command(tmux.BinaryPath(), "list-panes", "-t", name, "-F", "#{pane_id}")
+	cmd.Env = commandEnv
+	out, err := cmd.Output()
 	if err != nil {
 		return 0, err
 	}
@@ -237,10 +265,16 @@ func WaitForSession(name string, timeout time.Duration) error {
 
 // CapturePane captures the visible content of a pane.
 func CapturePane(name string, paneIndex int) (string, error) {
+	commandEnv, ok := isolatedTmuxCommandEnv()
+	if !ok {
+		return "", fmt.Errorf("tmux test isolation is not configured")
+	}
 	target := fmt.Sprintf("%s:%d", name, paneIndex)
 	ctx, cancel := context.WithTimeout(context.Background(), tmux.DefaultCommandTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, tmux.BinaryPath(), "capture-pane", "-t", target, "-p").Output()
+	cmd := exec.CommandContext(ctx, tmux.BinaryPath(), "capture-pane", "-t", target, "-p")
+	cmd.Env = commandEnv
+	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to capture pane %s: %w", target, err)
 	}

--- a/tests/testutil/session.go
+++ b/tests/testutil/session.go
@@ -36,6 +36,9 @@ type SessionConfig struct {
 // directory within it, named after the session.
 func CreateTestSession(t *testing.T, logger *TestLogger, config SessionConfig) string {
 	t.Helper()
+	if !isolatedTmuxReady() {
+		t.Fatal("tmux-backed test refused: call SetupIsolatedTmuxTestProcess from TestMain")
+	}
 
 	// Generate unique session/project name
 	name := fmt.Sprintf("ntm_test_%d", time.Now().UnixNano())
@@ -140,6 +143,10 @@ func killSession(logger *TestLogger, name string) {
 // Matches both naming conventions: "ntm_test_*" (underscore) and "ntm-test-*" (hyphen).
 // Useful for cleanup in TestMain or after failed tests.
 func KillAllTestSessions(logger *TestLogger) {
+	if !isolatedTmuxReady() {
+		logger.Log("Refusing tmux cleanup without an isolated test server")
+		return
+	}
 	logger.LogSection("Killing All Test Sessions")
 
 	withGlobalTmuxTestLock(func() {
@@ -170,6 +177,9 @@ func KillAllTestSessions(logger *TestLogger) {
 // best-effort and intentionally avoids blocking on the global tmux test lock so
 // concurrent package startup can continue under multi-agent test runs.
 func KillAllTestSessionsSilent() int {
+	if !isolatedTmuxReady() {
+		return 0
+	}
 	killed := 0
 	if !tryWithGlobalTmuxTestLock(func() {
 		out, err := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}").Output()

--- a/tests/testutil/skip.go
+++ b/tests/testutil/skip.go
@@ -96,12 +96,20 @@ func RequireTmuxServer(t *testing.T) {
 	if !ok {
 		t.Fatal("tmux-backed test refused: call SetupIsolatedTmuxTestProcess from TestMain")
 	}
-	cmd := exec.Command(tmux.BinaryPath(), "list-sessions")
-	cmd.Env = env
-	if err := cmd.Run(); err != nil {
+	if _, err := tmuxSessionInventory(env); err != nil {
 		// Start a temporary server
 		t.Log("No tmux server running, will create one for test")
 	}
+}
+
+// tmuxSessionInventory makes RequireTmuxServer's route observable and lets
+// hostile tests inject an explicit environment. Keeping command construction
+// here ensures the production probe and its regression oracle exercise the
+// same environment binding.
+func tmuxSessionInventory(env []string) ([]byte, error) {
+	cmd := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}")
+	cmd.Env = env
+	return cmd.CombinedOutput()
 }
 
 // RequireNotCI skips the test when running in CI environments.

--- a/tests/testutil/skip.go
+++ b/tests/testutil/skip.go
@@ -92,7 +92,13 @@ func RequireNTMBinary(t *testing.T) {
 func RequireTmuxServer(t *testing.T) {
 	t.Helper()
 	RequireTmux(t)
-	if err := exec.Command(tmux.BinaryPath(), "list-sessions").Run(); err != nil {
+	env, ok := isolatedTmuxCommandEnv()
+	if !ok {
+		t.Fatal("tmux-backed test refused: call SetupIsolatedTmuxTestProcess from TestMain")
+	}
+	cmd := exec.Command(tmux.BinaryPath(), "list-sessions")
+	cmd.Env = env
+	if err := cmd.Run(); err != nil {
 		// Start a temporary server
 		t.Log("No tmux server running, will create one for test")
 	}

--- a/tests/testutil/tmux_isolation.go
+++ b/tests/testutil/tmux_isolation.go
@@ -7,11 +7,17 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
 
 const isolatedTmuxMarker = "NTM_TEST_TMUX_ISOLATED"
+
+var isolationState struct {
+	sync.RWMutex
+	root string
+}
 
 // SetupIsolatedTmuxTestProcess moves the current test process and all of its
 // children onto a fresh private tmux server. The returned cleanup proves that
@@ -39,9 +45,11 @@ func SetupIsolatedTmuxTestProcess() (func() error, error) {
 		_ = os.RemoveAll(root)
 		return nil, fmt.Errorf("mark isolated tmux test process: %w", err)
 	}
+	setIsolationRoot(root)
 
 	cleanup := func() error {
 		after := defaultTmuxInventory(hostEnv)
+		setIsolationRoot("")
 		_ = os.RemoveAll(root)
 		if !bytes.Equal(before, after) {
 			return fmt.Errorf("host default tmux inventory changed\nbefore:\n%s\nafter:\n%s", before, after)
@@ -52,12 +60,29 @@ func SetupIsolatedTmuxTestProcess() (func() error, error) {
 }
 
 func isolatedTmuxReady() bool {
+	root := getIsolationRoot()
+	if root == "" {
+		return false
+	}
 	return os.Getenv(isolatedTmuxMarker) == "1" &&
-		os.Getenv("TMUX") == "" && os.Getenv("TMUX_TMPDIR") != ""
+		os.Getenv("TMUX") == "" && os.Getenv("TMUX_TMPDIR") == root
+}
+
+func setIsolationRoot(root string) {
+	isolationState.Lock()
+	defer isolationState.Unlock()
+	isolationState.root = root
+}
+
+func getIsolationRoot() string {
+	isolationState.RLock()
+	defer isolationState.RUnlock()
+	return isolationState.root
 }
 
 func defaultTmuxInventory(env []string) []byte {
-	cmd := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}")
+	cmd := exec.Command(tmux.BinaryPath(), "list-sessions", "-F",
+		"#{session_name}\\t#{session_id}\\t#{session_created}\\t#{session_windows}\\t#{session_attached}")
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	lines := strings.Fields(string(out))

--- a/tests/testutil/tmux_isolation.go
+++ b/tests/testutil/tmux_isolation.go
@@ -17,7 +17,10 @@ const isolatedTmuxMarker = "NTM_TEST_TMUX_ISOLATED"
 // children onto a fresh private tmux server. The returned cleanup proves that
 // the host's default-server inventory did not change.
 func SetupIsolatedTmuxTestProcess() (func() error, error) {
-	hostEnv := append([]string(nil), os.Environ()...)
+	// Host inventory must always mean the actual default server, even when the
+	// test runner was launched from inside tmux or inherited another socket.
+	hostEnv := filterEnv(os.Environ(), "TMUX")
+	hostEnv = filterEnv(hostEnv, "TMUX_TMPDIR")
 	before := defaultTmuxInventory(hostEnv)
 
 	root, err := os.MkdirTemp("", "ntm-test-tmux-")

--- a/tests/testutil/tmux_isolation.go
+++ b/tests/testutil/tmux_isolation.go
@@ -68,6 +68,21 @@ func isolatedTmuxReady() bool {
 		os.Getenv("TMUX") == "" && os.Getenv("TMUX_TMPDIR") == root
 }
 
+// isolatedTmuxCommandEnv returns an execution environment bound to the
+// process-owned private root. Callers must attach it directly to every tmux or
+// ntm command instead of relying on mutable process-global routing variables.
+func isolatedTmuxCommandEnv() ([]string, bool) {
+	root := getIsolationRoot()
+	if root == "" {
+		return nil, false
+	}
+	env := filterEnv(os.Environ(), "TMUX")
+	env = filterEnv(env, "TMUX_TMPDIR")
+	env = filterEnv(env, isolatedTmuxMarker)
+	env = append(env, "TMUX_TMPDIR="+root, isolatedTmuxMarker+"=1")
+	return env, true
+}
+
 func setIsolationRoot(root string) {
 	isolationState.Lock()
 	defer isolationState.Unlock()

--- a/tests/testutil/tmux_isolation.go
+++ b/tests/testutil/tmux_isolation.go
@@ -1,0 +1,63 @@
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/Dicklesworthstone/ntm/internal/tmux"
+)
+
+const isolatedTmuxMarker = "NTM_TEST_TMUX_ISOLATED"
+
+// SetupIsolatedTmuxTestProcess moves the current test process and all of its
+// children onto a fresh private tmux server. The returned cleanup proves that
+// the host's default-server inventory did not change.
+func SetupIsolatedTmuxTestProcess() (func() error, error) {
+	hostEnv := append([]string(nil), os.Environ()...)
+	before := defaultTmuxInventory(hostEnv)
+
+	root, err := os.MkdirTemp("", "ntm-test-tmux-")
+	if err != nil {
+		return nil, fmt.Errorf("create private TMUX_TMPDIR: %w", err)
+	}
+	if err := os.Unsetenv("TMUX"); err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("unset inherited TMUX: %w", err)
+	}
+	if err := os.Setenv("TMUX_TMPDIR", root); err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("set private TMUX_TMPDIR: %w", err)
+	}
+	if err := os.Setenv(isolatedTmuxMarker, "1"); err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("mark isolated tmux test process: %w", err)
+	}
+
+	cleanup := func() error {
+		after := defaultTmuxInventory(hostEnv)
+		_ = os.RemoveAll(root)
+		if !bytes.Equal(before, after) {
+			return fmt.Errorf("host default tmux inventory changed\nbefore:\n%s\nafter:\n%s", before, after)
+		}
+		return nil
+	}
+	return cleanup, nil
+}
+
+func isolatedTmuxReady() bool {
+	return os.Getenv(isolatedTmuxMarker) == "1" &&
+		os.Getenv("TMUX") == "" && os.Getenv("TMUX_TMPDIR") != ""
+}
+
+func defaultTmuxInventory(env []string) []byte {
+	cmd := exec.Command(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	lines := strings.Fields(string(out))
+	sort.Strings(lines)
+	return []byte(fmt.Sprintf("exit=%v\n%s\n", err, strings.Join(lines, "\n")))
+}

--- a/tests/testutil/tmux_isolation.go
+++ b/tests/testutil/tmux_isolation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -81,6 +82,22 @@ func isolatedTmuxCommandEnv() ([]string, bool) {
 	env = filterEnv(env, isolatedTmuxMarker)
 	env = append(env, "TMUX_TMPDIR="+root, isolatedTmuxMarker+"=1")
 	return env, true
+}
+
+// bindIsolatedTmuxCommand binds shared test helpers to the process-owned tmux
+// root whenever they launch ntm or tmux. Other subprocesses keep their normal
+// environment.
+func bindIsolatedTmuxCommand(name string, cmd *exec.Cmd) error {
+	base := filepath.Base(name)
+	if base != "ntm" && base != filepath.Base(tmux.BinaryPath()) {
+		return nil
+	}
+	env, ok := isolatedTmuxCommandEnv()
+	if !ok {
+		return fmt.Errorf("tmux-backed command %q refused: isolated test process is not configured", name)
+	}
+	cmd.Env = env
+	return nil
 }
 
 func setIsolationRoot(root string) {

--- a/tests/testutil/tmux_isolation_test.go
+++ b/tests/testutil/tmux_isolation_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
@@ -80,6 +81,89 @@ func TestIsolationCommandsIgnoreRouteSwap(t *testing.T) {
 	alternateOwned.Env = alternateEnv
 	if err := alternateOwned.Run(); err == nil {
 		t.Fatal("owned session creation was redirected to alternate root")
+	}
+}
+
+func TestSharedHelpersIgnoreRouteSwap(t *testing.T) {
+	cleanup, err := SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	ownedEnv, ok := isolatedTmuxCommandEnv()
+	if !ok {
+		t.Fatal("missing process-owned command environment")
+	}
+	ownedSession := "ntm_test_shared_owned"
+	ownedCreate := exec.Command(tmux.BinaryPath(), "new-session", "-d", "-s", ownedSession)
+	ownedCreate.Env = ownedEnv
+	if out, err := ownedCreate.CombinedOutput(); err != nil {
+		t.Fatalf("create owned sentinel: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command(tmux.BinaryPath(), "kill-session", "-t", ownedSession)
+		cmd.Env = ownedEnv
+		_ = cmd.Run()
+	})
+
+	alternateRoot := filepath.Join(t.TempDir(), "alternate-shared")
+	if err := os.MkdirAll(alternateRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alternateEnv := filterEnv(os.Environ(), "TMUX")
+	alternateEnv = filterEnv(alternateEnv, "TMUX_TMPDIR")
+	alternateEnv = append(alternateEnv, "TMUX_TMPDIR="+alternateRoot)
+	alternateSession := "ntm_test_shared_alternate"
+	alternateCreate := exec.Command(tmux.BinaryPath(), "new-session", "-d", "-s", alternateSession)
+	alternateCreate.Env = alternateEnv
+	if out, err := alternateCreate.CombinedOutput(); err != nil {
+		t.Fatalf("create alternate sentinel: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command(tmux.BinaryPath(), "kill-session", "-t", alternateSession)
+		cmd.Env = alternateEnv
+		_ = cmd.Run()
+	})
+
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_TMPDIR", alternateRoot)
+	logger := NewTestLoggerStdout(t)
+	createdByLogger := "ntm_test_shared_logger_create"
+	if _, err := logger.Exec(tmux.BinaryPath(), "new-session", "-d", "-s", createdByLogger); err != nil {
+		t.Fatalf("logger create did not use owned root: %v", err)
+	}
+	if _, err := logger.Exec(tmux.BinaryPath(), "list-sessions", "-F", "#{session_name}"); err != nil {
+		t.Fatalf("logger list did not use owned root: %v", err)
+	}
+	if _, err := logger.Exec(tmux.BinaryPath(), "capture-pane", "-p", "-t", createdByLogger); err != nil {
+		t.Fatalf("logger capture did not use owned root: %v", err)
+	}
+	if _, err := logger.Exec(tmux.BinaryPath(), "has-session", "-t", ownedSession); err != nil {
+		t.Fatalf("logger did not use owned root: %v", err)
+	}
+	if _, err := logger.ExecContext(time.Second, tmux.BinaryPath(), "has-session", "-t", alternateSession); err == nil {
+		t.Fatal("logger ExecContext reached alternate-root sentinel")
+	}
+	AssertSessionExists(t, logger, ownedSession)
+	AssertSessionNotExists(t, logger, alternateSession)
+	if _, err := logger.Exec(tmux.BinaryPath(), "kill-session", "-t", createdByLogger); err != nil {
+		t.Fatalf("logger exact kill did not use owned root: %v", err)
+	}
+	AssertSessionNotExists(t, logger, createdByLogger)
+	// This name exists only on the alternate root. Both the ntm attempt and its
+	// tmux fallback must stay on the process-owned root.
+	killSession(logger, alternateSession)
+	KillAllTestSessions(logger)
+
+	alternateHas := exec.Command(tmux.BinaryPath(), "has-session", "-t", alternateSession)
+	alternateHas.Env = alternateEnv
+	if err := alternateHas.Run(); err != nil {
+		t.Fatal("alternate-root sentinel did not survive shared helper probes")
 	}
 }
 

--- a/tests/testutil/tmux_isolation_test.go
+++ b/tests/testutil/tmux_isolation_test.go
@@ -2,7 +2,11 @@ package testutil
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+
+	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
 
 func TestIsolationAuthorizationCannotBeForged(t *testing.T) {
@@ -11,6 +15,71 @@ func TestIsolationAuthorizationCannotBeForged(t *testing.T) {
 	t.Setenv("TMUX", "")
 	if isolatedTmuxReady() {
 		t.Fatal("environment-only isolation authorization must be rejected")
+	}
+}
+
+func TestIsolationCommandsIgnoreRouteSwap(t *testing.T) {
+	cleanup, err := SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	ownedEnv, ok := isolatedTmuxCommandEnv()
+	if !ok {
+		t.Fatal("missing process-owned command environment")
+	}
+	ownedSession := "ntm_test_owned_create"
+
+	alternateRoot := filepath.Join(t.TempDir(), "alternate")
+	if err := os.MkdirAll(alternateRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alternateEnv := filterEnv(os.Environ(), "TMUX")
+	alternateEnv = filterEnv(alternateEnv, "TMUX_TMPDIR")
+	alternateEnv = append(alternateEnv, "TMUX_TMPDIR="+alternateRoot)
+	alternateSession := "ntm_test_route_swap"
+	alternateCreate := exec.Command(tmux.BinaryPath(), "new-session", "-d", "-s", alternateSession)
+	alternateCreate.Env = alternateEnv
+	if out, err := alternateCreate.CombinedOutput(); err != nil {
+		t.Fatalf("create alternate sentinel: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command(tmux.BinaryPath(), "kill-session", "-t", alternateSession)
+		cmd.Env = alternateEnv
+		_ = cmd.Run()
+	})
+
+	// Swap the mutable process route after setup. All shared operations must
+	// still execute with the stored process-owned environment.
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_TMPDIR", alternateRoot)
+	ownedCreate := exec.Command(tmux.BinaryPath(), "new-session", "-d", "-s", ownedSession)
+	ownedCreate.Env = ownedEnv
+	if out, err := ownedCreate.CombinedOutput(); err != nil {
+		t.Fatalf("create owned session after route swap: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command(tmux.BinaryPath(), "kill-session", "-t", ownedSession)
+		cmd.Env = ownedEnv
+		_ = cmd.Run()
+	})
+	KillAllTestSessionsSilent()
+	killSession(NewTestLogger(t, t.TempDir()), alternateSession)
+
+	alternateHas := exec.Command(tmux.BinaryPath(), "has-session", "-t", alternateSession)
+	alternateHas.Env = alternateEnv
+	if err := alternateHas.Run(); err != nil {
+		t.Fatal("alternate-root sentinel was reached by shared cleanup")
+	}
+	alternateOwned := exec.Command(tmux.BinaryPath(), "has-session", "-t", ownedSession)
+	alternateOwned.Env = alternateEnv
+	if err := alternateOwned.Run(); err == nil {
+		t.Fatal("owned session creation was redirected to alternate root")
 	}
 }
 

--- a/tests/testutil/tmux_isolation_test.go
+++ b/tests/testutil/tmux_isolation_test.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -133,6 +134,28 @@ func TestSharedHelpersIgnoreRouteSwap(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv("TMUX_TMPDIR", alternateRoot)
 	RequireTmuxServer(t)
+	probeInventory, err := tmuxSessionInventory(ownedEnv)
+	if err != nil {
+		t.Fatalf("owned-root server inventory: %v: %s", err, probeInventory)
+	}
+	if !inventoryHasSession(probeInventory, ownedSession) {
+		t.Fatalf("RequireTmuxServer route oracle missed owned sentinel: %q", probeInventory)
+	}
+	if inventoryHasSession(probeInventory, alternateSession) {
+		t.Fatalf("RequireTmuxServer route oracle reached alternate sentinel: %q", probeInventory)
+	}
+
+	// Seed the exact binding-removal mutant: a probe inheriting the swapped
+	// process environment must be distinguishable from the owned-root probe.
+	// Removing cmd.Env = env in tmuxSessionInventory makes the owned probe take
+	// this route and causes the assertions above to fail deterministically.
+	mutantInventory, err := tmuxSessionInventory(os.Environ())
+	if err != nil {
+		t.Fatalf("binding-removal mutant inventory: %v: %s", err, mutantInventory)
+	}
+	if !inventoryHasSession(mutantInventory, alternateSession) || inventoryHasSession(mutantInventory, ownedSession) {
+		t.Fatalf("binding-removal mutant was not routed to alternate root: %q", mutantInventory)
+	}
 	logger := NewTestLoggerStdout(t)
 	createdByLogger := "ntm_test_shared_logger_create"
 	if _, err := logger.Exec(tmux.BinaryPath(), "new-session", "-d", "-s", createdByLogger); err != nil {
@@ -166,6 +189,15 @@ func TestSharedHelpersIgnoreRouteSwap(t *testing.T) {
 	if err := alternateHas.Run(); err != nil {
 		t.Fatal("alternate-root sentinel did not survive shared helper probes")
 	}
+}
+
+func inventoryHasSession(inventory []byte, session string) bool {
+	for _, line := range bytes.Split(inventory, []byte{'\n'}) {
+		if bytes.Equal(line, []byte(session)) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestIsolationRejectsRoutingChangeAfterSetup(t *testing.T) {

--- a/tests/testutil/tmux_isolation_test.go
+++ b/tests/testutil/tmux_isolation_test.go
@@ -1,0 +1,40 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsolationAuthorizationCannotBeForged(t *testing.T) {
+	t.Setenv(isolatedTmuxMarker, "1")
+	t.Setenv("TMUX_TMPDIR", "/tmp")
+	t.Setenv("TMUX", "")
+	if isolatedTmuxReady() {
+		t.Fatal("environment-only isolation authorization must be rejected")
+	}
+}
+
+func TestIsolationRejectsRoutingChangeAfterSetup(t *testing.T) {
+	cleanup, err := SetupIsolatedTmuxTestProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	if !isolatedTmuxReady() {
+		t.Fatal("process-owned isolation should be ready after setup")
+	}
+	originalRoot := os.Getenv("TMUX_TMPDIR")
+	t.Setenv("TMUX_TMPDIR", "/tmp")
+	if isolatedTmuxReady() {
+		t.Fatal("routing change after setup must revoke mutation authorization")
+	}
+	t.Setenv("TMUX_TMPDIR", originalRoot)
+	if !isolatedTmuxReady() {
+		t.Fatal("restoring the exact process-owned root should restore authorization")
+	}
+}

--- a/tests/testutil/tmux_isolation_test.go
+++ b/tests/testutil/tmux_isolation_test.go
@@ -132,6 +132,7 @@ func TestSharedHelpersIgnoreRouteSwap(t *testing.T) {
 
 	t.Setenv("TMUX", "")
 	t.Setenv("TMUX_TMPDIR", alternateRoot)
+	RequireTmuxServer(t)
 	logger := NewTestLoggerStdout(t)
 	createdByLogger := "ntm_test_shared_logger_create"
 	if _, err := logger.Exec(tmux.BinaryPath(), "new-session", "-d", "-s", createdByLogger); err != nil {


### PR DESCRIPTION
## Summary

- move real-tmux CLI and robot tests onto a fresh private `TMUX_TMPDIR`
- unset inherited `TMUX` and make shared cleanup refuse the ambient server
- compare the host default-server session inventory before and after each guarded package

## Incident

This is the separate safety fix for #220. It does not expand or modify #219.

## Validation

Validation ran with an additional outer private `TMUX_TMPDIR` and `TMUX` unset:

```bash
env -u TMUX TMUX_TMPDIR="$(mktemp -d)" \
  go test ./internal/cli ./internal/robot ./tests/testutil \
  -run 'TestPrintSnapshotWithSession|^$' -count=1
```

- focused packages passed
- default tmux session inventory was identical before and after
- no `kill-server` or `kill-session -a` added
- `git diff --check` passed
- UBS investigated: its nanosecond session-name finding is a false positive (not a security token); its missing-module warning is caused by the four-file shadow workspace

## Scope

This first slice guards the two packages implicated in the incident and makes shared session creation/cleanup fail closed. Follow-up migration can install the same process guard in remaining real-tmux package suites.

Refs #220
