### PR TITLE
fix(send): pass dcg pre-send candidates after "--" and strip bullet markers

### DIFF
--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -3353,6 +3353,12 @@ func extractLikelyCommands(prompt string) []string {
 
 func normalizeCommandLine(line string) string {
 	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, "- ") {
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+	}
+	if strings.HasPrefix(trimmed, "* ") {
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "* "))
+	}
 	if strings.HasPrefix(trimmed, "$ ") {
 		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "$ "))
 	}

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -1072,6 +1072,21 @@ func TestExtractLikelyCommands(t *testing.T) {
 			input: "git status\nrm -rf /tmp\njust some text",
 			want:  []string{"git status", "rm -rf /tmp"},
 		},
+		{
+			name:  "markdown bullet with command chain",
+			input: "  - run br list && git status",
+			want:  []string{"run br list && git status"},
+		},
+		{
+			name:  "asterisk bullet with force flag",
+			input: "* deploy --force",
+			want:  []string{"deploy --force"},
+		},
+		{
+			name:  "bulleted git command",
+			input: "   - git push --force",
+			want:  []string{"git push --force"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/dcg.go
+++ b/internal/tools/dcg.go
@@ -368,7 +368,9 @@ func (a *DCGAdapter) CheckCommand(ctx context.Context, command string) (*Blocked
 
 	// dcg uses `dcg test` (not `check`) and `--format json` (not `--json`).
 	// Pair with `--robot` so stdout is pure JSON without rich/ANSI output.
-	cmd := exec.CommandContext(ctx, a.BinaryName(), "--robot", "test", "--format", "json", commandToCheck)
+	// The `--` terminator is required: without it a command starting with `-`
+	// (e.g. an extracted markdown bullet) is parsed as a flag and dcg exits 2.
+	cmd := exec.CommandContext(ctx, a.BinaryName(), "--robot", "test", "--format", "json", "--", commandToCheck)
 	cmd.WaitDelay = time.Second
 	stdout := NewLimitedBuffer(10 * 1024 * 1024)
 	var stderr bytes.Buffer
@@ -424,7 +426,7 @@ func (a *DCGAdapter) CheckCommandExtended(ctx context.Context, command, context_
 	// equivalent surface today and is intentionally dropped rather than
 	// passed as an unrecognized flag.
 	_ = context_
-	args := []string{"--robot", "test", "--format", "json", commandToCheck}
+	args := []string{"--robot", "test", "--format", "json", "--", commandToCheck}
 
 	cmd := exec.CommandContext(ctx, a.BinaryName(), args...)
 	if cwd != "" {

--- a/internal/tools/dcg_test.go
+++ b/internal/tools/dcg_test.go
@@ -1,6 +1,53 @@
 package tools
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestCheckCommandLeadingDashCommand is the regression guard for prompts whose
+// extracted command begins with "-" (e.g. a markdown bullet line): dcg must
+// receive the command after the "--" terminator, otherwise clap parses it as a
+// flag and exits 2, which failed the whole send instead of returning a verdict.
+func TestCheckCommandLeadingDashCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake dcg uses a shell script")
+	}
+	dir := t.TempDir()
+	// Emulates clap's argv handling: any pre-terminator operand that starts
+	// with "-" and is not a known flag is a parse error (exit 2).
+	script := "#!/bin/sh\n" +
+		"seen_sep=0\n" +
+		"skip_next=0\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$skip_next\" = \"1\" ]; then skip_next=0; continue; fi\n" +
+		"  if [ \"$seen_sep\" = \"1\" ]; then continue; fi\n" +
+		"  case \"$a\" in\n" +
+		"    --) seen_sep=1 ;;\n" +
+		"    --robot|test) ;;\n" +
+		"    --format) skip_next=1 ;;\n" +
+		"    -*) echo \"error: unexpected argument '$a' found\" 1>&2; exit 2 ;;\n" +
+		"    *) ;;\n" +
+		"  esac\n" +
+		"done\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "dcg"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake dcg: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	adapter := NewDCGAdapter()
+	blocked, err := adapter.CheckCommand(context.Background(), "- run br list && git status")
+	if err != nil {
+		t.Fatalf("CheckCommand returned error for leading-dash command: %v", err)
+	}
+	if blocked != nil {
+		t.Fatalf("CheckCommand unexpectedly blocked leading-dash command: %+v", blocked)
+	}
+}
 
 func TestInferSeverity(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Illustrative fix for #228, filed per CONTRIBUTING.md: I know direct outside PRs are not merged; this is for your agents to review and adapt.

## What

- `internal/tools/dcg.go`: pass the checked command after the `--` terminator in `CheckCommand` and `CheckCommandExtended`, so a candidate starting with `-` is always treated as the positional COMMAND and never parsed as flags. This is the fix dcg's own error tip suggests.
- `internal/cli/send.go`: strip `- ` and `* ` markdown list markers in `normalizeCommandLine`, so the pre-send guard evaluates the command text rather than the markdown decoration.

## Why

See #228: a prompt bullet line like `  - run br list && git status` is extracted as a candidate, keeps its `- ` marker, crashes dcg's clap parser (exit 2), and `maybeBlockSendWithDCG` turns that adapter error into a hard failure of the entire send. In our deployment this silently killed 100% of controller-driven dispatches for 6 days while short health probe sends kept passing.

## Tests

- New `TestCheckCommandLeadingDashCommand` with a clap-emulating fake dcg binary. On the old argv construction it fails with exactly the production error (`dcg test failed: exit status 2: error: unexpected argument ... found`); with `--` it passes.
- Bullet cases added to the `TestExtractLikelyCommands` table.
- `go test ./internal/tools/` passes. `./internal/cli/` passes except the pre-existing `TestFindGitHookPathLinkedWorktree`, which reads the developer's global `core.hooksPath` and fails on any machine where that is set globally; unrelated to this change.

Not touched: the fail-open vs fail-closed policy for adapter errors in `maybeBlockSendWithDCG` (see the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
