### PR TITLE
fix(install): suppress noisy curl 404 when probing checksum candidates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,15 +172,26 @@ normalize_release_version() {
     printf 'v%s\n' "${version#v}"
 }
 
-# Download a file
+# Download a file. Pass "true" as the third argument to suppress the
+# underlying tool's own error output (used when a 404 is an expected,
+# silently-handled fallback rather than a real failure).
 download_file() {
     local url="$1"
     local dest="$2"
+    local quiet="${3:-false}"
 
     if has_cmd curl; then
-        curl -fsSL "$url" -o "$dest" || return 1
+        if [ "$quiet" = true ]; then
+            curl -fsSL "$url" -o "$dest" 2>/dev/null || return 1
+        else
+            curl -fsSL "$url" -o "$dest" || return 1
+        fi
     elif has_cmd wget; then
-        wget -q "$url" -O "$dest" || return 1
+        if [ "$quiet" = true ]; then
+            wget -q "$url" -O "$dest" 2>/dev/null || return 1
+        else
+            wget -q "$url" -O "$dest" || return 1
+        fi
     else
         print_error "Neither curl nor wget found. Please install one."
         return 1
@@ -316,7 +327,7 @@ download_release_checksums() {
     for candidate in "${candidates[@]}"; do
         checksum_url=$(build_download_url "$version" "$candidate")
         checksum_path="${dest_dir}/${candidate}"
-        if download_file "$checksum_url" "$checksum_path"; then
+        if download_file "$checksum_url" "$checksum_path" true; then
             printf '%s\n' "$checksum_path"
             return 0
         fi


### PR DESCRIPTION
## Summary

- Fixes #247: `install.sh` printed a raw `curl: (22) The requested URL returned error: 404` while probing for an optional `checksums.txt` asset that doesn't exist in current releases (only `SHA256SUMS` and per-asset `.sha256` files are published), even though it immediately falls through to the next candidate and the install completes successfully.
- Adds a `quiet` flag to `download_file()` and passes it from `download_release_checksums()`'s probing loop, so expected-to-fail candidate probes don't leak the underlying curl/wget error to the user. The primary asset download still shows errors normally.

## Test plan

- [x] Ran `install.sh` locally against a scratch install dir before the fix — reproduced the `curl: (22) ... 404` line despite a fully successful install.
- [x] Ran it again after the fix — the 404 line is gone, `Verifying checksum...` is immediately followed by the tar extraction, and the install still succeeds.
- [x] Ran the installed binary (`ntm version`) to confirm the extracted binary is valid and checksum verification actually ran (not skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
