### PR TITLE
fix(cm): use current MCP server contract

### DIFF
--- a/internal/cm/client.go
+++ b/internal/cm/client.go
@@ -20,8 +20,27 @@ import (
 var ErrNotInstalled = fmt.Errorf("cm is not installed")
 
 type Client struct {
-	baseURL string
-	client  *http.Client
+	baseURL   string
+	sessionID string
+	client    *http.Client
+}
+
+type mcpRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpRPCResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *mcpRPCError    `json:"error"`
+}
+
+type mcpToolResult struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	IsError bool `json:"isError"`
 }
 
 // PIDFileInfo matches supervisor.PIDFileInfo
@@ -48,16 +67,100 @@ func NewClient(projectDir, sessionID string) (*Client, error) {
 	}
 
 	return &Client{
-		baseURL: fmt.Sprintf("http://127.0.0.1:%d", info.Port),
-		client:  &http.Client{Timeout: 10 * time.Second},
+		baseURL:   fmt.Sprintf("http://127.0.0.1:%d", info.Port),
+		sessionID: sessionID,
+		client:    &http.Client{Timeout: 10 * time.Second},
 	}, nil
 }
 
+func (c *Client) rpc(ctx context.Context, method string, params any, result any) error {
+	reqBody := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+	}
+	if params != nil {
+		reqBody["params"] = params
+	}
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshaling cm MCP request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("cm MCP %s failed: %s", method, resp.Status)
+	}
+
+	var rpcResponse mcpRPCResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 10*1024*1024)).Decode(&rpcResponse); err != nil {
+		return fmt.Errorf("decoding cm MCP %s response: %w", method, err)
+	}
+	if rpcResponse.Error != nil {
+		return fmt.Errorf("cm MCP %s failed (%d): %s", method, rpcResponse.Error.Code, rpcResponse.Error.Message)
+	}
+	if len(rpcResponse.Result) == 0 || string(rpcResponse.Result) == "null" {
+		return fmt.Errorf("cm MCP %s response contained no result", method)
+	}
+	if result == nil {
+		return nil
+	}
+	if err := json.Unmarshal(rpcResponse.Result, result); err != nil {
+		return fmt.Errorf("decoding cm MCP %s result: %w", method, err)
+	}
+	return nil
+}
+
+func (c *Client) callTool(ctx context.Context, name string, arguments any, result any) error {
+	var toolResult mcpToolResult
+	if err := c.rpc(ctx, "tools/call", map[string]any{
+		"name":      name,
+		"arguments": arguments,
+	}, &toolResult); err != nil {
+		return err
+	}
+
+	var textResult string
+	for _, content := range toolResult.Content {
+		if content.Type == "text" && strings.TrimSpace(content.Text) != "" {
+			textResult = content.Text
+			break
+		}
+	}
+	if toolResult.IsError {
+		if textResult != "" {
+			return fmt.Errorf("cm tool %s failed: %s", name, textResult)
+		}
+		return fmt.Errorf("cm tool %s failed", name)
+	}
+	if result == nil {
+		return nil
+	}
+	if textResult == "" {
+		return fmt.Errorf("cm tool %s response contained no text result", name)
+	}
+	if err := json.Unmarshal([]byte(textResult), result); err != nil {
+		return fmt.Errorf("decoding cm tool %s result: %w", name, err)
+	}
+	return nil
+}
+
 type ContextResult struct {
-	RelevantBullets  []Rule    `json:"relevantBullets"`
-	AntiPatterns     []Rule    `json:"antiPatterns"`
-	HistorySnippets  []Snippet `json:"historySnippets"`
-	SuggestedQueries []string  `json:"suggestedCassQueries"`
+	RelevantBullets  []Rule           `json:"relevantBullets"`
+	AntiPatterns     []Rule           `json:"antiPatterns"`
+	HistorySnippets  []CLIHistorySnip `json:"historySnippets"`
+	SuggestedQueries []string         `json:"suggestedCassQueries"`
 }
 
 type Rule struct {
@@ -67,66 +170,26 @@ type Rule struct {
 	Confidence *float64 `json:"confidence,omitempty"`
 }
 
-type Snippet struct {
-	ID      string `json:"id"`
-	Content string `json:"content"`
-}
-
-// GetContext queries CM for task-relevant rules via HTTP.
+// GetContext queries CM for task-relevant rules through its MCP HTTP server.
 //
 // `workspace`, when non-empty, is sent as a `workspace` field on the request
 // body so the daemon can scope its retrieval to that workspace and avoid
 // same-basename cross-project context bleed (#132).
 func (c *Client) GetContext(ctx context.Context, task string, workspace string) (*ContextResult, error) {
-	reqBody := map[string]string{"task": task}
+	arguments := map[string]string{"task": task}
 	if strings.TrimSpace(workspace) != "" {
-		reqBody["workspace"] = workspace
+		arguments["workspace"] = workspace
 	}
-	data, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/context", bytes.NewReader(data))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("cm context failed: %s", resp.Status)
-	}
-
 	var result ContextResult
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 10*1024*1024)).Decode(&result); err != nil {
+	if err := c.callTool(ctx, "cm_context", arguments, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-// Health checks whether the CM daemon is responding at /health.
+// Health checks whether the CM daemon responds to the MCP ping method.
 func (c *Client) Health(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("cm health failed: %s", resp.Status)
-	}
-	return nil
+	return c.rpc(ctx, "ping", map[string]any{}, nil)
 }
 
 // Port returns the daemon port extracted from the client's base URL.
@@ -164,26 +227,30 @@ type OutcomeReport struct {
 
 // RecordOutcome sends feedback about rule effectiveness.
 func (c *Client) RecordOutcome(ctx context.Context, report OutcomeReport) error {
-	data, err := json.Marshal(report)
-	if err != nil {
-		return fmt.Errorf("marshal outcome report: %w", err)
+	if strings.TrimSpace(c.sessionID) == "" {
+		return fmt.Errorf("cm outcome failed: session ID is empty")
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/outcome", bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return err
+	notes := strings.TrimSpace(report.Notes)
+	if sentiment := strings.TrimSpace(report.Sentiment); sentiment != "" {
+		// CM's MCP outcome schema has no separate sentiment field. Preserve the
+		// legacy NTM value in notes instead of silently dropping it.
+		if notes != "" {
+			notes = fmt.Sprintf("sentiment=%s\n%s", sentiment, notes)
+		} else {
+			notes = "sentiment=" + sentiment
+		}
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("cm outcome failed: %s", resp.Status)
+	arguments := map[string]any{
+		"sessionId": c.sessionID,
+		"outcome":   string(report.Status),
+		"rulesUsed": report.RuleIDs,
 	}
-	return nil
+	if notes != "" {
+		arguments["notes"] = notes
+	}
+	return c.callTool(ctx, "cm_outcome", arguments, nil)
 }
 
 // CLIClient interacts with the CM CLI directly via exec.Command.
@@ -302,11 +369,34 @@ func (c *CLIClient) GetContext(ctx context.Context, task string, workspace strin
 		}
 	}
 
-	var result CLIContextResponse
-	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+	result, err := decodeCLIContextResponse(stdout.Bytes())
+	if err != nil {
 		return nil, fmt.Errorf("parsing cm output: %w (raw: %s)", err, stdout.String())
 	}
 
+	return result, nil
+}
+
+func decodeCLIContextResponse(data []byte) (*CLIContextResponse, error) {
+	var envelope struct {
+		Success bool            `json:"success"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, err
+	}
+
+	var result CLIContextResponse
+	if len(envelope.Data) > 0 && string(envelope.Data) != "null" {
+		if err := json.Unmarshal(envelope.Data, &result); err != nil {
+			return nil, err
+		}
+		result.Success = envelope.Success
+		return &result, nil
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
 	return &result, nil
 }
 

--- a/internal/cm/client_test.go
+++ b/internal/cm/client_test.go
@@ -14,6 +14,38 @@ import (
 	"time"
 )
 
+func writeMCPResult(t *testing.T, w http.ResponseWriter, result any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result":  result,
+	}); err != nil {
+		t.Fatalf("encode MCP response: %v", err)
+	}
+}
+
+func writeMCPToolResponse(t *testing.T, w http.ResponseWriter, result any) {
+	t.Helper()
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal tool result: %v", err)
+	}
+	writeMCPResult(t, w, map[string]any{
+		"content": []map[string]string{{"type": "text", "text": string(data)}},
+	})
+}
+
+func writeMCPContextResponse(t *testing.T, w http.ResponseWriter, result ContextResult) {
+	t.Helper()
+	writeMCPToolResponse(t, w, result)
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
 func TestNewClient(t *testing.T) {
 	tmpDir := t.TempDir()
 	pidsDir := filepath.Join(tmpDir, ".ntm", "pids")
@@ -37,19 +69,21 @@ func TestNewClient(t *testing.T) {
 	if client.Port() != 12345 {
 		t.Errorf("NewClient() Port() = %d, want 12345", client.Port())
 	}
+	if client.sessionID != sessionID {
+		t.Errorf("NewClient() sessionID = %q, want %q", client.sessionID, sessionID)
+	}
 }
 
 func TestGetContext(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/context" {
-			t.Errorf("path = %s, want /context", r.URL.Path)
+		if r.URL.Path != "/" {
+			t.Errorf("path = %s, want /", r.URL.Path)
 		}
 		if r.Method != "POST" {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(ContextResult{
+		writeMCPContextResponse(t, w, ContextResult{
 			RelevantBullets: []Rule{{ID: "r1", Content: "Use HTTP"}},
 		})
 	}))
@@ -70,18 +104,35 @@ func TestGetContext(t *testing.T) {
 	}
 }
 
+func TestGetContextReturnsMCPToolError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeMCPResult(t, w, map[string]any{
+			"content": []map[string]string{{"type": "text", "text": "CASS unavailable"}},
+			"isError": true,
+		})
+	}))
+	defer ts.Close()
+
+	client := &Client{baseURL: ts.URL, client: ts.Client()}
+	_, err := client.GetContext(context.Background(), "test task", "")
+	if err == nil || !strings.Contains(err.Error(), "CASS unavailable") {
+		t.Fatalf("GetContext() error = %v, want MCP tool error", err)
+	}
+}
+
 func TestRecordOutcome(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/outcome" {
-			t.Errorf("path = %s, want /outcome", r.URL.Path)
+		if r.URL.Path != "/" {
+			t.Errorf("path = %s, want /", r.URL.Path)
 		}
-		w.WriteHeader(http.StatusOK)
+		writeMCPToolResponse(t, w, map[string]any{"success": true})
 	}))
 	defer ts.Close()
 
 	client := &Client{
-		baseURL: ts.URL,
-		client:  ts.Client(),
+		baseURL:   ts.URL,
+		sessionID: "test-session",
+		client:    ts.Client(),
 	}
 
 	err := client.RecordOutcome(context.Background(), OutcomeReport{
@@ -92,10 +143,24 @@ func TestRecordOutcome(t *testing.T) {
 	}
 }
 
+func TestRecordOutcomeRequiresSessionID(t *testing.T) {
+	client := &Client{
+		baseURL: "http://127.0.0.1:1",
+		client:  http.DefaultClient,
+	}
+
+	err := client.RecordOutcome(context.Background(), OutcomeReport{Status: OutcomeSuccess})
+	if err == nil || !strings.Contains(err.Error(), "session ID is empty") {
+		t.Fatalf("RecordOutcome() error = %v, want missing session ID error", err)
+	}
+}
+
 func TestGetContext_PreservesRuleConfidence(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"relevantBullets":[{"id":"rule-1","content":"Use the focused proof command","confidence":0.875}],"antiPatterns":[{"id":"anti-1","content":"Do not overclaim proof","confidence":0}]}`))
+		writeMCPContextResponse(t, w, ContextResult{
+			RelevantBullets: []Rule{{ID: "rule-1", Content: "Use the focused proof command", Confidence: float64Ptr(0.875)}},
+			AntiPatterns:    []Rule{{ID: "anti-1", Content: "Do not overclaim proof", Confidence: float64Ptr(0)}},
+		})
 	}))
 	defer ts.Close()
 
@@ -121,13 +186,22 @@ func TestGetContext_PreservesRuleConfidence(t *testing.T) {
 func TestClientHealth(t *testing.T) {
 	t.Run("healthy", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/health" {
-				t.Errorf("path = %s, want /health", r.URL.Path)
+			if r.URL.Path != "/" {
+				t.Errorf("path = %s, want /", r.URL.Path)
 			}
-			if r.Method != http.MethodGet {
-				t.Errorf("method = %s, want GET", r.Method)
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %s, want POST", r.Method)
 			}
-			w.WriteHeader(http.StatusOK)
+			var request struct {
+				Method string `json:"method"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode ping request: %v", err)
+			}
+			if request.Method != "ping" {
+				t.Errorf("MCP method = %q, want ping", request.Method)
+			}
+			writeMCPResult(t, w, map[string]any{})
 		}))
 		defer ts.Close()
 
@@ -154,6 +228,29 @@ func TestClientHealth(t *testing.T) {
 
 		if err := client.Health(context.Background()); err == nil {
 			t.Fatal("Health() error = nil, want non-nil")
+		}
+	})
+
+	t.Run("MCP error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"error": map[string]any{
+					"code":    -32601,
+					"message": "Method not found",
+				},
+			}); err != nil {
+				t.Fatalf("encode MCP error: %v", err)
+			}
+		}))
+		defer ts.Close()
+
+		client := &Client{baseURL: ts.URL, client: ts.Client()}
+		err := client.Health(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "-32601") {
+			t.Fatalf("Health() error = %v, want MCP method error", err)
 		}
 	})
 }
@@ -365,8 +462,9 @@ func TestGetContext_ServerError500(t *testing.T) {
 	defer ts.Close()
 
 	client := &Client{
-		baseURL: ts.URL,
-		client:  ts.Client(),
+		baseURL:   ts.URL,
+		sessionID: "test-session",
+		client:    ts.Client(),
 	}
 
 	_, err := client.GetContext(context.Background(), "test task", "")
@@ -502,8 +600,9 @@ func TestRecordOutcome_ServerErrors(t *testing.T) {
 			defer ts.Close()
 
 			client := &Client{
-				baseURL: ts.URL,
-				client:  ts.Client(),
+				baseURL:   ts.URL,
+				sessionID: "test-session",
+				client:    ts.Client(),
 			}
 
 			err := client.RecordOutcome(context.Background(), OutcomeReport{
@@ -675,13 +774,18 @@ func TestGetRecoveryContext_LimitsApplied(t *testing.T) {
 // TestGetContext_RequestBodyValidation verifies correct request body is sent
 func TestGetContext_RequestBodyValidation(t *testing.T) {
 	start := time.Now()
-	var receivedBody map[string]string
+	var receivedBody struct {
+		Method string `json:"method"`
+		Params struct {
+			Name      string            `json:"name"`
+			Arguments map[string]string `json:"arguments"`
+		} `json:"params"`
+	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		json.Unmarshal(body, &receivedBody)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(ContextResult{})
+		writeMCPContextResponse(t, w, ContextResult{})
 	}))
 	defer ts.Close()
 
@@ -696,29 +800,44 @@ func TestGetContext_RequestBodyValidation(t *testing.T) {
 		t.Fatalf("[CM-ERROR] GetContext: unexpected error: %v", err)
 	}
 
-	if receivedBody["task"] != testTask {
-		t.Errorf("[CM-ERROR] GetContext: task mismatch, sent=%q, received=%q", testTask, receivedBody["task"])
+	if receivedBody.Method != "tools/call" || receivedBody.Params.Name != "cm_context" {
+		t.Errorf("[CM-ERROR] GetContext: unexpected MCP call: %+v", receivedBody)
+	}
+	if receivedBody.Params.Arguments["task"] != testTask {
+		t.Errorf("[CM-ERROR] GetContext: task mismatch, sent=%q, received=%q", testTask, receivedBody.Params.Arguments["task"])
 	}
 
 	t.Logf("[CM-ERROR] Operation=RequestValidation | Task=%q | Received=%q | Duration=%v",
-		testTask, receivedBody["task"], time.Since(start))
+		testTask, receivedBody.Params.Arguments["task"], time.Since(start))
 }
 
 // TestRecordOutcome_RequestBodyValidation verifies correct outcome is sent
 func TestRecordOutcome_RequestBodyValidation(t *testing.T) {
 	start := time.Now()
-	var receivedBody OutcomeReport
+	var receivedBody struct {
+		Method string `json:"method"`
+		Params struct {
+			Name      string `json:"name"`
+			Arguments struct {
+				SessionID string   `json:"sessionId"`
+				Outcome   string   `json:"outcome"`
+				RulesUsed []string `json:"rulesUsed"`
+				Notes     string   `json:"notes"`
+			} `json:"arguments"`
+		} `json:"params"`
+	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		json.Unmarshal(body, &receivedBody)
-		w.WriteHeader(http.StatusOK)
+		writeMCPToolResponse(t, w, map[string]any{"success": true})
 	}))
 	defer ts.Close()
 
 	client := &Client{
-		baseURL: ts.URL,
-		client:  ts.Client(),
+		baseURL:   ts.URL,
+		sessionID: "test-session",
+		client:    ts.Client(),
 	}
 
 	report := OutcomeReport{
@@ -733,11 +852,20 @@ func TestRecordOutcome_RequestBodyValidation(t *testing.T) {
 		t.Fatalf("[CM-ERROR] RecordOutcome: unexpected error: %v", err)
 	}
 
-	if receivedBody.Status != report.Status {
-		t.Errorf("[CM-ERROR] Status mismatch: sent=%v, received=%v", report.Status, receivedBody.Status)
+	if receivedBody.Method != "tools/call" || receivedBody.Params.Name != "cm_outcome" {
+		t.Errorf("[CM-ERROR] unexpected MCP call: %+v", receivedBody)
 	}
-	if len(receivedBody.RuleIDs) != len(report.RuleIDs) {
-		t.Errorf("[CM-ERROR] RuleIDs mismatch: sent=%v, received=%v", report.RuleIDs, receivedBody.RuleIDs)
+	if receivedBody.Params.Arguments.SessionID != "test-session" {
+		t.Errorf("[CM-ERROR] SessionID mismatch: received=%q", receivedBody.Params.Arguments.SessionID)
+	}
+	if receivedBody.Params.Arguments.Outcome != string(report.Status) {
+		t.Errorf("[CM-ERROR] Status mismatch: sent=%v, received=%v", report.Status, receivedBody.Params.Arguments.Outcome)
+	}
+	if len(receivedBody.Params.Arguments.RulesUsed) != len(report.RuleIDs) {
+		t.Errorf("[CM-ERROR] RuleIDs mismatch: sent=%v, received=%v", report.RuleIDs, receivedBody.Params.Arguments.RulesUsed)
+	}
+	if receivedBody.Params.Arguments.Notes != "sentiment=positive\nTest notes" {
+		t.Errorf("[CM-ERROR] Notes mismatch: received=%q", receivedBody.Params.Arguments.Notes)
 	}
 
 	t.Logf("[CM-ERROR] Operation=OutcomeValidation | Status=%s | RuleCount=%d | Duration=%v",
@@ -882,9 +1010,8 @@ func TestGetContext_CASSUnavailable(t *testing.T) {
 
 	// Server returns success but with empty/error history snippets (CASS unavailable)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		// CM returns rules but no history (simulating CASS being down)
-		json.NewEncoder(w).Encode(ContextResult{
+		writeMCPContextResponse(t, w, ContextResult{
 			RelevantBullets: []Rule{{ID: "r1", Content: "Test rule"}},
 			AntiPatterns:    []Rule{},
 			// HistorySnippets would be nil/empty when CASS is unavailable
@@ -893,8 +1020,9 @@ func TestGetContext_CASSUnavailable(t *testing.T) {
 	defer ts.Close()
 
 	client := &Client{
-		baseURL: ts.URL,
-		client:  ts.Client(),
+		baseURL:   ts.URL,
+		sessionID: "test-session",
+		client:    ts.Client(),
 	}
 
 	res, err := client.GetContext(context.Background(), "test task", "")
@@ -916,10 +1044,9 @@ func TestGetContext_PartialResponse(t *testing.T) {
 	start := time.Now()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		// Partial response - only some fields populated
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"relevantBullets": []Rule{{ID: "partial-rule", Content: "Partial data"}},
+		writeMCPContextResponse(t, w, ContextResult{
+			RelevantBullets: []Rule{{ID: "partial-rule", Content: "Partial data"}},
 			// Missing antiPatterns, historySnippets, suggestedCassQueries
 		})
 	}))
@@ -1050,8 +1177,9 @@ func TestRecordOutcome_InvalidReport(t *testing.T) {
 	defer ts.Close()
 
 	client := &Client{
-		baseURL: ts.URL,
-		client:  ts.Client(),
+		baseURL:   ts.URL,
+		sessionID: "test-session",
+		client:    ts.Client(),
 	}
 
 	testCases := []struct {
@@ -1131,13 +1259,21 @@ func TestFallback_PartialCMFunctionality(t *testing.T) {
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		switch r.URL.Path {
-		case "/context":
+		var request struct {
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode MCP request: %v", err)
+		}
+		switch request.Params.Name {
+		case "cm_context":
 			// Context endpoint works
-			json.NewEncoder(w).Encode(ContextResult{
+			writeMCPContextResponse(t, w, ContextResult{
 				RelevantBullets: []Rule{{ID: "r1", Content: "Partial CM - rules work"}},
 			})
-		case "/outcome":
+		case "cm_outcome":
 			// Outcome endpoint fails
 			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte("Guard service unavailable"))
@@ -1148,8 +1284,9 @@ func TestFallback_PartialCMFunctionality(t *testing.T) {
 	defer ts.Close()
 
 	client := &Client{
-		baseURL: ts.URL,
-		client:  ts.Client(),
+		baseURL:   ts.URL,
+		sessionID: "test-session",
+		client:    ts.Client(),
 	}
 
 	// Context should work
@@ -1204,8 +1341,7 @@ func TestFallback_CachedContextOnError(t *testing.T) {
 		callCount++
 		if callCount == 1 {
 			// First call succeeds
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(ContextResult{
+			writeMCPContextResponse(t, w, ContextResult{
 				RelevantBullets: []Rule{{ID: "cached", Content: "Cached rule"}},
 			})
 		} else {
@@ -1378,10 +1514,31 @@ func TestCLIContextResponse_PreservesRuleConfidence(t *testing.T) {
 	}
 }
 
+func TestDecodeCLIContextResponse_CurrentEnvelope(t *testing.T) {
+	result, err := decodeCLIContextResponse([]byte(`{
+		"success": true,
+		"data": {
+			"task": "repair memory",
+			"relevantBullets": [{"id":"rule-1","content":"Use the native CM contract"}],
+			"antiPatterns": [],
+			"historySnippets": [{"source_path":"/tmp/session.jsonl","title":"Prior repair","snippet":"Fixed it","agent":"codex"}],
+			"suggestedCassQueries": ["cass search memory"]
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("decode current CM envelope: %v", err)
+	}
+	if !result.Success || result.Task != "repair memory" {
+		t.Fatalf("decoded result = %+v", result)
+	}
+	if len(result.HistorySnippets) != 1 || result.HistorySnippets[0].Snippet != "Fixed it" {
+		t.Fatalf("history snippets = %+v", result.HistorySnippets)
+	}
+}
+
 // TestGetContextSendsWorkspace verifies the #132 fix: when callers pass a
-// non-empty workspace, the HTTP client puts it on the request body so the
-// daemon can scope retrieval. Empty workspace must be elided so older
-// daemons that don't understand the field aren't confused by a "" value.
+// non-empty workspace, the HTTP client puts it in the cm_context MCP arguments
+// so the daemon can scope retrieval. Empty workspace must be elided.
 func TestGetContextSendsWorkspace(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -1398,19 +1555,22 @@ func TestGetContextSendsWorkspace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
-				var got map[string]string
+				var got struct {
+					Params struct {
+						Arguments map[string]string `json:"arguments"`
+					} `json:"params"`
+				}
 				if err := json.Unmarshal(body, &got); err != nil {
 					t.Fatalf("decode body: %v", err)
 				}
-				gotWs, present := got["workspace"]
+				gotWs, present := got.Params.Arguments["workspace"]
 				if present != tc.wantField {
 					t.Errorf("workspace field present=%v, want %v (body=%s)", present, tc.wantField, string(body))
 				}
 				if tc.wantField && gotWs != tc.wantValue {
 					t.Errorf("workspace=%q, want %q", gotWs, tc.wantValue)
 				}
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"relevant_bullets":[]}`))
+				writeMCPContextResponse(t, w, ContextResult{})
 			}))
 			defer ts.Close()
 

--- a/internal/serve/cass.go
+++ b/internal/serve/cass.go
@@ -1104,8 +1104,14 @@ func (s *Server) handleMemoryContext(w http.ResponseWriter, r *http.Request) {
 				snippets := make([]map[string]interface{}, 0, len(result.HistorySnippets))
 				for _, sn := range result.HistorySnippets {
 					snippets = append(snippets, map[string]interface{}{
-						"id":      sn.ID,
-						"content": sn.Content,
+						"source_path": sn.SourcePath,
+						"line_number": sn.LineNumber,
+						"agent":       sn.Agent,
+						"workspace":   sn.Workspace,
+						"title":       sn.Title,
+						"snippet":     sn.Snippet,
+						"score":       sn.Score,
+						"created_at":  sn.CreatedAt,
 					})
 				}
 

--- a/internal/tools/cm_test.go
+++ b/internal/tools/cm_test.go
@@ -28,10 +28,29 @@ func TestCMAdapterConnectSetsDiscoveredServerPort(t *testing.T) {
 
 func TestCMAdapterIsDaemonRunningUsesConnectedClientEndpoint(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/health" {
-			t.Errorf("path = %s, want /health", r.URL.Path)
+		if r.URL.Path != "/" {
+			t.Errorf("path = %s, want /", r.URL.Path)
 		}
-		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode MCP request: %v", err)
+		}
+		if request.Method != "ping" {
+			t.Errorf("MCP method = %q, want ping", request.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  map[string]any{},
+		}); err != nil {
+			t.Fatalf("encode MCP response: %v", err)
+		}
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
## Problem

NTM recovery still calls the removed CM REST endpoints (`/context`, `/health`, and `/outcome`). Current CM serves JSON-RPC MCP at its root, so recovery emits timeout/failure warnings even while both CM and CASS are healthy. The current CM CLI also wraps context under `data`, and CASS history snippets now carry source metadata instead of placeholder `id`/`content` fields.

Refs #249.

## Changes

- route CM health through MCP `ping`
- route context and outcome through MCP `tools/call` (`cm_context` and `cm_outcome`)
- retain the NTM session ID required by `cm_outcome`
- preserve legacy sentiment in outcome notes because the current MCP schema has no sentiment field
- decode both the current CLI envelope and the legacy bare response
- preserve full CASS history metadata in the serve adapter
- update focused HTTP adapter and CM tests for the current wire contract

## Validation

- `go test -short ./internal/cm ./internal/tools` via RCH: pass
- `go test -short ./internal/serve -run TestHandleMemoryContext` via RCH: pass
- `go build ./cmd/ntm` and release build via RCH: pass
- live `ntm memory context` against CM: 10 history snippets, no degraded state
- isolated recovery-enabled spawn: recovery prepared without CM, Agent Mail, or recovery-window warnings; Codex reached a working prompt and Agent Mail connected

The repository-wide `go test -short ./...` was also run through RCH. The changed CM and serve packages passed; the run still has unrelated timing/environment failures in existing e2e pipeline, Agent Mail call-count, approval/audit timers, scheduler cooldown, tmux multibyte, and TUI color tests. `make lint` could not execute `golangci-lint` because v2.12.2 is not installed on the worker.