### PR TITLE
fix(agentmail): stop the fallback test deleting the real ~/.config

### DIFF
--- a/internal/agentmail/session_fallback_test.go
+++ b/internal/agentmail/session_fallback_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -24,9 +25,13 @@ func TestLoadSessionAgent_Fallback(t *testing.T) {
 	// let's create the directory structure manually in a location and see if we can
 	// point the function to it. But we can't redirect it.
 
-	// WAIT: sessionAgentPath uses os.UserConfigDir() OR HOME/.config.
-	// We can set HOME environment variable to tmpDir.
+	// sessionAgentPath resolves through os.UserConfigDir(), which on Linux reads
+	// XDG_CONFIG_HOME FIRST and only falls back to $HOME/.config when that is
+	// unset. Setting HOME alone therefore redirects nothing on any desktop that
+	// exports XDG_CONFIG_HOME -- os.UserConfigDir() keeps returning the real
+	// ~/.config, and the reset helper below used to delete it. Both must be set.
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, ".config"))
 
 	sessionName := "test-session"
 	projectKey := "/path/to/project"
@@ -55,8 +60,18 @@ func TestLoadSessionAgent_Fallback(t *testing.T) {
 	}
 	data, _ := json.Marshal(info)
 
-	// Helper to clear directories
+	// Helper to clear directories.
+	//
+	// The containment check is not defensive programming for its own sake: this
+	// helper deleted the real ~/.config twice on 2026-08-21, taking the desktop's
+	// entire configuration with it, because configDir resolved outside tmpDir. A
+	// recursive delete of a path this test did not create is never correct, so it
+	// fails the test instead of running.
 	reset := func() {
+		t.Helper()
+		if !strings.HasPrefix(configDir, tmpDir+string(os.PathSeparator)) {
+			t.Fatalf("refusing to remove %q: outside the test temp dir %q", configDir, tmpDir)
+		}
 		os.RemoveAll(configDir)
 	}
 


### PR DESCRIPTION
`TestLoadSessionAgent_Fallback` resolves its config directory with `os.UserConfigDir()` and clears it between subtests with `os.RemoveAll`. It tries to redirect that resolution by setting `HOME` to a temp dir, which does not work: on Linux `os.UserConfigDir()` reads `XDG_CONFIG_HOME` first and only falls back to `$HOME/.config` when that variable is unset. Any desktop session that exports `XDG_CONFIG_HOME` — Hyprland and uwsm among them — leaves the test resolving the developer's real `~/.config`, and `reset()` then removes it, once per subtest.

This is not a hypothetical. It fired twice on one machine on 2026-08-21 during an ordinary `go test ./internal/...`, and took roughly a hundred directories with it: the compositor config, the shell's plugin set, the systemd user units together with the `*.target.wants` symlinks carrying their enablement, a running browser's profile, and the credentials directory holding the password for the backup repository that would otherwise have made the whole thing a non-event. The kernel audit record names the actor as `agentmail.test`.

The file's own comments preserve the author reasoning toward the wrong conclusion — *"we can't easily mock it"*, *"WAIT: sessionAgentPath uses os.UserConfigDir() OR HOME/.config"*, *"But we can't redirect it"* — so the fix carries the reason rather than only the corrected line.

Setting `XDG_CONFIG_HOME` alongside `HOME` is the correction. The containment check in `reset()` is the part that matters more, and it is why this is not a one-line diff: a recursive delete of a path the test did not create is never correct, whatever the environment says, and the check converts any reintroduction of the env bug into a failing assertion instead of a wiped home directory.

Verified both ways, with a sentinel directory planted in the real `~/.config`:

- fixed test — passes, `~/.config` entry count unchanged, sentinel intact
- `XDG_CONFIG_HOME` line removed, guard kept — fails with `refusing to remove "/home/gabriel/.config": outside the test temp dir "/mnt/build/go-tmp/TestLoadSessionAgent_Fallback.../001"`, and still deletes nothing

Twenty other test files in this repository call `os.UserConfigDir()` or `os.UserHomeDir()`. None of the others follows it with a recursive delete of the resolved path, so none can destroy data the same way, but several will write into the real config directory under the same misapprehension. That sweep is deliberately not in this PR.


Closes #258.
