### PR TITLE
fix(activity): expose window and stable pane identities

### DIFF
--- a/internal/cli/activity.go
+++ b/internal/cli/activity.go
@@ -240,13 +240,15 @@ type activityResult struct {
 }
 
 type agentInfo struct {
-	Pane       int
-	AgentType  string
-	State      string
-	Confidence float64
-	Velocity   float64
-	Duration   time.Duration
-	StateSince time.Time
+	Pane        int
+	WindowIndex int
+	PaneID      string
+	AgentType   string
+	State       string
+	Confidence  float64
+	Velocity    float64
+	Duration    time.Duration
+	StateSince  time.Time
 }
 
 func collectActivityData(session string, opts activityOptions) (*activityResult, error) {
@@ -284,9 +286,11 @@ func collectActivityData(session string, opts activityOptions) (*activityResult,
 		if err != nil {
 			// Include with unknown state on error
 			result.Agents = append(result.Agents, agentInfo{
-				Pane:      pane.Index,
-				AgentType: agentType,
-				State:     "UNKNOWN",
+				Pane:        pane.Index,
+				WindowIndex: pane.WindowIndex,
+				PaneID:      pane.ID,
+				AgentType:   agentType,
+				State:       "UNKNOWN",
 			})
 			result.Summary["UNKNOWN"]++
 			continue
@@ -299,13 +303,15 @@ func collectActivityData(session string, opts activityOptions) (*activityResult,
 		}
 
 		info := agentInfo{
-			Pane:       pane.Index,
-			AgentType:  agentType,
-			State:      string(activity.State),
-			Confidence: activity.Confidence,
-			Velocity:   activity.Velocity,
-			Duration:   duration,
-			StateSince: activity.StateSince,
+			Pane:        pane.Index,
+			WindowIndex: pane.WindowIndex,
+			PaneID:      pane.ID,
+			AgentType:   agentType,
+			State:       string(activity.State),
+			Confidence:  activity.Confidence,
+			Velocity:    activity.Velocity,
+			Duration:    duration,
+			StateSince:  activity.StateSince,
 		}
 
 		result.Agents = append(result.Agents, info)
@@ -387,13 +393,15 @@ func passesFilter(agentType string, pane tmux.Pane, opts activityOptions, multiW
 
 // activityJSONAgent is one agent row in the --json envelope.
 type activityJSONAgent struct {
-	Pane       int     `json:"pane"`
-	AgentType  string  `json:"agent_type"`
-	State      string  `json:"state"`
-	Confidence float64 `json:"confidence"`
-	Velocity   float64 `json:"velocity"`
-	Duration   string  `json:"duration"`
-	StateSince string  `json:"state_since,omitempty"`
+	Pane        int     `json:"pane"`
+	WindowIndex int     `json:"window_index"`
+	PaneID      string  `json:"pane_id"`
+	AgentType   string  `json:"agent_type"`
+	State       string  `json:"state"`
+	Confidence  float64 `json:"confidence"`
+	Velocity    float64 `json:"velocity"`
+	Duration    string  `json:"duration"`
+	StateSince  string  `json:"state_since,omitempty"`
 }
 
 // activityJSONEnvelope is the --json envelope for `ntm activity`. Watch mode
@@ -411,12 +419,14 @@ func buildActivityJSONEnvelope(result *activityResult) activityJSONEnvelope {
 	agents := make([]activityJSONAgent, len(result.Agents))
 	for i, a := range result.Agents {
 		agents[i] = activityJSONAgent{
-			Pane:       a.Pane,
-			AgentType:  a.AgentType,
-			State:      a.State,
-			Confidence: a.Confidence,
-			Velocity:   a.Velocity,
-			Duration:   formatActivityDuration(a.Duration),
+			Pane:        a.Pane,
+			WindowIndex: a.WindowIndex,
+			PaneID:      a.PaneID,
+			AgentType:   a.AgentType,
+			State:       a.State,
+			Confidence:  a.Confidence,
+			Velocity:    a.Velocity,
+			Duration:    formatActivityDuration(a.Duration),
 		}
 		if !a.StateSince.IsZero() {
 			agents[i].StateSince = a.StateSince.Format(time.RFC3339)
@@ -592,11 +602,13 @@ func renderActivityTUI(result *activityResult, watchMode bool) error {
 		return nil
 	}
 
-	// Build table header
-	header := fmt.Sprintf("%-6s  %-8s  %-12s  %-10s  %s",
-		"Pane", "Agent", "State", "Velocity", "Duration")
+	// Build table header. Win and PaneID disambiguate rows whose per-window
+	// Pane index collides across windows (gs-5wlp) — Pane alone is not a
+	// stable or unique identifier once a session has more than one window.
+	header := fmt.Sprintf("%-4s  %-6s  %-8s  %-8s  %-12s  %-10s  %s",
+		"Win", "Pane", "PaneID", "Agent", "State", "Velocity", "Duration")
 	fmt.Println(headerStyle.Render(header))
-	fmt.Println(mutedStyle.Render(strings.Repeat("─", 55)))
+	fmt.Println(mutedStyle.Render(strings.Repeat("─", 72)))
 
 	// Build table rows
 	for _, agent := range result.Agents {
@@ -613,8 +625,10 @@ func renderActivityTUI(result *activityResult, watchMode bool) error {
 		stateIcon := stateIcon(agent.State)
 		stateStr := stateStyle(agent.State).Render(fmt.Sprintf("%s %s", stateIcon, agent.State))
 
-		row := fmt.Sprintf("%-6d  %s  %-12s  %-10s  %s",
+		row := fmt.Sprintf("%-4d  %-6d  %-8s  %s  %-12s  %-10s  %s",
+			agent.WindowIndex,
 			agent.Pane,
+			agent.PaneID,
 			agentStyle(agent.AgentType).Render(fmt.Sprintf("%-8s", agent.AgentType)),
 			stateStr,
 			velocityStr,

--- a/internal/cli/activity_collision_test.go
+++ b/internal/cli/activity_collision_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Dicklesworthstone/ntm/internal/tmux"
+	"github.com/Dicklesworthstone/ntm/tests/testutil"
+)
+
+// newActivityCollisionTestSession builds a two-window session where each
+// window's sole pane is index 1 — the exact topology gs-5wlp reports:
+// `ntm activity` prints two rows both labelled "pane 1" with no way to tell
+// them apart.
+func newActivityCollisionTestSession(t *testing.T) string {
+	t.Helper()
+	testutil.RequireTmuxThrottled(t)
+
+	session := fmt.Sprintf("ntm_test_activity_collision_%d", time.Now().UnixNano())
+	dir := t.TempDir()
+	if err := tmux.CreateSession(session, dir); err != nil {
+		t.Fatalf("create test session: %v", err)
+	}
+	t.Cleanup(func() { _ = tmux.KillSession(session) })
+
+	initial, err := tmux.GetPanes(session)
+	if err != nil || len(initial) != 1 {
+		t.Fatalf("initial panes = %d, err = %v; want one pane", len(initial), err)
+	}
+	if _, err := tmux.DefaultClient.Run("select-pane", "-t", initial[0].ID, "-T", session+"__cc_1"); err != nil {
+		t.Fatalf("title window1 pane1: %v", err)
+	}
+
+	if _, err := tmux.DefaultClient.Run("new-window", "-d", "-t", session, "-c", dir); err != nil {
+		t.Fatalf("create second window: %v", err)
+	}
+
+	afterWindow, err := tmux.GetPanes(session)
+	if err != nil {
+		t.Fatalf("get panes after new window: %v", err)
+	}
+	var secondWindowPaneID string
+	for _, p := range afterWindow {
+		if p.WindowIndex != initial[0].WindowIndex {
+			secondWindowPaneID = p.ID
+			break
+		}
+	}
+	if secondWindowPaneID == "" {
+		t.Fatalf("second window pane not found in %+v", afterWindow)
+	}
+	if _, err := tmux.DefaultClient.Run("select-pane", "-t", secondWindowPaneID, "-T", session+"__cc_2"); err != nil {
+		t.Fatalf("title window2 pane1: %v", err)
+	}
+
+	// Let tmux settle before the panes are captured for state classification.
+	time.Sleep(150 * time.Millisecond)
+	return session
+}
+
+// TestCollectActivityData_DisambiguatesCollidingPaneIndexAcrossWindows is the
+// hostile collision regression for gs-5wlp: two panes that share the same
+// per-window index (both "pane 1" of their own window) must still resolve to
+// two distinct, identifiable agent rows in both the in-memory result and the
+// --json envelope.
+func TestCollectActivityData_DisambiguatesCollidingPaneIndexAcrossWindows(t *testing.T) {
+	session := newActivityCollisionTestSession(t)
+
+	panes, err := tmux.GetPanes(session)
+	if err != nil {
+		t.Fatalf("get panes: %v", err)
+	}
+	if len(panes) != 2 {
+		t.Fatalf("panes = %d, want 2: %+v", len(panes), panes)
+	}
+
+	// Hostile precondition: confirm the collision this test exists to catch is
+	// actually present before asserting anything about the fix.
+	if panes[0].Index != panes[1].Index {
+		t.Fatalf("test precondition failed: panes do not share an index (%d vs %d) — cannot exercise the collision", panes[0].Index, panes[1].Index)
+	}
+	if panes[0].WindowIndex == panes[1].WindowIndex {
+		t.Fatalf("test precondition failed: panes are in the same window")
+	}
+	if panes[0].ID == "" || panes[1].ID == "" || panes[0].ID == panes[1].ID {
+		t.Fatalf("test precondition failed: pane IDs not distinct (%q vs %q)", panes[0].ID, panes[1].ID)
+	}
+
+	result, err := collectActivityData(session, activityOptions{})
+	if err != nil {
+		t.Fatalf("collectActivityData: %v", err)
+	}
+	if len(result.Agents) != 2 {
+		t.Fatalf("agents = %d, want 2: %+v", len(result.Agents), result.Agents)
+	}
+
+	seenPaneIDs := map[string]bool{}
+	seenWindows := map[int]bool{}
+	for _, a := range result.Agents {
+		if a.PaneID == "" {
+			t.Fatalf("agent %+v missing PaneID — cannot disambiguate the colliding rows", a)
+		}
+		if seenPaneIDs[a.PaneID] {
+			t.Fatalf("duplicate PaneID %s across agents: %+v", a.PaneID, result.Agents)
+		}
+		seenPaneIDs[a.PaneID] = true
+		seenWindows[a.WindowIndex] = true
+	}
+	if len(seenPaneIDs) != 2 {
+		t.Fatalf("expected 2 distinct pane IDs, got %v", seenPaneIDs)
+	}
+	if len(seenWindows) != 2 {
+		t.Fatalf("expected agents to retain 2 distinct WindowIndex values, got %v: %+v", seenWindows, result.Agents)
+	}
+
+	// The JSON envelope --- the actual public contract automation reads --- must
+	// carry the same disambiguating fields, not just the in-memory struct.
+	envelope := buildActivityJSONEnvelope(result)
+	if len(envelope.Agents) != 2 {
+		t.Fatalf("envelope agents = %d, want 2: %+v", len(envelope.Agents), envelope.Agents)
+	}
+	jsonSeenPaneIDs := map[string]bool{}
+	for _, a := range envelope.Agents {
+		if a.PaneID == "" {
+			t.Fatalf("envelope agent %+v missing pane_id", a)
+		}
+		if jsonSeenPaneIDs[a.PaneID] {
+			t.Fatalf("duplicate pane_id in JSON envelope: %+v", envelope.Agents)
+		}
+		jsonSeenPaneIDs[a.PaneID] = true
+	}
+
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	if !strings.Contains(string(data), `"pane_id"`) || !strings.Contains(string(data), `"window_index"`) {
+		t.Fatalf("JSON envelope missing disambiguating fields: %s", data)
+	}
+}


### PR DESCRIPTION
## Summary

- add `window_index` and stable tmux `pane_id` to `ntm activity --json`
- show `Win` and `PaneID` in the activity table while retaining the existing `Pane` field
- add a real two-window tmux regression where both panes have the same window-local index

In multi-window sessions, pane indices are local to each window. Two panes can therefore both appear as `Pane 1`, making activity rows ambiguous. The added fields make each row identifiable without changing the existing `pane` field.

## Verification

- `gofmt -l internal/cli/activity.go internal/cli/activity_collision_test.go`
- `go vet ./internal/cli`
- `go test ./internal/cli -run TestCollectActivityData_DisambiguatesCollidingPaneIndexAcrossWindows -count=3`

The full `internal/cli` suite has the same pre-existing unrelated failures on clean upstream and this branch; the focused regression is green.
