### PR TITLE
fix: restore durable Agent Mail assignment flow

### DIFF
--- a/internal/agentmail/client.go
+++ b/internal/agentmail/client.go
@@ -479,11 +479,11 @@ func extractMCPContent(result json.RawMessage) (json.RawMessage, error) {
 			msgLower := strings.ToLower(errMsg)
 			// Detect transient busy errors so callers can retry
 			if strings.Contains(msgLower, "busy") || strings.Contains(msgLower, "temporarily unavailable") {
-				return nil, fmt.Errorf("%w: %s", ErrTransientBusy, errMsg)
+				return nil, &ToolRejectionError{Err: fmt.Errorf("%w: %s", ErrTransientBusy, errMsg)}
 			}
-			return nil, fmt.Errorf("tool error: %s", errMsg)
+			return nil, &ToolRejectionError{Err: fmt.Errorf("tool error: %s", errMsg)}
 		}
-		return nil, fmt.Errorf("tool returned error")
+		return nil, &ToolRejectionError{Err: errors.New("tool returned error")}
 	}
 
 	// Prefer structuredContent (already parsed JSON)

--- a/internal/agentmail/client_test.go
+++ b/internal/agentmail/client_test.go
@@ -898,6 +898,19 @@ func TestExtractMCPContent(t *testing.T) {
 	}
 }
 
+func TestExtractMCPContentTypesToolRejection(t *testing.T) {
+	_, err := extractMCPContent(json.RawMessage(`{
+		"content": [{"type": "text", "text": "Agent 'NTM-Coordinator' not found"}],
+		"isError": true
+	}`))
+	if err == nil || !IsToolRejection(err) {
+		t.Fatalf("extractMCPContent error=%v, want typed tool rejection", err)
+	}
+	if IsServerUnavailable(err) || IsTimeout(err) {
+		t.Fatalf("tool rejection was misclassified as ambiguous transport failure: %v", err)
+	}
+}
+
 func TestCallToolWithMCPEnvelope(t *testing.T) {
 	// Mock server that returns MCP envelope format
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/agentmail/errors.go
+++ b/internal/agentmail/errors.go
@@ -52,6 +52,37 @@ type JSONRPCError struct {
 	Data    interface{} `json:"data,omitempty"`
 }
 
+// ToolRejectionError records a completed MCP response that rejected the tool
+// call. Unlike a transport error or timeout, this proves the server returned a
+// negative result and the requested action did not complete. Callers that keep
+// crash-recovery barriers around external side effects can therefore safely
+// terminalize the attempt instead of leaving it outcome-unknown forever.
+type ToolRejectionError struct {
+	Err error
+}
+
+func (e *ToolRejectionError) Error() string {
+	if e == nil || e.Err == nil {
+		return "agent mail tool rejected the request"
+	}
+	return e.Err.Error()
+}
+
+func (e *ToolRejectionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// IsToolRejection reports whether Agent Mail completed the MCP exchange with
+// an explicit tool-level rejection. It deliberately excludes transport and
+// response-decode failures, whose side-effect outcome remains ambiguous.
+func IsToolRejection(err error) bool {
+	var rejection *ToolRejectionError
+	return errors.As(err, &rejection)
+}
+
 // Error implements the error interface.
 func (e *JSONRPCError) Error() string {
 	if e.Data != nil {

--- a/internal/agentmail/pane_identity.go
+++ b/internal/agentmail/pane_identity.go
@@ -32,6 +32,7 @@ import (
 	"crypto/sha1" //nolint:gosec // Not cryptographic; path namespace only.
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -268,6 +269,23 @@ func readIdentityFile(path string) (string, bool) {
 	trimmed := strings.TrimSpace(string(data))
 	if trimmed == "" {
 		return "", false
+	}
+	// Current mcp-agent-mail writes a structured pane-binding object while
+	// older NTM versions wrote the adjective+noun as plain text. Returning the
+	// raw object here makes that entire JSON blob become the Beads assignee and
+	// claim actor. Decode structured bindings and fail closed on malformed JSON;
+	// a JSON document is never itself a valid Agent Mail name.
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		var binding struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(data, &binding); err != nil {
+			return "", false
+		}
+		trimmed = strings.TrimSpace(binding.Name)
+		if trimmed == "" {
+			return "", false
+		}
 	}
 	return trimmed, true
 }

--- a/internal/agentmail/pane_identity_test.go
+++ b/internal/agentmail/pane_identity_test.go
@@ -114,6 +114,48 @@ func TestWriteIdentityRejectsEmptyName(t *testing.T) {
 	}
 }
 
+func TestResolveIdentityDecodesStructuredPaneBinding(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HOME", tmp)
+
+	projectKey := "/structured/project"
+	paneID := "%31"
+	path := CanonicalIdentityPath(projectKey, paneID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir identity dir: %v", err)
+	}
+	content := `{"schema_version":"am.pane-binding.v1","name":"SnowySparrow","pane_id":"%31"}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write structured identity: %v", err)
+	}
+
+	name, foundPath := ResolveIdentity(projectKey, paneID)
+	if name != "SnowySparrow" || foundPath != path {
+		t.Fatalf("ResolveIdentity = (%q, %q), want (SnowySparrow, %q)", name, foundPath, path)
+	}
+}
+
+func TestResolveIdentityRejectsMalformedStructuredPaneBinding(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HOME", tmp)
+
+	projectKey := "/malformed/project"
+	paneID := "%32"
+	path := CanonicalIdentityPath(projectKey, paneID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir identity dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"name":`), 0o600); err != nil {
+		t.Fatalf("write malformed identity: %v", err)
+	}
+
+	if name, foundPath := ResolveIdentity(projectKey, paneID); name != "" || foundPath != "" {
+		t.Fatalf("malformed JSON became an identity: name=%q path=%q", name, foundPath)
+	}
+}
+
 func TestResolveIdentityIgnoresCanonicalSymlink(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/agentmail/session.go
+++ b/internal/agentmail/session.go
@@ -17,10 +17,11 @@ import (
 
 // SessionAgentInfo tracks the registered agent identity for a session.
 type SessionAgentInfo struct {
-	AgentName    string    `json:"agent_name"`
-	ProjectKey   string    `json:"project_key"`
-	RegisteredAt time.Time `json:"registered_at"`
-	LastActiveAt time.Time `json:"last_active_at"`
+	AgentName         string    `json:"agent_name"`
+	ProjectKey        string    `json:"project_key"`
+	RegistrationToken string    `json:"registration_token,omitempty"`
+	RegisteredAt      time.Time `json:"registered_at"`
+	LastActiveAt      time.Time `json:"last_active_at"`
 }
 
 // sanitizeRegex is precompiled for performance (used by sanitizeSessionName)
@@ -269,12 +270,16 @@ func SaveSessionAgent(sessionName, projectKey string, info *SessionAgentInfo) er
 }
 
 // RegisterSessionAgent registers a session as an agent with Agent Mail.
-// If Agent Mail is unavailable, registration silently fails without blocking.
-// Returns the agent info on success, nil if unavailable, or an error on failure.
+// The required registration calls are also the availability probe: a full
+// health_check is intentionally not used here because its diagnostic snapshot
+// can be slower than ordinary identity operations under load.
+// Returns the agent info on success or an error on failure.
 func (c *Client) RegisterSessionAgent(ctx context.Context, sessionName, workingDir string) (*SessionAgentInfo, error) {
-	// Check if Agent Mail is available
-	if !c.IsAvailable() {
-		return nil, nil // Silently skip if unavailable
+	// Ensure the project first even when local session metadata exists. Agent
+	// Mail may have rebuilt its database from the archive since the last NTM
+	// run, and this required call doubles as the reachability probe.
+	if _, err := c.EnsureProject(ctx, workingDir); err != nil {
+		return nil, fmt.Errorf("ensuring project: %w", err)
 	}
 
 	// Check if already registered
@@ -285,12 +290,12 @@ func (c *Client) RegisterSessionAgent(ctx context.Context, sessionName, workingD
 
 	// If already registered with same project, just update activity
 	if existing != nil && existing.ProjectKey == workingDir && existing.AgentName != "" {
-		existing.LastActiveAt = time.Now()
-		if err := SaveSessionAgent(sessionName, workingDir, existing); err != nil {
-			return nil, err
+		if existing.RegistrationToken != "" {
+			c.SetRegistrationToken(workingDir, existing.AgentName, existing.RegistrationToken)
 		}
+		existing.LastActiveAt = time.Now()
 		// Update activity on server (re-register updates last_active_ts)
-		_, serverErr := c.RegisterAgent(ctx, RegisterAgentOptions{
+		agent, serverErr := c.RegisterAgent(ctx, RegisterAgentOptions{
 			ProjectKey:      workingDir,
 			Program:         "ntm",
 			Model:           "coordinator",
@@ -298,15 +303,15 @@ func (c *Client) RegisterSessionAgent(ctx context.Context, sessionName, workingD
 			TaskDescription: fmt.Sprintf("NTM session coordinator for %s", sessionName),
 		})
 		if serverErr != nil {
-			// Return local state but pass error up so caller can warn
 			return existing, fmt.Errorf("updating server activity: %w", serverErr)
 		}
+		if agent.RegistrationToken != "" {
+			existing.RegistrationToken = agent.RegistrationToken
+		}
+		if err := SaveSessionAgent(sessionName, workingDir, existing); err != nil {
+			return nil, err
+		}
 		return existing, nil
-	}
-
-	// Ensure project exists
-	if _, err := c.EnsureProject(ctx, workingDir); err != nil {
-		return nil, fmt.Errorf("ensuring project: %w", err)
 	}
 
 	// Register the agent. Omit Name so the server auto-generates a valid
@@ -323,10 +328,11 @@ func (c *Client) RegisterSessionAgent(ctx context.Context, sessionName, workingD
 
 	// Save locally
 	info := &SessionAgentInfo{
-		AgentName:    agent.Name,
-		ProjectKey:   workingDir,
-		RegisteredAt: time.Now(),
-		LastActiveAt: time.Now(),
+		AgentName:         agent.Name,
+		ProjectKey:        workingDir,
+		RegistrationToken: agent.RegistrationToken,
+		RegisteredAt:      time.Now(),
+		LastActiveAt:      time.Now(),
 	}
 	if err := SaveSessionAgent(sessionName, workingDir, info); err != nil {
 		return nil, err

--- a/internal/agentmail/session_test.go
+++ b/internal/agentmail/session_test.go
@@ -1,12 +1,46 @@
 package agentmail
 
 import (
+	"context"
 	"encoding/json"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestRegisterSessionAgentUsesRequiredCallsAndPersistsToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	server := httptest.NewServer(mockMCPHandler(t, map[string]func(map[string]interface{}) (interface{}, *JSONRPCError){
+		"ensure_project": func(args map[string]interface{}) (interface{}, *JSONRPCError) {
+			return Project{ID: 7, HumanKey: args["human_key"].(string)}, nil
+		},
+		"register_agent": func(args map[string]interface{}) (interface{}, *JSONRPCError) {
+			return Agent{ID: 8, Name: "WhiteHorse", Program: args["program"].(string), Model: args["model"].(string), RegistrationToken: "session-token"}, nil
+		},
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(WithBaseURL(server.URL + "/"))
+	info, err := client.RegisterSessionAgent(context.Background(), "session-token-test", "/project/token-test")
+	if err != nil {
+		t.Fatalf("RegisterSessionAgent: %v", err)
+	}
+	if info == nil || info.AgentName != "WhiteHorse" || info.RegistrationToken != "session-token" {
+		t.Fatalf("session info = %+v", info)
+	}
+	loaded, err := LoadSessionAgent("session-token-test", "/project/token-test")
+	if err != nil || loaded == nil || loaded.RegistrationToken != "session-token" {
+		t.Fatalf("persisted session info = %+v, error=%v", loaded, err)
+	}
+	if token := client.RegistrationToken("/project/token-test", "WhiteHorse"); token != "session-token" {
+		t.Fatalf("client token = %q, want session-token", token)
+	}
+}
 
 func TestSanitizeSessionName(t *testing.T) {
 	tests := []struct {

--- a/internal/assignment/atomic.go
+++ b/internal/assignment/atomic.go
@@ -1034,7 +1034,7 @@ func (c *AtomicCoordinator) releaseWorkingReplacementWithOperationLocks(ctx cont
 	}
 
 	if current.ClearState == ClearStateNone {
-		clearing, err := c.store.beginClearWithOperationLock(req.BeadID, c.now(), []AssignmentStatus{StatusWorking})
+		clearing, err := c.store.beginClearWithOperationLock(req.BeadID, c.now(), false, []AssignmentStatus{StatusWorking})
 		if err != nil {
 			return receipt, c.store.Get(req.BeadID), err
 		}

--- a/internal/assignment/store.go
+++ b/internal/assignment/store.go
@@ -1174,7 +1174,16 @@ func (s *AssignmentStore) ListActive() []*Assignment {
 // release. The barrier retains exact reservation IDs and blocks new assignment
 // generations until CompleteClear removes the record.
 func (s *AssignmentStore) BeginClear(ctx context.Context, beadID string, startedAt time.Time) (*Assignment, error) {
-	return s.beginClear(ctx, beadID, startedAt, nil)
+	return s.beginClear(ctx, beadID, startedAt, false, nil)
+}
+
+// BeginClearForce establishes the clear barrier even when dispatch is stuck
+// at the outcome-unknown sending boundary. This is an explicit operator escape
+// hatch: the original delivery may have happened, but its durable claim and
+// leases can still be released so the bead and pane do not remain occupied
+// forever.
+func (s *AssignmentStore) BeginClearForce(ctx context.Context, beadID string, startedAt time.Time) (*Assignment, error) {
+	return s.beginClear(ctx, beadID, startedAt, true, nil)
 }
 
 // BeginClearIfStatus establishes the clear barrier only if the status still
@@ -1185,7 +1194,15 @@ func (s *AssignmentStore) BeginClearIfStatus(ctx context.Context, beadID string,
 	if len(expected) == 0 {
 		return nil, errors.New("at least one expected assignment status is required")
 	}
-	return s.beginClear(ctx, beadID, startedAt, expected)
+	return s.beginClear(ctx, beadID, startedAt, false, expected)
+}
+
+// BeginClearForceIfStatus is the status-guarded variant of BeginClearForce.
+func (s *AssignmentStore) BeginClearForceIfStatus(ctx context.Context, beadID string, startedAt time.Time, expected ...AssignmentStatus) (*Assignment, error) {
+	if len(expected) == 0 {
+		return nil, errors.New("at least one expected assignment status is required")
+	}
+	return s.beginClear(ctx, beadID, startedAt, true, expected)
 }
 
 // BeginTerminalReconciliationIfCurrent durably records the desired terminal
@@ -1311,7 +1328,7 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 	return cloneAssignment(current), true, nil
 }
 
-func (s *AssignmentStore) beginClear(ctx context.Context, beadID string, startedAt time.Time, expected []AssignmentStatus) (*Assignment, error) {
+func (s *AssignmentStore) beginClear(ctx context.Context, beadID string, startedAt time.Time, forceOutcomeUnknown bool, expected []AssignmentStatus) (*Assignment, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -1323,13 +1340,13 @@ func (s *AssignmentStore) beginClear(ctx context.Context, beadID string, started
 	if err := s.LoadStrict(); err != nil {
 		return nil, fmt.Errorf("refresh assignment clear %s: %w", beadID, err)
 	}
-	return s.beginClearWithOperationLock(beadID, startedAt, expected)
+	return s.beginClearWithOperationLock(beadID, startedAt, forceOutcomeUnknown, expected)
 }
 
 // beginClearWithOperationLock mutates clear state while the caller owns the
 // bead operation lock and has refreshed the store. Atomic replacement uses it
 // to avoid recursively acquiring the same cross-process lock.
-func (s *AssignmentStore) beginClearWithOperationLock(beadID string, startedAt time.Time, expected []AssignmentStatus) (*Assignment, error) {
+func (s *AssignmentStore) beginClearWithOperationLock(beadID string, startedAt time.Time, forceOutcomeUnknown bool, expected []AssignmentStatus) (*Assignment, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	assignment := s.Assignments[beadID]
@@ -1339,7 +1356,7 @@ func (s *AssignmentStore) beginClearWithOperationLock(beadID string, startedAt t
 	if len(expected) > 0 && !assignmentStatusAllowed(assignment.Status, expected) {
 		return nil, fmt.Errorf("%w: %s is %s, expected %s", ErrAssignmentStatusMismatch, beadID, assignment.Status, formatAssignmentStatuses(expected))
 	}
-	if assignment.DispatchState == DispatchSending {
+	if assignment.DispatchState == DispatchSending && !forceOutcomeUnknown {
 		return nil, fmt.Errorf("%w: cannot clear %s while dispatch outcome is unknown", ErrDispatchOutcomeUnknown, beadID)
 	}
 	if strings.TrimSpace(assignment.PendingCompletionEventID) != "" {
@@ -1352,6 +1369,10 @@ func (s *AssignmentStore) beginClearWithOperationLock(beadID string, startedAt t
 		startedAt = time.Now().UTC()
 	}
 	previous := cloneAssignment(assignment)
+	if assignment.DispatchState == DispatchSending {
+		assignment.DispatchState = DispatchPending
+		assignment.LastDispatchError = "force-cleared after dispatch outcome became unknown"
+	}
 	assignment.ClearState = ClearStateReservationReleasing
 	assignment.ClearStartedAt = &startedAt
 	assignment.ClearError = ""

--- a/internal/assignment/store_test.go
+++ b/internal/assignment/store_test.go
@@ -2487,6 +2487,15 @@ func TestAssignmentClearRejectsUnknownDispatchOutcome(t *testing.T) {
 	if stored == nil || stored.ClearState != ClearStateNone || stored.DispatchState != DispatchSending || stored.DispatchAttempts != 1 {
 		t.Fatalf("rejected clear mutated dispatch barrier: %+v", stored)
 	}
+
+	forced, err := store.BeginClearForce(t.Context(), beadID, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("BeginClearForce: %v", err)
+	}
+	if forced.ClearState != ClearStateReservationReleasing || forced.DispatchState != DispatchPending ||
+		!strings.Contains(forced.LastDispatchError, "force-cleared") {
+		t.Fatalf("forced clear did not terminalize unknown dispatch: %+v", forced)
+	}
 }
 
 func TestBeginClearIfStatusRejectsConcurrentLifecycleChange(t *testing.T) {

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -322,7 +322,7 @@ Examples:
 
 	// Direct pane assignment flags
 	cmd.Flags().StringVar(&assignPane, "pane", "", "Assign bead directly to exactly one N, W.P, or %N pane selector (requires --beads)")
-	cmd.Flags().BoolVar(&assignForce, "force", false, "Force assignment even if pane is busy (also allows --clear to remove completed assignments)")
+	cmd.Flags().BoolVar(&assignForce, "force", false, "Force assignment even if pane is busy (also lets --clear remove completed or outcome-unknown assignments)")
 	cmd.Flags().BoolVar(&assignIgnoreDeps, "ignore-deps", false, "Ignore dependency checks for assignment")
 	cmd.Flags().StringVar(&assignPrompt, "prompt", "", "Custom prompt for direct assignment")
 
@@ -3832,9 +3832,14 @@ func clearStoredAssignmentIfStatus(ctx context.Context, store *assignment.Assign
 	}
 	current = refreshed
 	var clearing *assignment.Assignment
-	if len(expected) == 0 {
+	switch {
+	case assignForce && len(expected) == 0:
+		clearing, err = store.BeginClearForce(ctx, current.BeadID, time.Now().UTC())
+	case assignForce:
+		clearing, err = store.BeginClearForceIfStatus(ctx, current.BeadID, time.Now().UTC(), expected...)
+	case len(expected) == 0:
 		clearing, err = store.BeginClear(ctx, current.BeadID, time.Now().UTC())
-	} else {
+	default:
 		clearing, err = store.BeginClearIfStatus(ctx, current.BeadID, time.Now().UTC(), expected...)
 	}
 	if err != nil {

--- a/internal/cli/assign_clear_test.go
+++ b/internal/cli/assign_clear_test.go
@@ -550,6 +550,60 @@ func TestRunClearFailedAssignmentsClearsOnlyFailedRows(t *testing.T) {
 	}
 }
 
+func TestRunClearForceReleasesUnknownDispatchOutcome(t *testing.T) {
+	isolateSessionAgentStorage(t)
+	const (
+		session = "clear-force-unknown-dispatch"
+		beadID  = "ntm-clear-force-unknown"
+	)
+	store := assignment.NewStore(session)
+	request := assignment.AtomicRequest{
+		BeadID: beadID, BeadTitle: "Unknown delivery", Target: "%77", OccupancyKey: "%77", Pane: 1,
+		AgentType: "codex", AgentName: "BlueLake", Actor: "BlueLake", Prompt: "work", IdempotencyKey: "unknown-delivery-key",
+	}
+	if _, err := store.RecordAtomicIntent(request, assignment.StableClaimActor(request.Actor, request.IdempotencyKey), time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicIntent: %v", err)
+	}
+	if err := store.RecordAtomicDispatchStarted(beadID, request.IdempotencyKey, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicDispatchStarted: %v", err)
+	}
+	// This fixture has no external claim; the test is specifically about the
+	// force-clear dispatch barrier and local occupancy release.
+	store.Assignments[beadID].ClaimActor = ""
+	if err := store.Save(); err != nil {
+		t.Fatalf("save unknown dispatch fixture: %v", err)
+	}
+
+	previousJSON := jsonOutput
+	previousForce := assignForce
+	previousRelease := releaseAssignmentLeases
+	t.Cleanup(func() {
+		jsonOutput = previousJSON
+		assignForce = previousForce
+		releaseAssignmentLeases = previousRelease
+	})
+	jsonOutput = true
+	assignForce = true
+	releaseCalls := 0
+	releaseAssignmentLeases = func(_ context.Context, _ string, current *assignment.Assignment) ([]string, error) {
+		releaseCalls++
+		if current.DispatchState != assignment.DispatchPending || current.ClearState != assignment.ClearStateReservationReleasing {
+			t.Fatalf("force clear did not terminalize before release: %+v", current)
+		}
+		return nil, nil
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runClearSelectedAssignmentsFromStore(&cobra.Command{}, store, session, []string{beadID}, "clear")
+	})
+	if err != nil {
+		t.Fatalf("force clear unknown dispatch: %v\noutput=%s", err, output)
+	}
+	if releaseCalls != 1 || store.Get(beadID) != nil {
+		t.Fatalf("force clear release calls=%d remaining=%+v", releaseCalls, store.Get(beadID))
+	}
+}
+
 func TestRunClearSelectedAssignmentsCanceledJSONIsTimeoutWithoutMutation(t *testing.T) {
 	isolateSessionAgentStorage(t)
 	const (

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -14,12 +14,38 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Dicklesworthstone/ntm/internal/agentmail"
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	"github.com/Dicklesworthstone/ntm/internal/coordinator"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 	"github.com/Dicklesworthstone/ntm/internal/tui/theme"
 )
+
+func existingCoordinatorAgentName(session, projectKey string) string {
+	info, err := agentmail.LoadBestSessionAgent(session, projectKey)
+	if err != nil || info == nil {
+		return ""
+	}
+	return strings.TrimSpace(info.AgentName)
+}
+
+func registerCoordinatorAgent(ctx context.Context, client *agentmail.Client, session, projectKey string) (string, error) {
+	if ctx == nil {
+		return "", errors.New("coordinator Agent Mail registration requires a command context")
+	}
+	if client == nil {
+		return "", errors.New("coordinator Agent Mail client is not configured")
+	}
+	info, err := client.RegisterSessionAgent(ctx, session, projectKey)
+	if err != nil {
+		return "", fmt.Errorf("register coordinator Agent Mail identity: %w", err)
+	}
+	if info == nil || strings.TrimSpace(info.AgentName) == "" {
+		return "", errors.New("register coordinator Agent Mail identity: server returned no agent name")
+	}
+	return strings.TrimSpace(info.AgentName), nil
+}
 
 var (
 	coordinatorSessionExists  = tmux.SessionExists
@@ -122,7 +148,7 @@ func runCoordinatorStatus(cmd *cobra.Command, args []string) error {
 
 	// Create coordinator to get status without enabling configured side effects.
 	mailClient := newAgentMailClient(projectKey)
-	coord := coordinator.New(session, projectKey, mailClient, "NTM-Coordinator").WithConfig(runtimeConfig)
+	coord := coordinator.New(session, projectKey, mailClient, existingCoordinatorAgentName(session, projectKey)).WithConfig(runtimeConfig)
 
 	// Get agent states
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -323,10 +349,16 @@ func runCoordinatorDigest(cmd *cobra.Command, args []string, sendMail bool) erro
 	// Digest is a read-only surface: never let its brief coordinator run
 	// enqueue context rotations (bd-rpmg8).
 	runtimeConfig.RotationUsageThreshold = 0
-	coord := coordinator.New(session, projectKey, mailClient, "NTM-Coordinator").WithConfig(runtimeConfig)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+	agentName := existingCoordinatorAgentName(session, projectKey)
+	if sendMail {
+		agentName, err = registerCoordinatorAgent(ctx, mailClient, session, projectKey)
+		if err != nil {
+			return err
+		}
+	}
+	coord := coordinator.New(session, projectKey, mailClient, agentName).WithConfig(runtimeConfig)
 
 	if err := coord.Start(ctx); err != nil {
 		return fmt.Errorf("starting coordinator: %w", err)
@@ -408,7 +440,14 @@ func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
 	}
 
 	runtimeConfig, ntmConfig := loadCoordinatorRuntimeConfigWithNTM()
-	coord := coordinator.New(session, projectKey, newAgentMailClient(projectKey), "NTM-Coordinator").
+	mailClient := newAgentMailClient(projectKey)
+	registrationCtx, registrationCancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+	agentName, registrationErr := registerCoordinatorAgent(registrationCtx, mailClient, session, projectKey)
+	registrationCancel()
+	if registrationErr != nil {
+		return registrationErr
+	}
+	coord := coordinator.New(session, projectKey, mailClient, agentName).
 		WithConfig(runtimeConfig).
 		WithNTMConfig(ntmConfig)
 	if once {

--- a/internal/cli/spawn.go
+++ b/internal/cli/spawn.go
@@ -4373,17 +4373,15 @@ func (c *spawnIdentityCoordinator) ensureInit(parentCtx context.Context) {
 	}
 	c.client = agentmail.NewClient(opts...)
 
-	// Check availability first (uses cached result)
-	if !c.client.IsAvailable() {
-		c.status = &output.AgentMailSpawnStatus{
-			Available:         false,
-			ProjectRegistered: false,
-		}
-		return
-	}
-	c.available = true
+	// Do not gate spawn registration on the full MCP health_check. That probe
+	// has a deliberately small global availability budget, while a healthy
+	// Agent Mail server may need longer to assemble its diagnostic snapshot
+	// under database pressure. ensure_project below is the operation spawn
+	// actually needs and is also a sufficient reachability check. Treat its
+	// response as authoritative so a slow health report cannot suppress every
+	// identity and leave agent_registry.json absent.
 	c.status = &output.AgentMailSpawnStatus{
-		Available: true,
+		Available: false,
 		AgentMap:  make(map[string]string),
 	}
 
@@ -4396,7 +4394,7 @@ func (c *spawnIdentityCoordinator) ensureInit(parentCtx context.Context) {
 	c.observeLivePanes(parentCtx)
 
 	// Ensure project exists
-	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(parentCtx, 15*time.Second)
 	defer cancel()
 	if _, err := c.client.EnsureProject(ctx, c.workingDir); err != nil {
 		if !IsJSONOutput() {
@@ -4404,6 +4402,8 @@ func (c *spawnIdentityCoordinator) ensureInit(parentCtx context.Context) {
 		}
 		return
 	}
+	c.available = true
+	c.status.Available = true
 	c.projectOK = true
 	c.status.ProjectRegistered = true
 }

--- a/internal/cli/spawn_identity_order_test.go
+++ b/internal/cli/spawn_identity_order_test.go
@@ -241,6 +241,9 @@ func TestSpawnIdentityCoordinator_PublishesIdentityAtPrepareTime(t *testing.T) {
 	// The server must have been asked to create exactly one identity.
 	creates := 0
 	for _, tool := range calledTools() {
+		if tool == "health_check" {
+			t.Fatal("spawn identity registration must not be gated on the slower diagnostic health_check")
+		}
 		if tool == "create_agent_identity" || tool == "register_agent" {
 			creates++
 		}

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -1035,7 +1035,12 @@ func (c *SessionCoordinator) newAtomicAssignmentCoordinator(store *assignmentsto
 		})
 		receipt := assignmentstore.DispatchReceipt{Duration: time.Since(started)}
 		if err != nil {
-			return receipt, err
+			// An MCP tool-level rejection is a completed negative response: the
+			// server did not send a message. Mark it as no-actuation so the
+			// atomic ledger returns to pending instead of stranding the pane and
+			// bead behind a permanent dispatch_state="sending" barrier. Network
+			// timeouts and malformed success responses remain outcome-unknown.
+			return receipt, coordinatorMailDispatchError(err)
 		}
 		deliveryID, receiptErr := validatedAgentMailDeliveryID(
 			sent, c.projectKey, projectID, c.agentName, req.AgentName, subject, req.Prompt,
@@ -1137,6 +1142,13 @@ func (c *SessionCoordinator) newAtomicAssignmentCoordinator(store *assignmentsto
 			},
 		)).
 		WithWorkingReplacementAuthorizationPort(replacementAuthorization)
+}
+
+func coordinatorMailDispatchError(err error) error {
+	if err != nil && agentmail.IsToolRejection(err) {
+		return assignmentstore.GuaranteeNoActuation(err)
+	}
+	return err
 }
 
 func validatedAgentMailDeliveryID(sent *agentmail.SendResult, projectKey string, projectID int, senderName, agentName, subject, body string) (string, error) {

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -119,6 +119,18 @@ func TestWorkAssignmentStruct(t *testing.T) {
 	}
 }
 
+func TestCoordinatorMailDispatchErrorTerminalizesServerRejectionOnly(t *testing.T) {
+	rejection := &agentmail.ToolRejectionError{Err: errors.New("sender is not registered")}
+	if got := coordinatorMailDispatchError(rejection); !assignmentstore.IsGuaranteedNoActuation(got) {
+		t.Fatalf("server rejection remained outcome-unknown: %v", got)
+	}
+
+	timeout := agentmail.NewAPIError("send_message", 0, agentmail.ErrTimeout)
+	if got := coordinatorMailDispatchError(timeout); assignmentstore.IsGuaranteedNoActuation(got) || !errors.Is(got, agentmail.ErrTimeout) {
+		t.Fatalf("ambiguous timeout was terminalized: %v", got)
+	}
+}
+
 func TestAssignmentResultStruct(t *testing.T) {
 	ar := AssignmentResult{
 		Success:      true,


### PR DESCRIPTION
## Summary

- let spawn prove Agent Mail availability through ensure_project instead of the slower diagnostic health_check, so healthy loaded servers still produce pane identities and agent_registry.json
- register and reuse the session coordinator server-generated identity instead of the invalid hard-coded NTM-Coordinator sender; persist its registration token
- classify explicit MCP tool rejections as known no-actuation failures so atomic assignment returns from sending to pending, while keeping timeouts outcome-unknown
- support assign --clear --force for intentionally releasing outcome-unknown dispatches
- decode structured pane-binding identity files to their name field instead of using the full JSON object as a Beads assignee

## Verification

- go build ./cmd/ntm
- focused changed-path tests across internal/agentmail, internal/assignment, internal/coordinator, and internal/cli
- go test ./internal/agentmail ./internal/assignment ./internal/coordinator (pass)
- go test -short ./...: all changed packages pass, including internal/cli; one unrelated pre-existing failure in internal/bv TestGetTriage because its fixture reported zero issues
- gofmt -l . clean

The non-short internal/cli suite also reached only unrelated tmux fixture failures where test agent commands exited immediately to bare zsh/sh.