### PR TITLE
fix(coordinator): give Grok panes mail-nudge parity

### DIFF
--- a/internal/coordinator/mail_nudge_test.go
+++ b/internal/coordinator/mail_nudge_test.go
@@ -208,6 +208,76 @@ func TestMailNudgeWorkingPaneSkippedAndPublished(t *testing.T) {
 	}
 }
 
+// TestMailNudgeGrokIdlePaneDispatched proves Grok Build panes use their
+// landed live-state detector instead of being rejected as an unsupported
+// agent type. The empty bordered composer is the idle state observed in a
+// real Grok TUI capture.
+func TestMailNudgeGrokIdlePaneDispatched(t *testing.T) {
+	server := newMailInboxServer(t, map[string][]map[string]interface{}{
+		"CalmBison": {unreadMessage(1)},
+	})
+	defer server.Close()
+
+	panes := []tmux.Pane{{ID: "%3", Title: "mailsess__grok_1", Type: tmux.AgentGrok, Width: 120}}
+	env := newMailNudgeTestEnv(t, server.URL, panes,
+		map[string]string{"mailsess__grok_1": "CalmBison"},
+		func(string) (string, error) {
+			return "│ ❯                                      │\n─ Grok 4.6 (high) · always-approve ─╯\n", nil
+		})
+
+	decisions := env.mc.runOnce(t.Context())
+	if len(decisions) != 1 || decisions[0].Action != "nudged" || decisions[0].SkipReason != "" {
+		t.Fatalf("decisions = %+v, want one Grok nudge", decisions)
+	}
+	if len(env.dispatch) != 1 || env.dispatch[0] != "%3" {
+		t.Fatalf("dispatched panes = %v, want [%%3]", env.dispatch)
+	}
+}
+
+// TestMailNudgeGrokWorkingAndHeldInputSkipped covers both safety vetoes that
+// make autonomous Grok nudging safe: an in-flight spinner and text already in
+// the bordered composer. Neither capture may receive another prompt.
+func TestMailNudgeGrokWorkingAndHeldInputSkipped(t *testing.T) {
+	tests := []struct {
+		name       string
+		capture    string
+		wantReason string
+	}{
+		{
+			name:       "working",
+			capture:    "⠹ Waiting for response… 0.7s [stop]\n│ ❯                 │\nShift+Tab:mode │ Esc:cancel │ Ctrl+x:shortcuts\n",
+			wantReason: "working",
+		},
+		{
+			name:       "held input",
+			capture:    "│ ❯ finish the previous request           │\n─ Grok 4.6 (high) · always-approve ─╯\n",
+			wantReason: "unsubmitted_input",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newMailInboxServer(t, map[string][]map[string]interface{}{
+				"CalmBison": {unreadMessage(1)},
+			})
+			defer server.Close()
+
+			panes := []tmux.Pane{{ID: "%3", Title: "mailsess__grok_1", Type: tmux.AgentGrok, Width: 120}}
+			env := newMailNudgeTestEnv(t, server.URL, panes,
+				map[string]string{"mailsess__grok_1": "CalmBison"},
+				func(string) (string, error) { return tc.capture, nil })
+
+			decisions := env.mc.runOnce(t.Context())
+			if len(decisions) != 1 || decisions[0].Action != "skipped" || decisions[0].SkipReason != tc.wantReason {
+				t.Fatalf("decisions = %+v, want one skipped/%s", decisions, tc.wantReason)
+			}
+			if len(env.dispatch) != 0 {
+				t.Fatalf("Grok pane was dispatched to despite %s: %v", tc.wantReason, env.dispatch)
+			}
+		})
+	}
+}
+
 // TestMailNudgeFailsClosedForUnsupportedAgentTypes: agent types without a
 // working detector are refused outright.
 func TestMailNudgeFailsClosedForUnsupportedAgentTypes(t *testing.T) {

--- a/internal/coordinator/rotation.go
+++ b/internal/coordinator/rotation.go
@@ -419,9 +419,13 @@ func rotationEvidence(d rotationDecision) string {
 //  4. unsubmitted_input  — the composer holds typed-but-unsent text
 //  5. queued_messages    — the TUI reports queued unsubmitted messages
 //
-// Only Claude Code and Codex panes can reach this point (they are the only
-// agent types with known transcript locations); any other type is refused
-// outright because the automated rotation path does not support it.
+// The caller decides whether an agent supports the requested automation.
+// This shared fire-time gate admits only agent types with authoritative live
+// working detectors; every other type is refused rather than typed into while
+// its state is unknown. Context rotation currently reaches this gate only for
+// Claude Code and Codex because those are the types with known transcript
+// locations. Mail nudge can also reach it for Grok Build, whose TUI detector
+// and composer inspection are independent of transcript discovery.
 func rotationSafetySkipReason(captured string, pane tmux.Pane) string {
 	canonical := pane.Type.Canonical()
 	switch canonical {
@@ -431,6 +435,10 @@ func rotationSafetySkipReason(captured string, pane tmux.Pane) string {
 		}
 	case agent.AgentTypeCodex:
 		if agent.CodexActivelyWorking(captured, pane.Width) {
+			return "working"
+		}
+	case agent.AgentTypeGrok:
+		if agent.GrokActivelyWorking(captured, pane.Width) {
 			return "working"
 		}
 	default:


### PR DESCRIPTION
Adds Grok to `rotationSafetySkipReason` so Grok panes get idle-detection and mail-nudge parity through the existing `GrokActivelyWorking` detector. Unknown agent types still fail closed with `unsupported_agent_type`.

Behavioral coverage proves:
- an idle Grok pane with unread Agent Mail is nudged;
- an in-flight Grok spinner / `Esc:cancel` frame is skipped as `working`;
- text already held in the Grok composer is skipped as `unsubmitted_input`.

Verification:
- `go build ./cmd/ntm`
- `go test ./internal/coordinator -count=1`
- focused Grok mail-nudge tests

Tracking: agent-factory-ssrq.