### PR TITLE
fix: use configured Agent Mail client and guard stale panes

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3215,6 +3215,7 @@ Shell Integration:
 		// Robot-mail-check handler for Agent Mail inbox (bd-adgv)
 		if robotMailCheck {
 			opts := robot.MailCheckOptions{
+				Client:        newAgentMailClient(mailProject),
 				Project:       mailProject,
 				Agent:         mailAgent,
 				Thread:        mailThread,

--- a/internal/resilience/monitor.go
+++ b/internal/resilience/monitor.go
@@ -29,7 +29,21 @@ var (
 	checkSessionFn   = health.CheckSession
 	displayMessageFn = tmux.DisplayMessage
 	isChildAliveFn   = process.IsChildAlive
+	paneExistsFn     = paneExistsInSession
 )
+
+func paneExistsInSession(session, paneID string) (bool, error) {
+	panes, err := tmux.GetPanes(session)
+	if err != nil {
+		return false, err
+	}
+	for _, pane := range panes {
+		if pane.ID == paneID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // AgentState tracks the state of an individual agent for restart purposes
 type AgentState struct {
@@ -803,6 +817,7 @@ func (m *Monitor) restartAgent(ctx context.Context, agent *AgentState) {
 	buildFunc := buildPaneCmdFn
 	sendFunc := sendKeysFn
 	isChildAliveFunc := isChildAliveFn
+	paneExists := paneExistsFn
 	hooksMu.RUnlock()
 
 	select {
@@ -842,6 +857,22 @@ func (m *Monitor) restartAgent(ctx context.Context, agent *AgentState) {
 		if a, ok := m.agents[agent.PaneID]; ok {
 			a.Healthy = true
 		}
+		m.mu.Unlock()
+		return
+	}
+
+	// A manifest can outlive a pane after tmux topology changes. Never remap by
+	// index: a replacement pane may belong to another agent. Retire the stale
+	// runtime binding and fail closed before any keys are injected.
+	exists, err := paneExists(m.session, agent.PaneID)
+	if err != nil || !exists {
+		if err != nil {
+			log.Printf("[resilience] Stale pane binding %s: cannot verify membership in session %s: %v", agent.PaneID, m.session, err)
+		} else {
+			log.Printf("[resilience] Stale pane binding %s is not present in session %s; skipping restart", agent.PaneID, m.session)
+		}
+		m.mu.Lock()
+		delete(m.agents, agent.PaneID)
 		m.mu.Unlock()
 		return
 	}

--- a/internal/resilience/monitor_test.go
+++ b/internal/resilience/monitor_test.go
@@ -22,6 +22,8 @@ func saveHooks() func() {
 	origCheckSession := checkSessionFn
 	origDisplayMessage := displayMessageFn
 	origIsChildAlive := isChildAliveFn
+	origPaneExists := paneExistsFn
+	paneExistsFn = func(string, string) (bool, error) { return true, nil }
 	hooksMu.Unlock()
 
 	return func() {
@@ -32,7 +34,43 @@ func saveHooks() func() {
 		checkSessionFn = origCheckSession
 		displayMessageFn = origDisplayMessage
 		isChildAliveFn = origIsChildAlive
+		paneExistsFn = origPaneExists
 		hooksMu.Unlock()
+	}
+}
+
+func TestRestartAgentRetiresStalePaneWithoutSendingKeys(t *testing.T) {
+	restore := saveHooks()
+	defer restore()
+
+	sendCalls := 0
+	setHooksLocked(func() {
+		paneExistsFn = func(string, string) (bool, error) { return false, nil }
+		sendKeysFn = func(string, string, bool) error {
+			sendCalls++
+			return nil
+		}
+		buildPaneCmdFn = func(string, string) (string, error) { return "codex", nil }
+	})
+
+	cfg := config.Default()
+	cfg.Resilience.RestartDelaySeconds = 0
+	m := NewMonitor("test-session", "/tmp/project", cfg, true)
+	m.RegisterAgent("%404", 4, 0, "cod", "gpt-5", "codex")
+	m.mu.Lock()
+	m.agents["%404"].Healthy = false
+	m.mu.Unlock()
+
+	m.restartAgent(context.Background(), m.agents["%404"])
+
+	if sendCalls != 0 {
+		t.Fatalf("sendKeys calls = %d, want 0 for stale pane", sendCalls)
+	}
+	m.mu.RLock()
+	_, retained := m.agents["%404"]
+	m.mu.RUnlock()
+	if retained {
+		t.Fatal("stale pane binding remained registered after failed membership check")
 	}
 }
 

--- a/internal/robot/mail_check.go
+++ b/internal/robot/mail_check.go
@@ -68,6 +68,10 @@ type MailCheckAgentHints struct {
 
 // MailCheckOptions configures the GetMailCheck operation
 type MailCheckOptions struct {
+	// Client is the configured Agent Mail client supplied by the CLI. It is
+	// optional so direct package callers can retain the environment/default
+	// client behavior.
+	Client        *agentmail.Client
 	Project       string
 	Agent         string
 	Thread        string
@@ -298,16 +302,18 @@ func GetMailCheck(opts MailCheckOptions) (*MailCheckOutput, error) {
 		}, nil
 	}
 
-	// Create Agent Mail client
-	client := agentmail.NewClient()
+	client := opts.Client
+	if client == nil {
+		client = agentmail.NewClient()
+	}
 
 	// Check availability
 	if !client.IsAvailable() {
 		return &MailCheckOutput{
 			RobotResponse: NewErrorResponse(
 				fmt.Errorf("Agent Mail not available"),
-				ErrCodeDependencyMissing,
-				"Start Agent Mail server: mcp-agent-mail or ensure it's running",
+				ErrCodeInternalError,
+				"Check the configured Agent Mail URL and bearer token, then retry",
 			),
 			Project:  opts.Project,
 			Messages: []MailCheckMessage{},

--- a/internal/robot/mail_check_test.go
+++ b/internal/robot/mail_check_test.go
@@ -152,6 +152,48 @@ func TestMailCheckOptionsValidate(t *testing.T) {
 	}
 }
 
+func TestGetMailCheckUsesInjectedClientForConfiguredEndpointAndToken(t *testing.T) {
+	const token = "test-public-agent-mail-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("Authorization = %q, want configured bearer token", got)
+		}
+		var req agentmail.JSONRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		params, ok := req.Params.(map[string]interface{})
+		if !ok {
+			t.Fatalf("params type = %T, want map", req.Params)
+		}
+		switch params["name"] {
+		case "health_check":
+			_ = json.NewEncoder(w).Encode(agentmail.JSONRPCResponse{
+				JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`{"status":"ok"}`),
+			})
+		case "fetch_inbox":
+			_ = json.NewEncoder(w).Encode(agentmail.JSONRPCResponse{
+				JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`{"result":[]}`),
+			})
+		default:
+			t.Fatalf("unexpected Agent Mail tool %q", params["name"])
+		}
+	}))
+	defer server.Close()
+
+	output, err := GetMailCheck(MailCheckOptions{
+		Client:  agentmail.NewClient(agentmail.WithBaseURL(server.URL), agentmail.WithToken(token)),
+		Project: "/repos/example/project",
+		Agent:   "BlueLake",
+	})
+	if err != nil {
+		t.Fatalf("GetMailCheck returned error: %v", err)
+	}
+	if !output.Success {
+		t.Fatalf("GetMailCheck success = false, error=%q", output.Error)
+	}
+}
+
 // TestMailCheckOutputJSONSerialization tests that MailCheckOutput serializes correctly.
 func TestMailCheckOutputJSONSerialization(t *testing.T) {
 	// Test that all fields serialize correctly


### PR DESCRIPTION
## Summary

- inject NTM’s configured Agent Mail client into robot mail checks
- report Agent Mail URL/token unavailability as a configuration failure, not a missing dependency
- fail closed on stale tmux pane IDs before restart key injection

## Tests

- `env -u AGENT_MAIL_URL -u AGENT_MAIL_TOKEN go test ./internal/robot -run "^TestGetMailCheckUsesInjectedClientForConfiguredEndpointAndToken$" -count=1`
- `env -u AGENT_MAIL_URL -u AGENT_MAIL_TOKEN go test ./internal/resilience -run "^TestRestartAgentRetiresStalePaneWithoutSendingKeys$" -count=1`
- `env -u AGENT_MAIL_URL -u AGENT_MAIL_TOKEN go test ./internal/agentmail -run "^(TestNewClient|TestBaseURL)$" -count=1`
- `go build ./cmd/ntm`
- `git diff --check origin/main...HEAD`

## Scope

Source-only. No installed binary, live NTM session/config/manifests/panes, or identities changed.