### PR TITLE
fix(agentmail): bind spawned identities to bare pane generation

### DIFF
--- a/internal/agentmail/client.go
+++ b/internal/agentmail/client.go
@@ -534,6 +534,9 @@ func (c *Client) callTool(ctx context.Context, toolName string, args map[string]
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	if paneID, _ := ctx.Value(tmuxPaneContextKey{}).(string); paneID != "" {
+		req.Header.Set("X-Tmux-Pane", paneID)
+	}
 	if c.bearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.bearerToken)
 	}
@@ -579,6 +582,27 @@ func (c *Client) callTool(ctx context.Context, toolName string, args map[string]
 	}
 
 	return content, nil
+}
+
+type tmuxPaneContextKey struct{}
+
+// withTmuxPane binds one Agent Mail request to the bare pane address accepted
+// by the 0.3.31 X-Tmux-Pane contract. Composite session:window:pane labels are
+// provenance, not addresses, and must never reach the server header.
+func withTmuxPane(ctx context.Context, paneID string) (context.Context, error) {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return ctx, nil
+	}
+	if len(paneID) < 2 || paneID[0] != '%' {
+		return nil, fmt.Errorf("tmux pane id %q is not a bare %%N address", paneID)
+	}
+	for _, ch := range paneID[1:] {
+		if ch < '0' || ch > '9' {
+			return nil, fmt.Errorf("tmux pane id %q is not a bare %%N address", paneID)
+		}
+	}
+	return context.WithValue(ctx, tmuxPaneContextKey{}, paneID), nil
 }
 
 // callToolWithTimeout calls a tool with a specific timeout.

--- a/internal/agentmail/pane_identity.go
+++ b/internal/agentmail/pane_identity.go
@@ -8,11 +8,9 @@
 //
 //	~/.config/agent-mail/identity/<sha1(project_key)[:12]>/<sanitized_pane_id>
 //
-// Pane IDs are sanitized the same way the reference implementation sanitizes
-// them: the leading `%` is stripped; ASCII alphanumerics, `-`, and `_` are
-// preserved; `:` is replaced with `-` (so composite keys like
-// `main:0:2` become `main-0-2`); all other characters become `_`. An empty
-// result becomes `unknown`.
+// New writes accept only the upstream address contract: a bare `%N` pane id.
+// The sanitizer still understands composite keys because ResolveIdentity must
+// remain able to read files written by older ntm versions.
 //
 // Reads also check a small set of legacy locations for backwards
 // compatibility with identity files written by older `ntm` versions:
@@ -39,6 +37,19 @@ import (
 	"strings"
 )
 
+// PaneIdentityRecord is the generation receipt written by Agent Mail 0.3.31.
+// A plain-name compatibility file is readable, but it cannot prove that the
+// registering pane is still the holder and is therefore not sufficient for a
+// fresh ntm spawn.
+type PaneIdentityRecord struct {
+	Name        string `json:"name"`
+	SessionName string `json:"session_name"`
+	PaneID      string `json:"pane_id"`
+	PanePID     uint32 `json:"pane_pid"`
+	SocketPath  string `json:"socket_path"`
+	WrittenAt   string `json:"written_at"`
+}
+
 const (
 	// identityDirName is the sub-path under the user's config dir used to
 	// store per-pane identity files.
@@ -63,15 +74,70 @@ func CanonicalIdentityPath(projectKey, paneID string) string {
 // pane. The write is atomic (write-then-rename). Parent directories are
 // created with mode 0o700.
 //
-// A newline is appended to the agent name so the file is easy to read with
-// shell tooling; ResolveIdentity trims whitespace when reading.
+// This helper remains for legacy compatibility writers and tests. Spawned
+// identities use the structured receipt written by Agent Mail itself.
 func WriteIdentity(projectKey, paneID, agentName string) (string, error) {
+	if err := requireBarePaneID(paneID); err != nil {
+		return "", err
+	}
 	trimmed := strings.TrimSpace(agentName)
 	if trimmed == "" {
 		return "", fmt.Errorf("agent name must not be empty")
 	}
 	path := CanonicalIdentityPath(projectKey, paneID)
 	if err := writeIdentityFile(path, trimmed+"\n"); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func requireBarePaneID(paneID string) error {
+	if len(paneID) < 2 || paneID[0] != '%' {
+		return fmt.Errorf("pane id %q is not a bare %%N Agent Mail address", paneID)
+	}
+	for _, ch := range paneID[1:] {
+		if ch < '0' || ch > '9' {
+			return fmt.Errorf("pane id %q is not a bare %%N Agent Mail address", paneID)
+		}
+	}
+	return nil
+}
+
+// ReadVerifiedIdentity reads the server-written generation receipt and checks
+// that it binds the identity returned by registration to the requested pane.
+func ReadVerifiedIdentity(projectKey, paneID, agentName string) (*PaneIdentityRecord, []byte, error) {
+	if err := requireBarePaneID(paneID); err != nil {
+		return nil, nil, err
+	}
+	path := CanonicalIdentityPath(projectKey, paneID)
+	data, err := os.ReadFile(path) //nolint:gosec // canonical project/pane path
+	if err != nil {
+		return nil, nil, fmt.Errorf("read Agent Mail generation receipt %s: %w", path, err)
+	}
+	var record PaneIdentityRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, fmt.Errorf("Agent Mail generation receipt is not structured JSON: %w", err)
+	}
+	if record.Name != strings.TrimSpace(agentName) || record.PaneID != paneID {
+		return nil, nil, fmt.Errorf("Agent Mail generation receipt binds name=%q pane=%q, want name=%q pane=%q", record.Name, record.PaneID, agentName, paneID)
+	}
+	if record.SessionName == "" || record.PanePID == 0 || record.SocketPath == "" || record.WrittenAt == "" {
+		return nil, nil, fmt.Errorf("Agent Mail generation receipt for %s lacks verified-live binding facts", paneID)
+	}
+	return &record, data, nil
+}
+
+// MirrorVerifiedIdentity projects an already-verified receipt into another
+// project-key namespace without re-deriving or weakening its binding facts.
+func MirrorVerifiedIdentity(projectKey, paneID string, receipt []byte) (string, error) {
+	if err := requireBarePaneID(paneID); err != nil {
+		return "", err
+	}
+	if len(receipt) == 0 {
+		return "", fmt.Errorf("cannot mirror an empty Agent Mail generation receipt")
+	}
+	path := CanonicalIdentityPath(projectKey, paneID)
+	if err := writeIdentityFile(path, string(receipt)); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/internal/agentmail/pane_identity_test.go
+++ b/internal/agentmail/pane_identity_test.go
@@ -3,6 +3,7 @@ package agentmail
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,6 +115,51 @@ func TestWriteIdentityRejectsEmptyName(t *testing.T) {
 	}
 }
 
+func TestWriteIdentityRefusesCompositePaneAddress(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	if _, err := WriteIdentity("/p", "main:0:2", "BlueLake"); err == nil {
+		t.Fatal("composite pane address must be refused")
+	}
+}
+
+func TestVerifiedGenerationReceiptAndMirror(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	record := PaneIdentityRecord{Name: "BlueLake", SessionName: "main", PaneID: "%42", PanePID: 123, SocketPath: "/tmp/tmux.sock", WrittenAt: "2026-08-31T00:00:00Z"}
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := CanonicalIdentityPath("/source", "%42")
+	if err := writeIdentityFile(path, string(data)); err != nil {
+		t.Fatal(err)
+	}
+	_, verified, err := ReadVerifiedIdentity("/source", "%42", "BlueLake")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MirrorVerifiedIdentity("/worktree", "%42", verified); err != nil {
+		t.Fatal(err)
+	}
+	mirrored, err := os.ReadFile(CanonicalIdentityPath("/worktree", "%42"))
+	if err != nil || string(mirrored) != string(data) {
+		t.Fatalf("mirror changed receipt: err=%v got=%s", err, mirrored)
+	}
+}
+
+func TestPlainNameIsNotGenerationEvidence(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	path := CanonicalIdentityPath("/p", "%42")
+	if err := writeIdentityFile(path, "BlueLake\n"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ReadVerifiedIdentity("/p", "%42", "BlueLake"); err == nil {
+		t.Fatal("plain-name compatibility file must not satisfy generation proof")
+	}
+}
+
 func TestResolveIdentityIgnoresCanonicalSymlink(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
@@ -218,7 +264,7 @@ func TestResolveIdentityReturnsEmptyWhenMissing(t *testing.T) {
 	}
 }
 
-// Guarantees #107 regression: ntm-written identities must be discoverable at
+// Guarantees #107 regression: bare-pane identities must be discoverable at
 // the exact path the mcp-agent-mail Rust reference computes. We recompute
 // the reference path independently (sha1[:12] of project_key under
 // `~/.config/agent-mail/identity/<hash>/<sanitized>`) and assert byte
@@ -243,7 +289,6 @@ func TestRustContractCompatibility(t *testing.T) {
 	cases := []vec{
 		{"/project/alpha", "%0", "0"},
 		{"/project/beta", "%42", "42"},
-		{"/project/gamma", "main:0:2", "main-0-2"},
 	}
 
 	for _, c := range cases {

--- a/internal/agentmail/tools.go
+++ b/internal/agentmail/tools.go
@@ -73,6 +73,11 @@ func (c *Client) EnsureProject(ctx context.Context, projectKey string) (*Project
 
 // RegisterAgent registers an agent in a project.
 func (c *Client) RegisterAgent(ctx context.Context, opts RegisterAgentOptions) (*Agent, error) {
+	var err error
+	ctx, err = withTmuxPane(ctx, opts.PaneID)
+	if err != nil {
+		return nil, NewAPIError("register_agent", 0, err)
+	}
 	args := map[string]interface{}{
 		"project_key": opts.ProjectKey,
 		"program":     opts.Program,
@@ -107,6 +112,11 @@ func (c *Client) RegisterAgent(ctx context.Context, opts RegisterAgentOptions) (
 
 // CreateAgentIdentity creates a new unique agent identity.
 func (c *Client) CreateAgentIdentity(ctx context.Context, opts RegisterAgentOptions) (*Agent, error) {
+	var err error
+	ctx, err = withTmuxPane(ctx, opts.PaneID)
+	if err != nil {
+		return nil, NewAPIError("create_agent_identity", 0, err)
+	}
 	args := map[string]interface{}{
 		"project_key": opts.ProjectKey,
 		"program":     opts.Program,

--- a/internal/agentmail/tools_httptest_test.go
+++ b/internal/agentmail/tools_httptest_test.go
@@ -1297,6 +1297,42 @@ func TestRegisterAgent_WithOptionalFields(t *testing.T) {
 	}
 }
 
+func TestCreateAgentIdentityCarriesBarePaneHeader(t *testing.T) {
+	t.Parallel()
+	var got string
+	base := mockMCPHandler(t, map[string]func(map[string]interface{}) (interface{}, *JSONRPCError){
+		"create_agent_identity": func(map[string]interface{}) (interface{}, *JSONRPCError) {
+			return Agent{ID: 1, Name: "BlueLake", Program: "ntm", Model: "opus"}, nil
+		},
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Tmux-Pane")
+		base.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+	c := NewClient(WithBaseURL(server.URL + "/"))
+	_, err := c.CreateAgentIdentity(context.Background(), RegisterAgentOptions{
+		ProjectKey: "/test", Program: "ntm", Model: "opus", PaneID: "%42",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "%42" {
+		t.Fatalf("X-Tmux-Pane = %q, want %%42", got)
+	}
+}
+
+func TestRegistrationRefusesCompositePaneAddress(t *testing.T) {
+	t.Parallel()
+	c := NewClient()
+	_, err := c.CreateAgentIdentity(context.Background(), RegisterAgentOptions{
+		ProjectKey: "/test", Program: "ntm", Model: "opus", PaneID: "main:0:2",
+	})
+	if err == nil || !strings.Contains(err.Error(), "bare %N") {
+		t.Fatalf("expected bare-address refusal, got %v", err)
+	}
+}
+
 func TestFetchInbox_WithAllOptions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agentmail/types.go
+++ b/internal/agentmail/types.go
@@ -275,6 +275,7 @@ type RegisterAgentOptions struct {
 	Model           string
 	Name            string // Optional; auto-generated if empty
 	TaskDescription string
+	PaneID          string // Optional bare tmux pane id (%N); binds the server generation receipt
 }
 
 // SendMessageOptions contains options for sending a message.

--- a/internal/cli/spawn.go
+++ b/internal/cli/spawn.go
@@ -4435,6 +4435,32 @@ func (c *spawnIdentityCoordinator) prepareAgent(parentCtx context.Context, agent
 	// recorded pane is still live means the slot is occupied and the running
 	// agent keeps its name, so this pane gets a fresh identity (ntm#256).
 	if existingName, recoveredFrom, ok := c.registry.ResolveForPane(agent.paneTitle, agent.paneID, c.liveness); ok && existingName != "" {
+		program := agentTypeToProgram(agent.agentType)
+		model := agent.resolvedModel
+		if model == "" {
+			model = agent.model
+		}
+		if strings.TrimSpace(model) == "" {
+			model = delegatedModelPlaceholder(program)
+		}
+		c.registry.HydrateClientTokens(c.client)
+		regCtx, regCancel := context.WithTimeout(parentCtx, 15*time.Second)
+		registered, regErr := c.client.RegisterAgent(regCtx, agentmail.RegisterAgentOptions{
+			ProjectKey: c.workingDir,
+			Program:    program,
+			Model:      model,
+			Name:       existingName,
+			PaneID:     agent.paneID,
+		})
+		regCancel()
+		if regErr != nil || registered == nil {
+			c.status.AgentsFailed++
+			return
+		}
+		if err := c.publishIdentity(agent, registered.Name); err != nil {
+			c.status.AgentsFailed++
+			return
+		}
 		c.status.AgentsRegistered++
 		c.status.AgentMap[agent.paneID] = existingName
 		if !IsJSONOutput() {
@@ -4444,7 +4470,6 @@ func (c *spawnIdentityCoordinator) prepareAgent(parentCtx context.Context, agent
 				output.PrintInfof("Reused existing identity for pane %d: %s", agent.paneIndex, existingName)
 			}
 		}
-		c.publishIdentity(agent, existingName)
 		c.registry.AddAgent(agent.paneTitle, agent.paneID, existingName)
 		c.recordPanePID(parentCtx, agent.paneID)
 		c.persistRegistry()
@@ -4474,6 +4499,7 @@ func (c *spawnIdentityCoordinator) prepareAgent(parentCtx context.Context, agent
 		ProjectKey: c.workingDir,
 		Program:    program,
 		Model:      model,
+		PaneID:     agent.paneID,
 	})
 	regCancel()
 
@@ -4519,7 +4545,13 @@ func (c *spawnIdentityCoordinator) prepareAgent(parentCtx context.Context, agent
 
 	// Write the per-pane identity file(s) so Agent Mail and notify hooks can
 	// resolve AGENT_MAIL_AGENT before the agent process starts.
-	c.publishIdentity(agent, registered.Name)
+	if err := c.publishIdentity(agent, registered.Name); err != nil {
+		c.status.AgentsFailed++
+		if !IsJSONOutput() {
+			output.PrintWarningf("Agent Mail registration for pane %d lacked verified generation readback: %v", agent.paneIndex, err)
+		}
+		return
+	}
 
 	c.status.AgentsRegistered++
 	c.status.AgentMap[agent.paneID] = registered.Name
@@ -4604,13 +4636,20 @@ func (c *spawnIdentityCoordinator) recordPanePID(ctx context.Context, paneID str
 // resolve its identity through: the session key, its symlink-resolved form,
 // and the pane's worktree directory (ntm#257). The extra keys are best-effort;
 // only a failure on the session key itself is reported.
-func (c *spawnIdentityCoordinator) publishIdentity(agent spawnedAgentInfo, name string) {
-	for i, key := range identityPublishKeys(c.workingDir, agent.paneDir) {
-		if _, writeErr := agentmail.WriteIdentity(key, agent.paneID, name); writeErr != nil && i == 0 && !IsJSONOutput() {
-			output.PrintWarningf("Failed to write identity file for pane %d: %v", agent.paneIndex, writeErr)
+func (c *spawnIdentityCoordinator) publishIdentity(agent spawnedAgentInfo, name string) error {
+	_, receipt, err := agentmail.ReadVerifiedIdentity(c.workingDir, agent.paneID, name)
+	if err != nil {
+		return err
+	}
+	for _, key := range identityPublishKeys(c.workingDir, agent.paneDir) {
+		if key != c.workingDir {
+			if _, writeErr := agentmail.MirrorVerifiedIdentity(key, agent.paneID, receipt); writeErr != nil {
+				return writeErr
+			}
 		}
 		_ = agentmail.WriteLegacyCompatIdentity(key, agent.paneID, name)
 	}
+	return nil
 }
 
 // delegatedModelPlaceholder is the model identifier NTM registers with Agent

--- a/internal/cli/spawn_identity_liveness_test.go
+++ b/internal/cli/spawn_identity_liveness_test.go
@@ -59,11 +59,8 @@ func seedRegistry(t *testing.T, session, projectKey, title, paneID, agentName st
 
 func readIdentity(t *testing.T, projectKey, paneID string) string {
 	t.Helper()
-	raw, err := os.ReadFile(agentmail.CanonicalIdentityPath(projectKey, paneID))
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(raw))
+	name, _ := agentmail.ResolveIdentity(projectKey, paneID)
+	return name
 }
 
 func countCreates(tools []string) int {
@@ -129,7 +126,7 @@ func TestSpawnIdentityCoordinator_LiveHolderKeepsItsName(t *testing.T) {
 
 // TestSpawnIdentityCoordinator_DeadHolderIsReused keeps the #69 contract:
 // after the holder of a title died, a same-session respawn gets its name
-// back without a server round-trip, and the binding moves to the new pane.
+// back after a server re-registration binds it to the new pane generation.
 func TestSpawnIdentityCoordinator_DeadHolderIsReused(t *testing.T) {
 	isolateIdentityDirs(t)
 	srv, calledTools := fakeSpawnMailServer(t, "BraveFalcon")
@@ -150,8 +147,8 @@ func TestSpawnIdentityCoordinator_DeadHolderIsReused(t *testing.T) {
 	if status == nil || status.AgentsRegistered != 1 || status.AgentMap["%9"] != "OldTenant" {
 		t.Fatalf("status = %+v, want OldTenant reused for %%9", status)
 	}
-	if creates := countCreates(calledTools()); creates != 0 {
-		t.Fatalf("identity creations = %d, want 0 (dead slot must be reused)", creates)
+	if creates := countCreates(calledTools()); creates != 1 {
+		t.Fatalf("identity registrations = %d, want 1 generation-bound reuse", creates)
 	}
 	if got := readIdentity(t, projectKey, "%9"); got != "OldTenant" {
 		t.Fatalf("identity file for %%9 = %q, want OldTenant", got)
@@ -192,8 +189,8 @@ func TestSpawnIdentityCoordinator_RecycledPaneIDIsDead(t *testing.T) {
 	if status := coordinator.finalStatus(); status == nil || status.AgentMap["%9"] != "OldTenant" {
 		t.Fatalf("status = %+v, want OldTenant recovered from the dead %%5 binding", status)
 	}
-	if creates := countCreates(calledTools()); creates != 0 {
-		t.Fatalf("identity creations = %d, want 0", creates)
+	if creates := countCreates(calledTools()); creates != 1 {
+		t.Fatalf("identity registrations = %d, want 1", creates)
 	}
 }
 

--- a/internal/cli/spawn_identity_order_test.go
+++ b/internal/cli/spawn_identity_order_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 
@@ -141,8 +140,22 @@ func fakeSpawnMailServer(t *testing.T, agentName string) (*httptest.Server, func
 		case "ensure_project":
 			result = map[string]interface{}{"id": 1, "slug": "proj", "human_key": "proj"}
 		case "create_agent_identity", "register_agent":
+			registeredName := agentName
+			if name, ok := req.Params.Arguments["name"].(string); ok && name != "" {
+				registeredName = name
+			}
+			paneID := r.Header.Get("X-Tmux-Pane")
+			projectKey, _ := req.Params.Arguments["project_key"].(string)
+			receipt := agentmail.PaneIdentityRecord{
+				Name: registeredName, SessionName: "test-session", PaneID: paneID,
+				PanePID: 4242, SocketPath: "/tmp/test-tmux.sock", WrittenAt: "2026-08-31T00:00:00Z",
+			}
+			data, _ := json.Marshal(receipt)
+			path := agentmail.CanonicalIdentityPath(projectKey, paneID)
+			_ = os.MkdirAll(filepath.Dir(path), 0o700)
+			_ = os.WriteFile(path, data, 0o600)
 			result = map[string]interface{}{
-				"id": 42, "name": agentName,
+				"id": 42, "name": registeredName,
 				"program": req.Params.Arguments["program"],
 				"model":   req.Params.Arguments["model"],
 			}
@@ -225,7 +238,11 @@ func TestSpawnIdentityCoordinator_PublishesIdentityAtPrepareTime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("canonical identity must exist before launch: %v", err)
 	}
-	if got := strings.TrimSpace(string(raw)); got != "BraveFalcon" {
+	var receipt agentmail.PaneIdentityRecord
+	if err := json.Unmarshal(raw, &receipt); err != nil {
+		t.Fatalf("canonical identity is not a generation receipt: %v", err)
+	}
+	if got := receipt.Name; got != "BraveFalcon" {
 		t.Fatalf("canonical identity = %q, want BraveFalcon (stale value must be replaced before launch)", got)
 	}
 


### PR DESCRIPTION
## Summary
- carry each spawned bare `%N` pane as `X-Tmux-Pane` on Agent Mail registration requests
- refuse composite pane addresses and stop overwriting server generation receipts with plain names
- verify the structured 0.3.31 binding receipt before publishing registry authority, and mirror its exact bytes into worktree project namespaces
- re-register reused identities so their binding follows the new pane generation

## Verification
- `go test ./internal/agentmail -count=1`
- focused spawn/registration suite: `go test ./internal/cli -run TestSpawnIdentityCoordinator\|TestSpawnPublishesIdentityBeforeLaunch\|TestAgentMail.*Identity\|Test.*AgentMail.*Register -count=1 -timeout=5m`
- `go build ./cmd/ntm`

The full `internal/cli` package also ran to completion; its failures were pre-existing tmux E2E cases whose fake agent panes remain at `zsh`/`sh` and are therefore correctly rejected as `PANE_AGENT_DEAD`, unrelated to this diff.