### PR TITLE
fix(assign): respect persona roles when matching work

### DIFF
--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -257,6 +257,16 @@ func filterAssignAgentsByTemplate(agents []assignAgentInfo, template string) []a
 	return filtered
 }
 
+func roleEligibleAssignAgents(agents []assignAgentInfo, projectDir, template string) ([]assignAgentInfo, error) {
+	withRoles, err := applyAssignPersonaRoles(agents, projectDir)
+	if err != nil {
+		return nil, err
+	}
+	return filterAssignAgentsByTemplate(withRoles, template), nil
+}
+
+var checkAssignCycles = CheckCycles
+
 func newAssignCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "assign [session]",
@@ -1776,7 +1786,7 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 	// Filter out beads in dependency cycles (with warning)
 	var cycleWarnings int
 	var cyclicBeads []SkippedItem
-	cycles, err := CheckCycles(ctx, projectDir, false)
+	cycles, err := checkAssignCycles(ctx, projectDir, false)
 	if err != nil {
 		return nil, fmt.Errorf("inspect assignment dependency cycles: %w", err)
 	}
@@ -1807,6 +1817,10 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 
 	// Combine all skipped beads
 	allSkipped := append(blockedBeads, cyclicBeads...)
+	idleAgents, err = roleEligibleAssignAgents(idleAgents, projectDir, opts.Template)
+	if err != nil {
+		return nil, err
+	}
 
 	result := &AssignOutputEnhanced{
 		Strategy:    opts.Strategy,
@@ -1843,12 +1857,6 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 	}
 
 	// Generate assignments using strategy
-	idleAgents, err = applyAssignPersonaRoles(idleAgents, projectDir)
-	if err != nil {
-		return nil, err
-	}
-	idleAgents = filterAssignAgentsByTemplate(idleAgents, opts.Template)
-	result.Summary.IdleAgents = len(idleAgents)
 	assignments, allocationPlan := generateAssignmentsEnhancedWithPlan(ctx, idleAgents, readyBeads, opts, true)
 	result.Allocation = assignAllocationView(allocationPlan)
 	if allocationPlan != nil && allocationPlan.Decision == assign.AllocationDecisionDefer && len(assignments) == 0 {
@@ -3508,6 +3516,10 @@ func runRetryAssignments(ctx context.Context, session string) error {
 			}
 			return fmt.Errorf("failed to get idle agents: %w", err)
 		}
+		idleAgents, err = roleEligibleAssignAgents(idleAgents, projectDir, assignTemplate)
+		if err != nil {
+			return emitRetryFailure(session, "PERSONA_ERROR", err)
+		}
 	}
 
 	// Process each failed assignment
@@ -4444,6 +4456,10 @@ func runReassignment(ctx context.Context, session string) error {
 		idleAgents, idleErr := getIdleAgents(ctx, session, assignToType, assignVerbose)
 		if idleErr != nil {
 			return emitContextAwareReassignFailure(ctx, session, "TMUX_ERROR", idleErr, nil)
+		}
+		idleAgents, idleErr = roleEligibleAssignAgents(idleAgents, projectDir, assignTemplate)
+		if idleErr != nil {
+			return emitReassignFailure(session, "PERSONA_ERROR", idleErr.Error(), nil)
 		}
 		if len(idleAgents) == 0 {
 			return emitReassignFailure(session, "NO_IDLE_AGENT", fmt.Sprintf("no idle %s agents available", assignToType), map[string]interface{}{"agent_type": assignToType})
@@ -6033,12 +6049,11 @@ func PerformAutoReassignment(ctx context.Context, completedBeadID string, opts *
 		policyProject:   opts.policyProject,
 	}
 
-	idleAgents, err = applyAssignPersonaRoles(idleAgents, projectDir)
+	idleAgents, err = roleEligibleAssignAgents(idleAgents, projectDir, assignOpts.Template)
 	if err != nil {
 		result.Errors = append(result.Errors, err.Error())
 		return result, nil
 	}
-	idleAgents = filterAssignAgentsByTemplate(idleAgents, assignOpts.Template)
 	result.IdleAgents = len(idleAgents)
 	assignments := generateAssignmentsEnhanced(ctx, idleAgents, filteredBeads, assignOpts)
 	result.Assignments = assignments

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	dispatchsvc "github.com/Dicklesworthstone/ntm/internal/dispatch"
 	"github.com/Dicklesworthstone/ntm/internal/events"
+	"github.com/Dicklesworthstone/ntm/internal/persona"
 	"github.com/Dicklesworthstone/ntm/internal/pressure"
 	"github.com/Dicklesworthstone/ntm/internal/redaction"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
@@ -202,6 +203,58 @@ type assignAgentInfo struct {
 	contextUsage      float64
 	activeAssignments int
 	resourceHeadroom  float64
+	personaRoles      []string
+}
+
+func assignPersonaRoles(registry *persona.Registry, pane tmux.Pane) []string {
+	variant, _ := tmux.ParsePaneVariant(pane.Variant)
+	profile, ok := registry.Get(variant)
+	if !ok {
+		return nil
+	}
+	roles := make([]string, 0, len(profile.Tags))
+	for _, tag := range profile.Tags {
+		switch role := strings.ToLower(strings.TrimSpace(tag)); role {
+		case "implementer", "reviewer":
+			roles = append(roles, role)
+		}
+	}
+	return roles
+}
+
+func applyAssignPersonaRoles(agents []assignAgentInfo, projectDir string) ([]assignAgentInfo, error) {
+	registry, err := persona.LoadRegistry(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading persona roles for assignment: %w", err)
+	}
+	for i := range agents {
+		agents[i].personaRoles = assignPersonaRoles(registry, agents[i].pane)
+	}
+	return agents, nil
+}
+
+func filterAssignAgentsByTemplate(agents []assignAgentInfo, template string) []assignAgentInfo {
+	template = strings.ToLower(strings.TrimSpace(template))
+	if template != "impl" && template != "review" {
+		return agents
+	}
+	filtered := make([]assignAgentInfo, 0, len(agents))
+	for _, candidate := range agents {
+		implementer := false
+		reviewer := false
+		for _, role := range candidate.personaRoles {
+			implementer = implementer || role == "implementer"
+			reviewer = reviewer || role == "reviewer"
+		}
+		if template == "impl" && reviewer && !implementer {
+			continue
+		}
+		if template == "review" && implementer && !reviewer {
+			continue
+		}
+		filtered = append(filtered, candidate)
+	}
+	return filtered
 }
 
 func newAssignCmd() *cobra.Command {
@@ -211,7 +264,8 @@ func newAssignCmd() *cobra.Command {
 		Long: `Analyze ready work from BV and recommend or execute task-to-agent assignments.
 
 This command queries BV for prioritized ready work and matches tasks to idle agents
-based on agent type strengths and the selected strategy.
+based on agent type strengths, persona role tags, and the selected strategy. The
+impl and review templates exclude panes explicitly tagged for the opposite role.
 
 Strategies:
   balanced    - Balance workload across agents (default)
@@ -1789,6 +1843,12 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 	}
 
 	// Generate assignments using strategy
+	idleAgents, err = applyAssignPersonaRoles(idleAgents, projectDir)
+	if err != nil {
+		return nil, err
+	}
+	idleAgents = filterAssignAgentsByTemplate(idleAgents, opts.Template)
+	result.Summary.IdleAgents = len(idleAgents)
 	assignments, allocationPlan := generateAssignmentsEnhancedWithPlan(ctx, idleAgents, readyBeads, opts, true)
 	result.Allocation = assignAllocationView(allocationPlan)
 	if allocationPlan != nil && allocationPlan.Decision == assign.AllocationDecisionDefer && len(assignments) == 0 {
@@ -5973,6 +6033,13 @@ func PerformAutoReassignment(ctx context.Context, completedBeadID string, opts *
 		policyProject:   opts.policyProject,
 	}
 
+	idleAgents, err = applyAssignPersonaRoles(idleAgents, projectDir)
+	if err != nil {
+		result.Errors = append(result.Errors, err.Error())
+		return result, nil
+	}
+	idleAgents = filterAssignAgentsByTemplate(idleAgents, assignOpts.Template)
+	result.IdleAgents = len(idleAgents)
 	assignments := generateAssignmentsEnhanced(ctx, idleAgents, filteredBeads, assignOpts)
 	result.Assignments = assignments
 

--- a/internal/cli/assign_reassign_test.go
+++ b/internal/cli/assign_reassign_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -42,6 +43,83 @@ func TestAssignmentEntryPointsRejectCanceledContextBeforeSideEffects(t *testing.
 				t.Fatalf("error = %v, want context.Canceled", err)
 			}
 		})
+	}
+}
+
+func TestGetAssignOutputEnhancedExcludesReviewerPersonaFromImplementation(t *testing.T) {
+	testutil.RequireTmuxThrottled(t)
+
+	snapshot := captureAssignGlobals()
+	defer snapshot.restore()
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpDir, "xdg"))
+	t.Setenv("AGENT_MAIL_URL", "http://127.0.0.1:1")
+	cfg = newTmuxIntegrationTestConfig(tmpDir)
+	cfg.Agents.Claude = testAgentCatCommandTemplate
+	cfg.Agents.Codex = testAgentCatCommandTemplate
+
+	sessionName, claudePane, codexPane := setupReassignSession(t, tmpDir)
+	projectDir := t.TempDir()
+	ntmDir := filepath.Join(projectDir, ".ntm")
+	if err := os.MkdirAll(ntmDir, 0o755); err != nil {
+		t.Fatalf("create project ntm dir: %v", err)
+	}
+	personas := `[[personas]]
+name = "implementation-seat"
+agent_type = "claude"
+tags = ["implementer"]
+
+[[personas]]
+name = "review-seat"
+agent_type = "codex"
+tags = ["reviewer"]
+`
+	if err := os.WriteFile(filepath.Join(ntmDir, "personas.toml"), []byte(personas), 0o600); err != nil {
+		t.Fatalf("write personas: %v", err)
+	}
+	if err := tmux.SetPaneTitle(claudePane.ID, tmux.FormatPaneName(sessionName, "cc", 1, "implementation-seat")); err != nil {
+		t.Fatalf("title implementation pane: %v", err)
+	}
+	if err := tmux.SetPaneTitle(codexPane.ID, tmux.FormatPaneName(sessionName, "cod", 1, "review-seat")); err != nil {
+		t.Fatalf("title review pane: %v", err)
+	}
+
+	previousObserver := newAssignSessionObserver
+	observedAt := time.Now().UTC()
+	newAssignSessionObserver = func() assignSessionObserver {
+		return fixedAssignSessionObserver{observation: statuspkg.SessionObservation{
+			Session: sessionName, ObservedAt: observedAt, Complete: true,
+			Panes: []statuspkg.PaneObservation{
+				{Pane: tmux.PaneRef{ID: claudePane.ID, WindowIndex: claudePane.WindowIndex, PaneIndex: claudePane.Index}, Current: statuspkg.StateObservation{Status: statuspkg.AgentStatus{State: statuspkg.StateIdle}, ObservedAt: observedAt, Freshness: statuspkg.FreshnessFresh, Confidence: 0.99}},
+				{Pane: tmux.PaneRef{ID: codexPane.ID, WindowIndex: codexPane.WindowIndex, PaneIndex: codexPane.Index}, Current: statuspkg.StateObservation{Status: statuspkg.AgentStatus{State: statuspkg.StateIdle}, ObservedAt: observedAt, Freshness: statuspkg.FreshnessFresh, Confidence: 0.99}},
+			},
+		}}
+	}
+	previousCycles := checkAssignCycles
+	checkAssignCycles = func(context.Context, string, bool) ([][]string, error) { return nil, nil }
+	t.Cleanup(func() {
+		newAssignSessionObserver = previousObserver
+		checkAssignCycles = previousCycles
+	})
+
+	out, err := getAssignOutputEnhanced(t.Context(), &AssignCommandOptions{
+		Session:                     sessionName,
+		ProjectDir:                  projectDir,
+		Strategy:                    "quality",
+		Template:                    "impl",
+		actionablePreflightVerified: true,
+		verifiedActionable: []bv.TriageRecommendation{{
+			ID: "bd-role-live", Title: "Implement new assignment feature", Type: "task", Status: "open", Priority: 2,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("getAssignOutputEnhanced: %v", err)
+	}
+	if len(out.Assignments) != 1 {
+		t.Fatalf("output = %+v, want one implementation assignment", out)
+	}
+	if out.Assignments[0].PaneID != claudePane.ID {
+		t.Fatalf("implementation assigned to pane %s, want implementer %s (reviewer was %s)", out.Assignments[0].PaneID, claudePane.ID, codexPane.ID)
 	}
 }
 
@@ -108,6 +186,9 @@ func setupReassignSession(t *testing.T, tmpDir string) (string, tmux.Pane, tmux.
 	t.Helper()
 
 	sessionName := fmt.Sprintf("ntm-test-reassign-%d", time.Now().UnixNano())
+	if err := os.MkdirAll(filepath.Join(tmpDir, sessionName), 0o755); err != nil {
+		t.Fatalf("create session project: %v", err)
+	}
 	t.Cleanup(func() {
 		_ = tmux.KillSession(sessionName)
 	})

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/completion"
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	dispatchsvc "github.com/Dicklesworthstone/ntm/internal/dispatch"
+	"github.com/Dicklesworthstone/ntm/internal/persona"
 	"github.com/Dicklesworthstone/ntm/internal/redaction"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	statuspkg "github.com/Dicklesworthstone/ntm/internal/status"
@@ -1147,6 +1148,47 @@ func TestMakeReassignErrorEnvelope(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAssignPersonaRolesResolvePaneVariantTags(t *testing.T) {
+	registry := persona.NewRegistry()
+	registry.Add(&persona.Persona{Name: "quill", Tags: []string{"reviewer", "standing-qa-pool"}})
+
+	roles := assignPersonaRoles(registry, tmux.Pane{Variant: "quill"})
+	if !reflect.DeepEqual(roles, []string{"reviewer"}) {
+		t.Fatalf("assignPersonaRoles() = %v, want [reviewer]", roles)
+	}
+	if roles := assignPersonaRoles(registry, tmux.Pane{Variant: "gpt-5@high"}); len(roles) != 0 {
+		t.Fatalf("model-only pane roles = %v, want none", roles)
+	}
+}
+
+func TestFilterAssignAgentsByTemplateHonorsPersonaRoles(t *testing.T) {
+	agents := []assignAgentInfo{
+		{pane: tmux.Pane{ID: "%1"}, personaRoles: []string{"reviewer"}},
+		{pane: tmux.Pane{ID: "%2"}, personaRoles: []string{"implementer"}},
+		{pane: tmux.Pane{ID: "%3"}},
+		{pane: tmux.Pane{ID: "%4"}, personaRoles: []string{"reviewer", "implementer"}},
+	}
+
+	impl := filterAssignAgentsByTemplate(agents, "impl")
+	if len(impl) != 3 {
+		t.Fatalf("impl candidate count = %d, want 3", len(impl))
+	}
+	if got := []string{impl[0].pane.ID, impl[1].pane.ID, impl[2].pane.ID}; !reflect.DeepEqual(got, []string{"%2", "%3", "%4"}) {
+		t.Fatalf("impl candidates = %v, want implementer, untagged, and dual-role panes", got)
+	}
+	review := filterAssignAgentsByTemplate(agents, "review")
+	if len(review) != 3 {
+		t.Fatalf("review candidate count = %d, want 3", len(review))
+	}
+	if got := []string{review[0].pane.ID, review[1].pane.ID, review[2].pane.ID}; !reflect.DeepEqual(got, []string{"%1", "%3", "%4"}) {
+		t.Fatalf("review candidates = %v, want reviewer, untagged, and dual-role panes", got)
+	}
+	custom := filterAssignAgentsByTemplate(agents, "custom")
+	if len(custom) != len(agents) {
+		t.Fatalf("custom template filtered %d agents, want %d", len(custom), len(agents))
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolve persona role tags from each pane's durable persona variant
- exclude reviewer-only panes from `--template=impl` assignment and implementer-only panes from `--template=review`
- preserve compatibility for untagged/model-only and explicitly dual-role panes
- apply the same eligible candidate set to balanced/allocation and legacy strategies, including auto-reassignment

## Verification
- `go test -short ./...`
- `go test -short ./internal/cli ./internal/assign`
- `go build ./cmd/ntm`
- `gofmt -l internal/cli/assign.go internal/cli/assign_test.go` (clean)
- `git diff --check`

Tracks agent-factory-0t6k.