### PR TITLE
fix(assign): reconcile stale plans with live bead lifecycle

### DIFF
--- a/e2e/atomic_assignment_cli_e2e_test.go
+++ b/e2e/atomic_assignment_cli_e2e_test.go
@@ -5084,15 +5084,21 @@ func TestE2EAtomicAssignmentLabelEnrichmentFailuresFailClosedBuiltProcess(t *tes
 		"#!/bin/sh",
 		`printf '%s\n' "$*" >> "$NTM_E2E_BR_TRACE"`,
 		`command=`,
+		`all=false`,
 		`for arg in "$@"; do`,
 		`  case "$arg" in ready|list) command="$arg"; break ;; esac`,
 		`done`,
+		`for arg in "$@"; do [ "$arg" = "--all" ] && all=true; done`,
+		`[ "$command" = list ] && [ "$all" = true ] && command=list_all`,
 		`case "$NTM_E2E_BR_MODE:$command" in`,
 		`  ready_failure:ready) printf 'injected br ready failure\n' >&2; exit 70 ;;`,
 		`  list_failure:list) printf 'injected br list failure\n' >&2; exit 71 ;;`,
 		`  malformed_ready:ready) printf '{\n'; exit 0 ;;`,
 		`  malformed_list:list) printf '{\n'; exit 0 ;;`,
 		`  absent:ready|absent:list) printf '[]\n'; exit 0 ;;`,
+		`  absent:list_all) printf '[]\n'; exit 0 ;;`,
+		`  closed:ready|closed:list) printf '[]\n'; exit 0 ;;`,
+		`  closed:list_all) printf '[{"id":"%s","status":"closed"}]\n' "$NTM_E2E_BEAD_ID"; exit 0 ;;`,
 		"esac",
 		"real_br=" + tmux.ShellQuote(fixture.brPath),
 		`exec "$real_br" "$@"`,
@@ -5113,6 +5119,7 @@ func TestE2EAtomicAssignmentLabelEnrichmentFailuresFailClosedBuiltProcess(t *tes
 		mode              string
 		wantDiagnostic    string
 		wantBRInvocations []string
+		wantLifecycleSkip bool
 	}{
 		{
 			name: "br ready failure", mode: "ready_failure",
@@ -5136,8 +5143,21 @@ func TestE2EAtomicAssignmentLabelEnrichmentFailuresFailClosedBuiltProcess(t *tes
 		},
 		{
 			name: "plan item absent from both label sources", mode: "absent",
-			wantDiagnostic:    "absent from both br ready and br list --status open",
-			wantBRInvocations: []string{"--lock-timeout 5000 ready --json --limit 100000", "--lock-timeout 5000 list --json --status open --limit 100000"},
+			wantDiagnostic: "absent from br ready, br list --status open, and br list --all",
+			wantBRInvocations: []string{
+				"--lock-timeout 5000 ready --json --limit 100000",
+				"--lock-timeout 5000 list --json --status open --limit 100000",
+				"--lock-timeout 5000 list --json --all --limit 100000",
+			},
+		},
+		{
+			name: "closed tracked plan item is satisfied", mode: "closed",
+			wantLifecycleSkip: true,
+			wantBRInvocations: []string{
+				"--lock-timeout 5000 ready --json --limit 100000",
+				"--lock-timeout 5000 list --json --status open --limit 100000",
+				"--lock-timeout 5000 list --json --all --limit 100000",
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -5175,6 +5195,7 @@ func TestE2EAtomicAssignmentLabelEnrichmentFailuresFailClosedBuiltProcess(t *tes
 			env["NTM_E2E_PLAN_PAYLOAD"] = planPath
 			env["NTM_E2E_BR_TRACE"] = brTrace
 			env["NTM_E2E_BR_MODE"] = tc.mode
+			env["NTM_E2E_BEAD_ID"] = beadID
 			result := fixture.runNTM(t, env,
 				"--json", "assign", fixture.session,
 				"--repo="+fixture.projectDir,
@@ -5187,10 +5208,27 @@ func TestE2EAtomicAssignmentLabelEnrichmentFailuresFailClosedBuiltProcess(t *tes
 				"--timeout=15s",
 				"--quiet",
 			)
-			code, message := assertAtomicAssignmentSingleFailureJSON(t, result)
-			if code != "ASSIGN_ERROR" || !strings.Contains(message, "actionable bead labels could not be verified") ||
-				!strings.Contains(message, tc.wantDiagnostic) {
-				t.Fatalf("label-enrichment failure code=%q message=%q, want ASSIGN_ERROR containing %q", code, message, tc.wantDiagnostic)
+			if tc.wantLifecycleSkip {
+				if result.exitCode != 0 || len(bytes.TrimSpace(result.stderr)) != 0 {
+					t.Fatalf("lifecycle skip exit=%d stdout=%s stderr=%s, want clean success", result.exitCode, result.stdout, result.stderr)
+				}
+				var envelope struct {
+					Success bool `json:"success"`
+					Summary struct {
+						Assigned int `json:"assigned"`
+						Failed   int `json:"failed"`
+					} `json:"summary"`
+				}
+				decodeAtomicAssignmentJSON(t, result.stdout, &envelope)
+				if !envelope.Success || envelope.Summary.Assigned != 0 || envelope.Summary.Failed != 0 {
+					t.Fatalf("lifecycle skip envelope=%+v raw=%s", envelope, result.stdout)
+				}
+			} else {
+				code, message := assertAtomicAssignmentSingleFailureJSON(t, result)
+				if code != "ASSIGN_ERROR" || !strings.Contains(message, "actionable bead labels could not be verified") ||
+					!strings.Contains(message, tc.wantDiagnostic) {
+					t.Fatalf("label-enrichment failure code=%q message=%q, want ASSIGN_ERROR containing %q", code, message, tc.wantDiagnostic)
+				}
 			}
 
 			trace, err := os.ReadFile(brTrace)

--- a/internal/bv/triage.go
+++ b/internal/bv/triage.go
@@ -271,9 +271,38 @@ func GetActionableRecommendationsContext(ctx context.Context, dir string, n int)
 	if labelsErr != nil {
 		return nil, classifyActionableLabelsError(ctx, labelsErr)
 	}
+	missingFromOpen := make([]string, 0)
 	for _, item := range planItems {
 		if _, verified := labelsByID[item.ID]; !verified {
-			return nil, fmt.Errorf("%w: open actionable plan item %q was absent from both br ready and br list --status open", ErrActionableLabelsUnverified, item.ID)
+			missingFromOpen = append(missingFromOpen, item.ID)
+		}
+	}
+	if len(missingFromOpen) > 0 {
+		statusesByID, statusErr := allBeadStatusesContext(ctx, dir)
+		if statusErr != nil {
+			return nil, classifyActionableLabelsError(ctx, statusErr)
+		}
+		for _, id := range missingFromOpen {
+			status, exists := statusesByID[id]
+			if !exists {
+				return nil, fmt.Errorf("%w: actionable plan item %q was absent from br ready, br list --status open, and br list --all", ErrActionableLabelsUnverified, id)
+			}
+			// bv --robot-plan is a ranked snapshot. Beads owns lifecycle state:
+			// a tracked item closed or otherwise made non-open after the snapshot
+			// is satisfied/ineligible, not unverifiable actionable work. Dropping
+			// it also prevents blocked and in-progress review rows from being
+			// dispatched when the plan still says open (agent-factory-ozms).
+			if status != "open" {
+				delete(planByID, id)
+			}
+		}
+	}
+	for _, item := range planItems {
+		if _, stillOpen := planByID[item.ID]; !stillOpen {
+			continue
+		}
+		if _, verified := labelsByID[item.ID]; !verified {
+			return nil, fmt.Errorf("%w: plan item %q is still open in br list --all but was absent from both br ready and br list --status open", ErrActionableLabelsUnverified, item.ID)
 		}
 		// Type evidence follows the same coverage invariant as labels: without
 		// a verified issue type the classifier cannot prove a plan item is not
@@ -310,6 +339,9 @@ func GetActionableRecommendationsContext(ctx context.Context, dir string, n int)
 		recs = append(recs, rec)
 	}
 	for _, item := range planItems {
+		if _, authorized := planByID[item.ID]; !authorized {
+			continue
+		}
 		if _, duplicate := seen[item.ID]; duplicate {
 			continue
 		}
@@ -425,6 +457,38 @@ func readyBeadLabelsContext(ctx context.Context, dir string) (map[string][]strin
 		}
 	}
 	return labels, issueTypes, nil
+}
+
+// allBeadStatusesContext resolves stale bv plan rows against Beads' complete
+// lifecycle surface. It is called only when an item disappeared from both
+// open-only label sources, so normal assignment keeps the existing two-call
+// path while close/block transitions gain an authoritative classification.
+func allBeadStatusesContext(ctx context.Context, dir string) (map[string]string, error) {
+	args := []string{"list", "--json", "--all", "--limit", "100000"}
+	output, err := RunBdContext(ctx, dir, args...)
+	if err != nil {
+		return nil, fmt.Errorf("read bead lifecycle (br %s): %w", strings.Join(args, " "), err)
+	}
+	items, err := UnmarshalBdList[struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}](output)
+	if err != nil {
+		return nil, fmt.Errorf("parse bead lifecycle (br %s): %w", strings.Join(args, " "), err)
+	}
+	statuses := make(map[string]string, len(items))
+	for _, item := range items {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		status := strings.ToLower(strings.TrimSpace(item.Status))
+		if status == "" {
+			return nil, fmt.Errorf("parse bead lifecycle (br %s): bead %q has a blank status", strings.Join(args, " "), id)
+		}
+		statuses[id] = status
+	}
+	return statuses, nil
 }
 
 // GetNextRecommendation returns the single top recommendation.

--- a/internal/bv/triage_test.go
+++ b/internal/bv/triage_test.go
@@ -854,6 +854,76 @@ func TestGetActionableRecommendationsUsesPlanMembershipAndLiveBeadState(t *testi
 	}
 }
 
+func TestGetActionableRecommendationsSkipsStalePlanRowsByLiveLifecycle(t *testing.T) {
+	for _, status := range []string{"closed", "blocked", "in_progress", "deferred"} {
+		t.Run(status, func(t *testing.T) {
+			binDir := t.TempDir()
+			bvScript := `#!/bin/sh
+case "$1" in
+  --robot-triage) printf '%s\n' '{"triage":{"recommendations":[{"id":"tracked","title":"tracked","status":"open","priority":1}]}}' ;;
+  --robot-plan) printf '%s\n' '{"plan":{"tracks":[{"track_id":"one","items":[{"id":"tracked","title":"tracked","status":"open","priority":1}]}]}}' ;;
+  *) exit 64 ;;
+esac
+`
+			brScript := `#!/bin/sh
+case "$*" in
+  *" ready "*|*" --status open "*) printf '%s\n' '[]' ;;
+  *" --all "*) printf '%s\n' '[{"id":"tracked","status":"` + status + `"}]' ;;
+  *) printf 'unexpected br args: %s\n' "$*" >&2; exit 64 ;;
+esac
+`
+			for name, script := range map[string]string{"bv": bvScript, "br": brScript} {
+				if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o700); err != nil {
+					t.Fatalf("write fake %s: %v", name, err)
+				}
+			}
+			t.Setenv("PATH", binDir)
+			InvalidateTriageCache()
+			t.Cleanup(InvalidateTriageCache)
+
+			recs, err := GetActionableRecommendationsContext(t.Context(), t.TempDir(), 0)
+			if err != nil {
+				t.Fatalf("lifecycle %s returned error: %v", status, err)
+			}
+			if len(recs) != 0 {
+				t.Fatalf("lifecycle %s recommendations=%+v, want stale row skipped", status, recs)
+			}
+		})
+	}
+}
+
+func TestGetActionableRecommendationsStillRefusesUnverifiedOpenLifecycle(t *testing.T) {
+	binDir := t.TempDir()
+	bvScript := `#!/bin/sh
+case "$1" in
+  --robot-triage) printf '%s\n' '{"triage":{"recommendations":[]}}' ;;
+  --robot-plan) printf '%s\n' '{"plan":{"tracks":[{"track_id":"one","items":[{"id":"tracked","title":"tracked","status":"open","priority":1}]}]}}' ;;
+  *) exit 64 ;;
+esac
+`
+	brScript := `#!/bin/sh
+case "$*" in
+  *" ready "*|*" --status open "*) printf '%s\n' '[]' ;;
+  *" --all "*) printf '%s\n' '[{"id":"tracked","status":"open"}]' ;;
+  *) exit 64 ;;
+esac
+`
+	for name, script := range map[string]string{"bv": bvScript, "br": brScript} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o700); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", binDir)
+	InvalidateTriageCache()
+	t.Cleanup(InvalidateTriageCache)
+
+	recs, err := GetActionableRecommendationsContext(t.Context(), t.TempDir(), 0)
+	if recs != nil || err == nil || !errors.Is(err, ErrActionableLabelsUnverified) ||
+		!strings.Contains(err.Error(), "still open") {
+		t.Fatalf("recommendations=%+v error=%v, want fail-closed live-open error", recs, err)
+	}
+}
+
 func TestGetActionableRecommendationsExcludesNonOpenPlanRowsBeforeLabelVerification(t *testing.T) {
 	installActionableRecommendationTestTools(
 		t,


### PR DESCRIPTION
## Problem

`ntm assign --watch` treats `bv --robot-plan` as live lifecycle authority. If a tracked plan item is closed mid-session, it disappears from both `br ready` and `br list --status open`; label enrichment then returns a fatal error and kills the watch loop. The same stale-plan shape can dispatch blocked or in-progress/review work.

## Fix

When a plan row disappears from both open-only label surfaces, resolve it once against authoritative `br list --all` lifecycle state:

- closed, blocked, in_progress, deferred, or any other non-open status: skip as satisfied/ineligible;
- still open but missing label/type coverage: keep failing closed;
- absent from the complete tracker surface: keep failing closed.

The all-lifecycle read only runs for rows missing from the two existing open surfaces, so the normal two-call path is unchanged.

## Tests

- lifecycle table covers closed/blocked/in_progress/deferred;
- live-open-but-unverified remains refused;
- built-process E2E drives real `ntm assign --auto` with a stale-open BV plan plus live-closed Beads row and asserts exit 0, success, zero assignments/failures, no prompt/mail, and unchanged state;
- missing-ID built-process E2E remains fail-closed;
- deleting the non-open skip kills the lifecycle tests;
- `go test ./internal/bv` and tagged built-process E2E pass.