### PR TITLE
fix(agent-mail): scope controller identities to canonical project

### DIFF
--- a/internal/agentmail/client.go
+++ b/internal/agentmail/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,8 +172,12 @@ func NewClient(opts ...Option) *Client {
 		},
 	}
 
-	// Check environment variables
+	// Check environment variables. MCP_AGENT_MAIL_TOKEN is the public MCP
+	// convention; AGENT_MAIL_TOKEN remains the explicit NTM override when both
+	// are present.
 	if token := os.Getenv("AGENT_MAIL_TOKEN"); token != "" {
+		c.bearerToken = token
+	} else if token := os.Getenv("MCP_AGENT_MAIL_TOKEN"); token != "" {
 		c.bearerToken = token
 	}
 	if baseURL := os.Getenv("AGENT_MAIL_URL"); baseURL != "" {
@@ -512,6 +517,7 @@ type ToolCallParams struct {
 // callTool makes a JSON-RPC call to the Agent Mail server.
 func (c *Client) callTool(ctx context.Context, toolName string, args map[string]interface{}) (json.RawMessage, error) {
 	reqID := c.requestID.Add(1)
+	args = withInvocationProjectKey(args)
 
 	rpcReq := JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -581,6 +587,36 @@ func (c *Client) callTool(ctx context.Context, toolName string, args map[string]
 	return content, nil
 }
 
+// withInvocationProjectKey rewrites only the project-bearing fields at the
+// single Agent Mail RPC boundary. Keeping this here covers every Agent Mail
+// tool without changing local NTM session/worktree resolution. Copy first so
+// callers can safely reuse their argument maps after a request.
+func withInvocationProjectKey(args map[string]interface{}) map[string]interface{} {
+	if len(args) == 0 {
+		return args
+	}
+	override := InvocationProjectKey("")
+	if override == "" {
+		return args
+	}
+	_, hasProjectKey := args["project_key"]
+	_, hasHumanKey := args["human_key"]
+	if !hasProjectKey && !hasHumanKey {
+		return args
+	}
+	cloned := make(map[string]interface{}, len(args))
+	for key, value := range args {
+		cloned[key] = value
+	}
+	if hasProjectKey {
+		cloned["project_key"] = override
+	}
+	if hasHumanKey {
+		cloned["human_key"] = override
+	}
+	return cloned
+}
+
 // callToolWithTimeout calls a tool with a specific timeout.
 func (c *Client) callToolWithTimeout(ctx context.Context, toolName string, args map[string]interface{}, timeout time.Duration) (json.RawMessage, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -621,6 +657,7 @@ func (c *Client) callToolWithBusyRetry(ctx context.Context, toolName string, arg
 // ReadResource reads a resource from the Agent Mail server.
 func (c *Client) ReadResource(ctx context.Context, uri string) (json.RawMessage, error) {
 	reqID := c.requestID.Add(1)
+	uri = withInvocationProjectKeyResourceURI(uri)
 
 	rpcReq := JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -681,6 +718,42 @@ func (c *Client) ReadResource(ctx context.Context, uri string) (json.RawMessage,
 	}
 
 	return rpcResp.Result, nil
+}
+
+// withInvocationProjectKeyResourceURI applies the invocation key to the
+// project-bearing Agent Mail resource shapes. Resources carry identity in a
+// URI rather than a tools/call argument, so they do not pass through
+// withInvocationProjectKey above.
+func withInvocationProjectKeyResourceURI(uri string) string {
+	override := InvocationProjectKey("")
+	if override == "" {
+		return uri
+	}
+	parsed, err := url.Parse(uri)
+	if err != nil || parsed.Scheme != "resource" {
+		return uri
+	}
+
+	changed := false
+	query := parsed.Query()
+	if _, ok := query["project"]; ok {
+		query.Set("project", override)
+		parsed.RawQuery = query.Encode()
+		changed = true
+	}
+	switch parsed.Host {
+	case "agents", "file_reservations":
+		// Agent Mail treats this as one escaped path segment. Preserve the
+		// original callers' url.PathEscape representation so an absolute
+		// canonical key does not become resource://...//repos/... .
+		parsed.Path = override
+		parsed.RawPath = url.PathEscape(override)
+		changed = true
+	}
+	if !changed {
+		return uri
+	}
+	return parsed.String()
 }
 
 // httpBaseURL returns the HTTP REST API base URL derived from the MCP base URL.

--- a/internal/agentmail/client_test.go
+++ b/internal/agentmail/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"sync"
@@ -68,6 +69,109 @@ func TestNewClient(t *testing.T) {
 	}
 	if c.bearerToken != "test-token" {
 		t.Errorf("expected token 'test-token', got %s", c.bearerToken)
+	}
+}
+
+func TestNewClientUsesPublicMCPTokenFallbackWithoutLeakingIt(t *testing.T) {
+	const token = "public-agent-mail-token-must-not-appear-in-errors"
+	t.Setenv("AGENT_MAIL_TOKEN", "")
+	t.Setenv("MCP_AGENT_MAIL_TOKEN", token)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Errorf("Authorization = %q, want public MCP token", got)
+		}
+		http.Error(w, "denied", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := NewClient(WithBaseURL(server.URL + "/"))
+	_, err := c.HealthCheck(context.Background())
+	if err == nil {
+		t.Fatal("HealthCheck unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("Agent Mail token leaked through error: %v", err)
+	}
+}
+
+func TestClientRewritesAllProjectRPCKeysForInvocationOverride(t *testing.T) {
+	const canonical = "/repos/github.com/biji-biji-initiative/bbi-infrastructure"
+	const physical = "/home/ubuntu/work/bbi-infrastructure"
+	t.Setenv(ProjectKeyOverrideEnv, canonical)
+
+	seen := make(map[string]map[string]interface{})
+	var resourceURIs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string          `json:"method"`
+			ID     interface{}     `json:"id"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Method == "resources/read" {
+			var params map[string]string
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				t.Fatalf("decode resource params: %v", err)
+			}
+			seen["resources/read"] = map[string]interface{}{"uri": params["uri"]}
+			resourceURIs = append(resourceURIs, params["uri"])
+			_ = json.NewEncoder(w).Encode(JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`{"contents":[]}`)})
+			return
+		}
+		var params struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			t.Fatalf("decode tool params: %v", err)
+		}
+		seen[params.Name] = params.Arguments
+		var result interface{}
+		switch params.Name {
+		case "ensure_project":
+			result = Project{ID: 7, HumanKey: canonical}
+		case "send_message":
+			result = SendResult{}
+		default:
+			t.Fatalf("unexpected tool %q", params.Name)
+		}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: raw})
+	}))
+	defer server.Close()
+
+	c := NewClient(WithBaseURL(server.URL + "/"))
+	if _, err := c.EnsureProject(context.Background(), physical); err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+	if _, err := c.SendMessage(context.Background(), SendMessageOptions{
+		ProjectKey: physical, SenderName: "BlueLake", To: []string{"GreenCastle"}, Subject: "scope", BodyMD: "test",
+	}); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if _, err := c.ReadResource(context.Background(), "resource://inbox/BlueLake?project=/home/ubuntu/work/bbi-infrastructure"); err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	if _, err := c.ReadResource(context.Background(), "resource://agents/"+url.PathEscape(physical)); err != nil {
+		t.Fatalf("ReadResource agents: %v", err)
+	}
+	if got, _ := seen["ensure_project"]["human_key"].(string); got != canonical {
+		t.Fatalf("ensure_project human_key = %q, want %q", got, canonical)
+	}
+	if got, _ := seen["send_message"]["project_key"].(string); got != canonical {
+		t.Fatalf("send_message project_key = %q, want %q", got, canonical)
+	}
+	if got, _ := seen["resources/read"]["uri"].(string); got != "resource://agents/"+url.PathEscape(canonical) {
+		t.Fatalf("agent resource URI = %q, want one escaped canonical path segment", got)
+	}
+	if len(resourceURIs) != 2 || !strings.Contains(resourceURIs[0], "project="+url.QueryEscape(canonical)) {
+		t.Fatalf("resource URIs = %q, want canonical project query followed by escaped path", resourceURIs)
 	}
 }
 

--- a/internal/agentmail/coordinator_state.go
+++ b/internal/agentmail/coordinator_state.go
@@ -1,0 +1,155 @@
+package agentmail
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Dicklesworthstone/ntm/internal/util"
+)
+
+const coordinatorStateVersion = 1
+
+// CoordinatorIdentity is the durable Agent Mail sender used by the NTM
+// coordinator. The registration token is intentionally persisted in the
+// same mode-0600 session artifact as the identity; dispatch never invents a
+// sender or silently registers one.
+type CoordinatorIdentity struct {
+	AgentName         string `json:"agent_name"`
+	RegistrationToken string `json:"registration_token"`
+	Program           string `json:"program"`
+	Model             string `json:"model"`
+}
+
+// CoordinatorPaneBinding is an explicitly imported, live pane identity.
+// PanePID prevents a recycled tmux pane id from inheriting the old binding.
+type CoordinatorPaneBinding struct {
+	AgentName  string    `json:"agent_name"`
+	PanePID    int       `json:"pane_pid"`
+	ProjectDir string    `json:"project_dir"`
+	ImportedAt time.Time `json:"imported_at"`
+}
+
+// CoordinatorSessionState separates the physical checkout used by bv/br from
+// the canonical Agent Mail namespace. It is written only by the explicit
+// `ntm coordinator bootstrap` workflow.
+type CoordinatorSessionState struct {
+	Version        int                               `json:"version"`
+	SessionName    string                            `json:"session_name"`
+	ProjectDir     string                            `json:"project_dir"`
+	MailProjectKey string                            `json:"mail_project_key"`
+	Coordinator    CoordinatorIdentity               `json:"coordinator"`
+	PaneBindings   map[string]CoordinatorPaneBinding `json:"pane_bindings"`
+	CreatedAt      time.Time                         `json:"created_at"`
+	UpdatedAt      time.Time                         `json:"updated_at"`
+}
+
+func coordinatorStatePath(sessionName, projectDir string) string {
+	return filepath.Join(getSessionsBaseDir(), sessionName, primaryProjectSlug(projectDir), "coordinator.json")
+}
+
+// LoadCoordinatorSessionState loads only the artifact namespaced by the exact
+// physical project directory. It deliberately has no best-effort or legacy
+// fallback: stale state from another checkout/mail namespace is not authority.
+func LoadCoordinatorSessionState(sessionName, projectDir string) (*CoordinatorSessionState, error) {
+	if err := validateSessionStorageName(sessionName); err != nil {
+		return nil, err
+	}
+	if !filepath.IsAbs(strings.TrimSpace(projectDir)) {
+		return nil, fmt.Errorf("coordinator project directory must be absolute: %q", projectDir)
+	}
+	path := coordinatorStatePath(sessionName, filepath.Clean(projectDir))
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading coordinator state: %w", err)
+	}
+	var state CoordinatorSessionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parsing coordinator state: %w", err)
+	}
+	if err := ValidateCoordinatorSessionState(&state, sessionName, projectDir); err != nil {
+		return nil, fmt.Errorf("invalid coordinator state %s: %w", path, err)
+	}
+	return &state, nil
+}
+
+// SaveCoordinatorSessionState atomically persists a validated coordinator
+// sender/token and the exact pane bindings imported by the operator.
+func SaveCoordinatorSessionState(state *CoordinatorSessionState) error {
+	if state == nil {
+		return fmt.Errorf("cannot save nil coordinator state")
+	}
+	if state.Version == 0 {
+		state.Version = coordinatorStateVersion
+	}
+	if err := ValidateCoordinatorSessionState(state, state.SessionName, state.ProjectDir); err != nil {
+		return err
+	}
+	path := coordinatorStatePath(state.SessionName, state.ProjectDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating coordinator state directory: %w", err)
+	}
+	now := time.Now().UTC()
+	if state.CreatedAt.IsZero() {
+		state.CreatedAt = now
+	}
+	state.UpdatedAt = now
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling coordinator state: %w", err)
+	}
+	if err := util.AtomicWriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing coordinator state: %w", err)
+	}
+	return nil
+}
+
+// ValidateCoordinatorSessionState enforces the fail-closed runtime contract.
+func ValidateCoordinatorSessionState(state *CoordinatorSessionState, sessionName, projectDir string) error {
+	if state == nil {
+		return fmt.Errorf("coordinator state is required")
+	}
+	if err := validateSessionStorageName(sessionName); err != nil {
+		return err
+	}
+	if state.Version != coordinatorStateVersion {
+		return fmt.Errorf("unsupported version %d", state.Version)
+	}
+	if strings.TrimSpace(state.SessionName) != strings.TrimSpace(sessionName) {
+		return fmt.Errorf("session %q does not match %q", state.SessionName, sessionName)
+	}
+	cleanProjectDir := filepath.Clean(strings.TrimSpace(projectDir))
+	if !filepath.IsAbs(cleanProjectDir) || filepath.Clean(state.ProjectDir) != cleanProjectDir {
+		return fmt.Errorf("project directory %q does not match %q", state.ProjectDir, projectDir)
+	}
+	if key := strings.TrimSpace(state.MailProjectKey); !filepath.IsAbs(key) {
+		return fmt.Errorf("mail project key must be an absolute canonical key: %q", state.MailProjectKey)
+	}
+	if strings.TrimSpace(state.Coordinator.AgentName) == "" {
+		return fmt.Errorf("coordinator agent name is required")
+	}
+	if strings.TrimSpace(state.Coordinator.RegistrationToken) == "" {
+		return fmt.Errorf("coordinator registration token is required")
+	}
+	if state.Coordinator.Program != "ntm" || state.Coordinator.Model != "coordinator" {
+		return fmt.Errorf("coordinator identity must use program=ntm and model=coordinator")
+	}
+	for paneID, binding := range state.PaneBindings {
+		if strings.TrimSpace(paneID) == "" || strings.TrimSpace(binding.AgentName) == "" {
+			return fmt.Errorf("pane binding has an empty pane id or agent name")
+		}
+		if binding.PanePID <= 0 {
+			return fmt.Errorf("pane %s binding has invalid pid %d", paneID, binding.PanePID)
+		}
+		if filepath.Clean(binding.ProjectDir) != cleanProjectDir {
+			return fmt.Errorf("pane %s project %q does not match %q", paneID, binding.ProjectDir, cleanProjectDir)
+		}
+	}
+	return nil
+}

--- a/internal/agentmail/coordinator_state_test.go
+++ b/internal/agentmail/coordinator_state_test.go
@@ -1,0 +1,61 @@
+package agentmail
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorSessionStateRoundTripPersistsStrictIdentityAndBindings(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("HOME", configHome)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	projectDir := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := &CoordinatorSessionState{
+		Version: 1, SessionName: "bbi-infrastructure", ProjectDir: projectDir,
+		MailProjectKey: "/repos/github.com/biji-biji-initiative/bbi-infrastructure",
+		Coordinator: CoordinatorIdentity{
+			AgentName: "SilverHarbor", RegistrationToken: "secret-token", Program: "ntm", Model: "coordinator",
+		},
+		PaneBindings: map[string]CoordinatorPaneBinding{
+			"%44": {AgentName: "AzureCreek", PanePID: 4400, ProjectDir: projectDir, ImportedAt: time.Now().UTC()},
+		},
+	}
+	if err := SaveCoordinatorSessionState(state); err != nil {
+		t.Fatalf("SaveCoordinatorSessionState: %v", err)
+	}
+	loaded, err := LoadCoordinatorSessionState(state.SessionName, projectDir)
+	if err != nil {
+		t.Fatalf("LoadCoordinatorSessionState: %v", err)
+	}
+	if loaded == nil || loaded.MailProjectKey == loaded.ProjectDir {
+		t.Fatalf("project/mail namespaces were conflated: %+v", loaded)
+	}
+	if loaded.Coordinator.AgentName != "SilverHarbor" || loaded.Coordinator.RegistrationToken != "secret-token" {
+		t.Fatalf("coordinator identity/token not persisted: %+v", loaded.Coordinator)
+	}
+	if got := loaded.PaneBindings["%44"]; got.AgentName != "AzureCreek" || got.PanePID != 4400 {
+		t.Fatalf("exact pane binding not persisted: %+v", got)
+	}
+	info, err := os.Stat(coordinatorStatePath(state.SessionName, projectDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("coordinator state mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestCoordinatorSessionStateRejectsMissingSenderToken(t *testing.T) {
+	state := &CoordinatorSessionState{
+		Version: 1, SessionName: "session", ProjectDir: "/work/project", MailProjectKey: "/repos/example/project",
+		Coordinator: CoordinatorIdentity{AgentName: "SilverHarbor", Program: "ntm", Model: "coordinator"},
+	}
+	if err := ValidateCoordinatorSessionState(state, "session", "/work/project"); err == nil {
+		t.Fatal("state without a coordinator token was accepted")
+	}
+}

--- a/internal/agentmail/project_key.go
+++ b/internal/agentmail/project_key.go
@@ -1,9 +1,29 @@
 package agentmail
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 )
+
+// ProjectKeyOverrideEnv selects a canonical Agent Mail project identity for
+// one NTM invocation. It is deliberately environment-scoped: callers that do
+// not set it retain their physical checkout path as the Agent Mail key.
+//
+// This is useful when a checked-out upstream project must coordinate through a
+// registered shared namespace, for example the public BBI project key.
+const ProjectKeyOverrideEnv = "NTM_AGENT_MAIL_PROJECT_KEY"
+
+// InvocationProjectKey returns the Agent Mail key to use for this process.
+// An explicitly configured canonical key wins over a physical working
+// directory; whitespace-only overrides are ignored so they cannot turn a
+// normal invocation into an empty project key.
+func InvocationProjectKey(projectKey string) string {
+	if override := strings.TrimSpace(os.Getenv(ProjectKeyOverrideEnv)); override != "" {
+		return override
+	}
+	return projectKey
+}
 
 // CanonicalProjectKey resolves a project key through symlinks to the real
 // directory Agent Mail registers projects under.

--- a/internal/agentmail/project_key_test.go
+++ b/internal/agentmail/project_key_test.go
@@ -48,6 +48,21 @@ func TestCanonicalProjectKeyFallsBackOnMissingPath(t *testing.T) {
 	}
 }
 
+func TestInvocationProjectKeyOverrideIsScopedAndExplicit(t *testing.T) {
+	physical := "/home/ubuntu/work/bbi-infrastructure"
+	canonical := "/repos/github.com/biji-biji-initiative/bbi-infrastructure"
+
+	t.Setenv(ProjectKeyOverrideEnv, "  "+canonical+"  ")
+	if got := InvocationProjectKey(physical); got != canonical {
+		t.Fatalf("InvocationProjectKey() = %q, want canonical public key %q", got, canonical)
+	}
+
+	t.Setenv(ProjectKeyOverrideEnv, " \t ")
+	if got := InvocationProjectKey(physical); got != physical {
+		t.Fatalf("blank override must preserve physical key: got %q want %q", got, physical)
+	}
+}
+
 func TestProjectKeysEquivalent(t *testing.T) {
 	t.Parallel()
 	real, link := makeSymlinkedDir(t)

--- a/internal/cli/controller.go
+++ b/internal/cli/controller.go
@@ -19,6 +19,31 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
 
+var controllerCreateDetachedWindow = func(ctx context.Context, session, directory string) (string, error) {
+	return tmux.DefaultClient.RunContext(ctx, newControllerWindowArgs(session, directory)...)
+}
+
+func newControllerWindowArgs(session, directory string) []string {
+	return []string{"new-window", "-d", "-t", tmux.TargetSession(session), "-c", directory, "-n", "ntm-controller", "-P", "-F", "#{pane_id}"}
+}
+
+func createDedicatedControllerPane(ctx context.Context, session, directory string, existing []tmux.Pane) (string, error) {
+	paneID, err := controllerCreateDetachedWindow(ctx, session, directory)
+	if err != nil {
+		return "", err
+	}
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return "", fmt.Errorf("detached controller window returned no pane id")
+	}
+	for _, pane := range existing {
+		if pane.ID == paneID {
+			return "", fmt.Errorf("detached controller window returned existing pane id %s", paneID)
+		}
+	}
+	return paneID, nil
+}
+
 // ControllerInput is the kernel input for sessions.controller.
 type ControllerInput struct {
 	Session    string `json:"session"`
@@ -81,7 +106,7 @@ func init() {
 	// Register sessions.controller command
 	kernel.MustRegister(kernel.Command{
 		Name:        "sessions.controller",
-		Description: "Launch a dedicated controller agent in pane 1",
+		Description: "Launch a dedicated controller agent in a detached window",
 		Category:    "sessions",
 		Input: &kernel.SchemaRef{
 			Name: "ControllerInput",
@@ -139,8 +164,8 @@ func newControllerCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "controller <session>",
-		Short: "Launch a dedicated controller agent in pane 1",
-		Long: `Launch a controller agent in pane 1 of an existing session.
+		Short: "Launch a dedicated controller agent in a detached window",
+		Long: `Launch a controller agent in a new detached window of an existing session.
 
 The controller agent coordinates work among other agents in the session,
 prevents conflicts, and ensures quality.
@@ -314,38 +339,22 @@ func buildControllerResponse(ctx context.Context, opts ControllerInput) (*Contro
 		agentCmd = claudeEnv.ApplyToCommand(agentCmd)
 	}
 
-	// Find or create pane 1
-	var targetPaneID string
-	var targetPaneIndex int
-	pane1Found := false
-
-	for _, p := range panes {
-		if p.Index == 1 {
-			pane1Found = true
-			targetPaneID = p.ID
+	// Always create a detached dedicated window and target only the pane ID
+	// returned by tmux. Pane indices repeat across windows; reusing "pane 1"
+	// can overwrite a running agent in an unrelated window.
+	targetPaneID, err := createDedicatedControllerPane(ctx, session, dir, panes)
+	if err != nil {
+		return nil, fmt.Errorf("creating detached controller window: %w", err)
+	}
+	targetPaneIndex := 0
+	updatedPanes, err := tmux.GetPanes(session)
+	if err != nil {
+		return nil, fmt.Errorf("getting updated panes: %w", err)
+	}
+	for _, p := range updatedPanes {
+		if p.ID == targetPaneID {
 			targetPaneIndex = p.Index
 			break
-		}
-	}
-
-	if !pane1Found {
-		// Create a new pane which will become the controller pane
-		newPaneID, err := tmux.SplitWindow(session, dir)
-		if err != nil {
-			return nil, fmt.Errorf("creating controller pane: %w", err)
-		}
-		targetPaneID = newPaneID
-
-		// Get updated pane list to find the new pane's index
-		updatedPanes, err := tmux.GetPanes(session)
-		if err != nil {
-			return nil, fmt.Errorf("getting updated panes: %w", err)
-		}
-		for _, p := range updatedPanes {
-			if p.ID == newPaneID {
-				targetPaneIndex = p.Index
-				break
-			}
 		}
 	}
 

--- a/internal/cli/controller.go
+++ b/internal/cli/controller.go
@@ -17,10 +17,15 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/swarm"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
+	"github.com/Dicklesworthstone/ntm/internal/util"
 )
 
 var controllerCreateDetachedWindow = func(ctx context.Context, session, directory string) (string, error) {
 	return tmux.DefaultClient.RunContext(ctx, newControllerWindowArgs(session, directory)...)
+}
+
+var controllerPaneCurrentDir = func(paneID string) (string, error) {
+	return tmux.DefaultClient.Run("display-message", "-p", "-t", tmux.ExactTarget(paneID), "#{pane_current_path}")
 }
 
 func newControllerWindowArgs(session, directory string) []string {
@@ -46,22 +51,26 @@ func createDedicatedControllerPane(ctx context.Context, session, directory strin
 
 // ControllerInput is the kernel input for sessions.controller.
 type ControllerInput struct {
-	Session    string `json:"session"`
-	AgentType  string `json:"agent_type,omitempty"`
-	PromptFile string `json:"prompt_file,omitempty"`
-	NoPrompt   bool   `json:"no_prompt,omitempty"`
+	Session         string `json:"session"`
+	AgentType       string `json:"agent_type,omitempty"`
+	Model           string `json:"model,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	PromptFile      string `json:"prompt_file,omitempty"`
+	NoPrompt        bool   `json:"no_prompt,omitempty"`
 }
 
 // ControllerResponse is the JSON output for the controller command.
 type ControllerResponse struct {
 	output.TimestampedResponse
-	Session    string `json:"session"`
-	PaneID     string `json:"pane_id"`
-	PaneIndex  int    `json:"pane_index"`
-	AgentType  string `json:"agent_type"`
-	PromptUsed string `json:"prompt_used,omitempty"`
-	AgentCount int    `json:"agent_count"`
-	AgentList  string `json:"agent_list,omitempty"`
+	Session         string `json:"session"`
+	PaneID          string `json:"pane_id"`
+	PaneIndex       int    `json:"pane_index"`
+	AgentType       string `json:"agent_type"`
+	Model           string `json:"model,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	PromptUsed      string `json:"prompt_used,omitempty"`
+	AgentCount      int    `json:"agent_count"`
+	AgentList       string `json:"agent_list,omitempty"`
 }
 
 // Default controller prompt template
@@ -159,6 +168,8 @@ func init() {
 
 func newControllerCmd() *cobra.Command {
 	var agentType string
+	var model string
+	var reasoningEffort string
 	var promptFile string
 	var noPrompt bool
 
@@ -176,6 +187,7 @@ You can customize the agent type and prompt as needed.
 Examples:
   ntm controller myproject                    # Default Claude controller
   ntm controller myproject --agent-type=cod   # Use Codex as controller
+  ntm controller myproject --agent-type=cod --model=gpt-5.6-sol --reasoning-effort=ultra
   ntm controller myproject --prompt=ctrl.txt  # Custom prompt from file
 
 The default prompt includes:
@@ -190,16 +202,20 @@ Custom prompt files support template variables:
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := ControllerInput{
-				Session:    args[0],
-				AgentType:  agentType,
-				PromptFile: promptFile,
-				NoPrompt:   noPrompt,
+				Session:         args[0],
+				AgentType:       agentType,
+				Model:           model,
+				ReasoningEffort: reasoningEffort,
+				PromptFile:      promptFile,
+				NoPrompt:        noPrompt,
 			}
 			return runController(cmd.Context(), opts)
 		},
 	}
 
 	cmd.Flags().StringVar(&agentType, "agent-type", "cc", "Agent type: cc, cod, gmi, agy, cursor, windsurf|ws, aider, oc, or ollama")
+	cmd.Flags().StringVar(&model, "model", "", "Exact model for the controller agent")
+	cmd.Flags().StringVar(&reasoningEffort, "reasoning-effort", "", "Exact reasoning effort for the controller agent")
 	cmd.Flags().StringVar(&promptFile, "prompt", "", "Custom prompt file (supports template variables)")
 	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Skip sending initial prompt")
 	cmd.ValidArgsFunction = completeSessionArgs
@@ -225,6 +241,12 @@ func runController(ctx context.Context, opts ControllerInput) error {
 	fmt.Printf("✓ Controller agent launched in session '%s'\n", resp.Session)
 	fmt.Printf("  Pane: %d (%s)\n", resp.PaneIndex, resp.PaneID)
 	fmt.Printf("  Agent type: %s\n", resp.AgentType)
+	if resp.Model != "" {
+		fmt.Printf("  Model: %s\n", resp.Model)
+	}
+	if resp.ReasoningEffort != "" {
+		fmt.Printf("  Reasoning effort: %s\n", resp.ReasoningEffort)
+	}
 	if resp.PromptUsed != "" {
 		fmt.Printf("  Prompt: %s\n", resp.PromptUsed)
 	}
@@ -310,18 +332,13 @@ func buildControllerResponse(ctx context.Context, opts ControllerInput) (*Contro
 		return nil, fmt.Errorf("unknown agent type: %s", agentType)
 	}
 
-	dir, err := resolveExplicitProjectDirForSessionContext(ctx, session)
+	dir, err := resolveControllerProjectDir(ctx, session, panes)
 	if err != nil {
 		return nil, err
 	}
 
 	// Render the agent command template (fixes raw {{}} being sent to shell)
-	agentCmd, err := config.GenerateAgentCommand(agentCmdTemplate, config.AgentTemplateVars{
-		AgentType:   agentType,
-		SessionName: session,
-		PaneIndex:   1,
-		ProjectDir:  dir,
-	})
+	agentCmd, err := renderControllerAgentCommand(agentCmdTemplate, opts, agentType, agentTypeFull, session, dir)
 	if err != nil {
 		return nil, fmt.Errorf("rendering agent command template: %w", err)
 	}
@@ -393,10 +410,65 @@ func buildControllerResponse(ctx context.Context, opts ControllerInput) (*Contro
 		PaneID:              targetPaneID,
 		PaneIndex:           targetPaneIndex,
 		AgentType:           agentTypeFull,
+		Model:               strings.TrimSpace(opts.Model),
+		ReasoningEffort:     strings.TrimSpace(opts.ReasoningEffort),
 		PromptUsed:          promptUsed,
 		AgentCount:          agentCount,
 		AgentList:           strings.Join(agentList, "\n"),
 	}, nil
+}
+
+// resolveControllerProjectDir permits an intentionally mixed session only
+// when at least one live pane still proves the configured session checkout.
+// The dedicated controller is created in that checkout; unrelated utility
+// panes neither redefine the project nor become controller targets.
+func resolveControllerProjectDir(ctx context.Context, session string, panes []tmux.Pane) (string, error) {
+	activeCfg := cfg
+	if activeCfg == nil {
+		activeCfg = config.Default()
+	}
+	if activeCfg != nil {
+		configured := filepath.Clean(activeCfg.GetProjectDir(session))
+		if filepath.IsAbs(configured) && util.ProjectDirScore(configured) > 0 {
+			for _, pane := range panes {
+				paneDir, err := controllerPaneCurrentDir(pane.ID)
+				if err != nil {
+					continue
+				}
+				if same, _ := coordinatorProjectDirsMatch(ctx, configured, paneDir); same {
+					return configured, nil
+				}
+			}
+		}
+	}
+	return resolveExplicitProjectDirForSessionContext(ctx, session)
+}
+
+func renderControllerAgentCommand(agentCmdTemplate string, opts ControllerInput, agentType, agentTypeFull, session, projectDir string) (string, error) {
+	model := strings.TrimSpace(opts.Model)
+	reasoningEffort := strings.TrimSpace(opts.ReasoningEffort)
+	agentCmd, err := config.GenerateAgentCommand(agentCmdTemplate, config.AgentTemplateVars{
+		AgentType:       agentType,
+		Model:           model,
+		ModelRequested:  model != "",
+		ReasoningEffort: reasoningEffort,
+		SessionName:     session,
+		PaneIndex:       1,
+		ProjectDir:      projectDir,
+	})
+	if err != nil {
+		return "", err
+	}
+	// A controller window is born inside the existing tmux server and does not
+	// reliably inherit arbitrary client variables. Freeze an explicitly supplied
+	// Codex profile into the one-shot pane command instead of falling back to the
+	// profile embedded in the user's agent template.
+	if agentTypeFull == "codex" {
+		if profile := strings.TrimSpace(os.Getenv("NTM_CODEX_PROFILE")); profile != "" {
+			agentCmd = "export NTM_CODEX_PROFILE=" + config.ShellQuote(profile) + "; " + agentCmd
+		}
+	}
+	return agentCmd, nil
 }
 
 func controllerAgentList(panes []tmux.Pane) ([]string, int) {

--- a/internal/cli/controller.go
+++ b/internal/cli/controller.go
@@ -381,6 +381,20 @@ func buildControllerResponse(ctx context.Context, opts ControllerInput) (*Contro
 		return nil, fmt.Errorf("setting controller pane identity: %w", err)
 	}
 
+	// Register and publish the controller's Agent Mail identity before its
+	// command starts. A controller begins using NTM's coordination surfaces
+	// immediately, so delaying this until after SendKeys creates the same
+	// boot-time identity race avoided by normal spawn (#255).
+	identityCoordinator := newSpawnIdentityCoordinator(dir, session)
+	identityCoordinator.prepareAgent(ctx, spawnedAgentInfo{
+		paneIndex: targetPaneIndex,
+		paneID:    targetPaneID,
+		paneTitle: title,
+		paneDir:   dir,
+		agentType: agentType,
+		model:     opts.Model,
+	})
+
 	// Launch the agent
 	if err := tmux.SendKeys(targetPaneID, agentCmd, true); err != nil {
 		return nil, fmt.Errorf("launching agent: %w", err)

--- a/internal/cli/controller_test.go
+++ b/internal/cli/controller_test.go
@@ -1,14 +1,56 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
+
+func TestControllerUsesDetachedDedicatedWindowWithoutTargetingExistingPanes(t *testing.T) {
+	existing := []tmux.Pane{
+		{ID: "%44", Index: 1, WindowIndex: 1, PID: 4400, Title: "bbi-infrastructure__cod_1"},
+		{ID: "%51", Index: 0, WindowIndex: 2, PID: 5100, Title: "bbi-infrastructure__cod_2"},
+	}
+	before := append([]tmux.Pane(nil), existing...)
+	previousCreate := controllerCreateDetachedWindow
+	controllerCreateDetachedWindow = func(_ context.Context, session, directory string) (string, error) {
+		if session != "bbi-infrastructure" || directory != "/home/ubuntu/work/bbi-infrastructure" {
+			t.Fatalf("detached window target = %q %q", session, directory)
+		}
+		return "%200", nil
+	}
+	t.Cleanup(func() { controllerCreateDetachedWindow = previousCreate })
+	newPaneID, err := createDedicatedControllerPane(t.Context(), "bbi-infrastructure", "/home/ubuntu/work/bbi-infrastructure", existing)
+	if err != nil {
+		t.Fatalf("createDedicatedControllerPane: %v", err)
+	}
+	if newPaneID != "%200" {
+		t.Fatalf("controller pane = %q, want newly-created %%200", newPaneID)
+	}
+	args := newControllerWindowArgs("bbi-infrastructure", "/home/ubuntu/work/bbi-infrastructure")
+
+	want := []string{
+		"new-window", "-d", "-t", "=bbi-infrastructure", "-c", "/home/ubuntu/work/bbi-infrastructure",
+		"-n", "ntm-controller", "-P", "-F", "#{pane_id}",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("controller window args = %#v, want %#v", args, want)
+	}
+	if !reflect.DeepEqual(existing, before) {
+		t.Fatalf("controller planning mutated existing panes: got %+v want %+v", existing, before)
+	}
+	for _, arg := range args {
+		if arg == "%44" || arg == "%51" || arg == "split-window" || arg == "send-keys" {
+			t.Fatalf("detached controller creation targets an existing pane/process via %q", arg)
+		}
+	}
+}
 
 // ---------------------------------------------------------------------------
 // resolveControllerPrompt – template variable substitution

--- a/internal/cli/controller_test.go
+++ b/internal/cli/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Dicklesworthstone/ntm/internal/config"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
@@ -48,6 +49,65 @@ func TestControllerUsesDetachedDedicatedWindowWithoutTargetingExistingPanes(t *t
 	for _, arg := range args {
 		if arg == "%44" || arg == "%51" || arg == "split-window" || arg == "send-keys" {
 			t.Fatalf("detached controller creation targets an existing pane/process via %q", arg)
+		}
+	}
+}
+
+func TestResolveControllerProjectDirPreservesConfiguredTargetInMixedSession(t *testing.T) {
+	projectsBase := t.TempDir()
+	target := filepath.Join(projectsBase, "bbi-infrastructure")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	previousCfg := cfg
+	configured := config.Default()
+	configured.ProjectsBase = projectsBase
+	cfg = configured
+	t.Cleanup(func() { cfg = previousCfg })
+
+	previousCurrentDir := controllerPaneCurrentDir
+	controllerPaneCurrentDir = func(paneID string) (string, error) {
+		switch paneID {
+		case "%44":
+			return target, nil
+		case "%66":
+			return "/home/ubuntu/work/mereka-lms", nil
+		default:
+			return "", os.ErrNotExist
+		}
+	}
+	t.Cleanup(func() { controllerPaneCurrentDir = previousCurrentDir })
+
+	panes := []tmux.Pane{
+		{ID: "%44", PID: 4400, Title: "bbi-infrastructure__cod_1"},
+		{ID: "%66", PID: 6600, Title: "mereka-lms__cc_1"},
+	}
+	got, err := resolveControllerProjectDir(t.Context(), "bbi-infrastructure", panes)
+	if err != nil {
+		t.Fatalf("resolveControllerProjectDir: %v", err)
+	}
+	if got != target {
+		t.Fatalf("controller project dir = %q, want configured BBI checkout %q", got, target)
+	}
+}
+
+func TestRenderControllerAgentCommandCarriesExplicitSolUltraAndProfile(t *testing.T) {
+	t.Setenv("NTM_CODEX_PROFILE", "g1")
+	template := `exec /opt/ntm/codex ${NTM_CODEX_PROFILE:-g3} -m {{shellQuote .Model}} -c model_reasoning_effort={{shellQuote .ReasoningEffort}}`
+	opts := ControllerInput{Model: "gpt-5.6-sol", ReasoningEffort: "ultra"}
+
+	got, err := renderControllerAgentCommand(template, opts, "cod", "codex", "bbi-infrastructure", "/home/ubuntu/work/bbi-infrastructure")
+	if err != nil {
+		t.Fatalf("renderControllerAgentCommand: %v", err)
+	}
+	for _, want := range []string{
+		"export NTM_CODEX_PROFILE='g1';",
+		"'gpt-5.6-sol'",
+		"model_reasoning_effort='ultra'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered controller command %q does not contain %q", got, want)
 		}
 	}
 }
@@ -428,6 +488,23 @@ func TestControllerCmdFlags(t *testing.T) {
 		t.Errorf("--agent-type default = %q, want 'cc'", f.DefValue)
 	}
 
+	// Explicit model and effort flags must reach AgentTemplateVars rather than
+	// silently falling back to the controller template's defaults.
+	f = cmd.Flags().Lookup("model")
+	if f == nil {
+		t.Fatal("--model flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--model default = %q, want ''", f.DefValue)
+	}
+	f = cmd.Flags().Lookup("reasoning-effort")
+	if f == nil {
+		t.Fatal("--reasoning-effort flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--reasoning-effort default = %q, want ''", f.DefValue)
+	}
+
 	// Check --prompt flag
 	f = cmd.Flags().Lookup("prompt")
 	if f == nil {
@@ -472,13 +549,15 @@ func TestControllerCmdRequiresExactlyOneArg(t *testing.T) {
 
 func TestControllerResponseFields(t *testing.T) {
 	resp := ControllerResponse{
-		Session:    "test-proj",
-		PaneID:     "%5",
-		PaneIndex:  1,
-		AgentType:  "claude",
-		PromptUsed: "default",
-		AgentCount: 3,
-		AgentList:  "- Pane 2: cc\n- Pane 3: cod\n- Pane 4: gmi",
+		Session:         "test-proj",
+		PaneID:          "%5",
+		PaneIndex:       1,
+		AgentType:       "codex",
+		Model:           "gpt-5.6-sol",
+		ReasoningEffort: "ultra",
+		PromptUsed:      "default",
+		AgentCount:      3,
+		AgentList:       "- Pane 2: cc\n- Pane 3: cod\n- Pane 4: gmi",
 	}
 
 	if resp.Session != "test-proj" {
@@ -487,8 +566,11 @@ func TestControllerResponseFields(t *testing.T) {
 	if resp.PaneIndex != 1 {
 		t.Errorf("PaneIndex = %d, want 1", resp.PaneIndex)
 	}
-	if resp.AgentType != "claude" {
-		t.Errorf("AgentType = %q, want 'claude'", resp.AgentType)
+	if resp.AgentType != "codex" {
+		t.Errorf("AgentType = %q, want 'codex'", resp.AgentType)
+	}
+	if resp.Model != "gpt-5.6-sol" || resp.ReasoningEffort != "ultra" {
+		t.Errorf("controller model/effort = %q/%q, want gpt-5.6-sol/ultra", resp.Model, resp.ReasoningEffort)
 	}
 	if resp.AgentCount != 3 {
 		t.Errorf("AgentCount = %d, want 3", resp.AgentCount)

--- a/internal/cli/controller_test.go
+++ b/internal/cli/controller_test.go
@@ -2,9 +2,13 @@ package cli
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -12,6 +16,60 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 )
+
+// TestControllerBootstrapsIdentityBeforeAgentCommand prevents controller
+// launches from regressing to the old post-launch registration race. The
+// check is structural because the production dispatch is a real tmux command:
+// the identity coordinator must run before controller SendKeys.
+func TestControllerBootstrapsIdentityBeforeAgentCommand(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate controller test source")
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath.Join(filepath.Dir(testFile), "controller.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse controller.go: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if candidate, ok := decl.(*ast.FuncDecl); ok && candidate.Name.Name == "buildControllerResponse" {
+			fn = candidate
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("buildControllerResponse not found")
+	}
+
+	var prepare, launch token.Pos
+	ast.Inspect(fn, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch selector.Sel.Name {
+		case "prepareAgent":
+			prepare = call.Pos()
+		case "SendKeys":
+			if launch == token.NoPos {
+				launch = call.Pos()
+			}
+		}
+		return true
+	})
+	if prepare == token.NoPos || launch == token.NoPos {
+		t.Fatalf("controller bootstrap/launch calls missing: prepare=%v launch=%v", prepare, launch)
+	}
+	if fset.Position(prepare).Offset >= fset.Position(launch).Offset {
+		t.Fatalf("controller identity bootstrap at %v must precede agent command at %v", fset.Position(prepare), fset.Position(launch))
+	}
+}
 
 func TestControllerUsesDetachedDedicatedWindowWithoutTargetingExistingPanes(t *testing.T) {
 	existing := []tmux.Pane{

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -654,6 +654,7 @@ type coordinatorRunOutput struct {
 
 func newCoordinatorRunCmd() *cobra.Command {
 	var once bool
+	var allowCriticalPressure bool
 	cmd := &cobra.Command{
 		Use:   "run [session]",
 		Short: "Run the session coordinator until interrupted",
@@ -663,14 +664,18 @@ opt-in automatic assignment. The command exits cleanly on SIGINT or SIGTERM.
 Use --once to execute exactly one fresh observation and assignment cycle.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoordinatorRun(cmd, args, once)
+			return runCoordinatorRun(cmd, args, once, allowCriticalPressure)
 		},
 	}
 	cmd.Flags().BoolVar(&once, "once", false, "Run exactly one fresh coordinator cycle")
+	cmd.Flags().BoolVar(&allowCriticalPressure, "allow-critical-pressure", false, "Allow one explicit assignment cycle under reported critical host pressure (requires --once)")
 	return cmd
 }
 
-func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
+func runCoordinatorRun(cmd *cobra.Command, args []string, once, allowCriticalPressure bool) error {
+	if allowCriticalPressure && !once {
+		return markCLIInvalidInput(errors.New("--allow-critical-pressure requires --once"))
+	}
 	var session string
 	if len(args) > 0 {
 		session = args[0]
@@ -699,6 +704,7 @@ func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
 	}
 
 	runtimeConfig, ntmConfig := loadCoordinatorRuntimeConfigWithNTM()
+	runtimeConfig.AllowCriticalPressure = allowCriticalPressure
 	coord, _, err := loadBootstrappedCoordinator(session, projectKey)
 	if err != nil {
 		return err
@@ -762,7 +768,7 @@ func coordinatorRunFailure(assignments []coordinator.AssignmentResult, cycleErr 
 	}
 	failed := 0
 	for _, result := range assignments {
-		if !result.Success {
+		if !result.Success && !result.Deferred {
 			failed++
 		}
 	}

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -27,6 +27,7 @@ import (
 var (
 	coordinatorSessionExists  = tmux.SessionExists
 	coordinatorGetPanes       = tmux.GetPanes
+	coordinatorGetAllPanes    = tmux.GetAllPanesContext
 	coordinatorPaneCurrentDir = func(paneID string) (string, error) {
 		return tmux.DefaultClient.Run("display-message", "-p", "-t", tmux.ExactTarget(paneID), "#{pane_current_path}")
 	}
@@ -162,6 +163,10 @@ func runCoordinatorBootstrap(cmd *cobra.Command, requestedSession string, opts c
 	if err != nil {
 		return fmt.Errorf("getting coordinator panes: %w", err)
 	}
+	panes, err = coordinatorBootstrapPanes(cmd.Context(), panes, opts.Bindings)
+	if err != nil {
+		return fmt.Errorf("getting explicitly bound coordinator panes: %w", err)
+	}
 	bindings, publicBindings, err := validateCoordinatorBootstrapBindings(cmd.Context(), projectDir, panes, opts.Bindings)
 	if err != nil {
 		return markCLIInvalidInput(err)
@@ -257,6 +262,44 @@ func runCoordinatorBootstrap(cmd *cobra.Command, requestedSession string, opts c
 	}
 	result.Persisted = true
 	return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+}
+
+// coordinatorBootstrapPanes expands the primary session topology only when an
+// explicit binding names a pane outside it. Pane IDs are tmux-server-global;
+// the later PID and project checks remain the authorization boundary.
+func coordinatorBootstrapPanes(ctx context.Context, primary []tmux.Pane, specs []string) ([]tmux.Pane, error) {
+	live := make(map[string]struct{}, len(primary))
+	for _, pane := range primary {
+		live[pane.ID] = struct{}{}
+	}
+	needsAll := false
+	for _, spec := range specs {
+		paneID, _, ok := strings.Cut(spec, "=")
+		if ok {
+			if _, present := live[strings.TrimSpace(paneID)]; !present {
+				needsAll = true
+				break
+			}
+		}
+	}
+	if !needsAll {
+		return primary, nil
+	}
+	bySession, err := coordinatorGetAllPanes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := append([]tmux.Pane(nil), primary...)
+	for _, panes := range bySession {
+		for _, pane := range panes {
+			if _, exists := live[pane.ID]; exists {
+				continue
+			}
+			live[pane.ID] = struct{}{}
+			result = append(result, pane)
+		}
+	}
+	return result, nil
 }
 
 func validateCoordinatorBootstrapBindings(ctx context.Context, projectDir string, panes []tmux.Pane, specs []string) (map[string]agentmail.CoordinatorPaneBinding, map[string]string, error) {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -14,11 +14,14 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Dicklesworthstone/ntm/internal/agentmail"
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	"github.com/Dicklesworthstone/ntm/internal/coordinator"
+	ntmgit "github.com/Dicklesworthstone/ntm/internal/git"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
 	"github.com/Dicklesworthstone/ntm/internal/tui/theme"
+	"github.com/Dicklesworthstone/ntm/internal/util"
 )
 
 var (
@@ -53,6 +56,7 @@ Examples:
 	}
 
 	cmd.AddCommand(newCoordinatorStatusCmd())
+	cmd.AddCommand(newCoordinatorBootstrapCmd())
 	cmd.AddCommand(newCoordinatorDigestCmd())
 	cmd.AddCommand(newCoordinatorConflictsCmd())
 	cmd.AddCommand(newCoordinatorAssignCmd())
@@ -82,6 +86,244 @@ Examples:
 	}
 
 	return cmd
+}
+
+type coordinatorBootstrapOptions struct {
+	MailProjectKey  string
+	CoordinatorName string
+	TokenFile       string
+	Bindings        []string
+	DryRun          bool
+}
+
+type coordinatorBootstrapResult struct {
+	Success         bool              `json:"success"`
+	DryRun          bool              `json:"dry_run"`
+	Session         string            `json:"session"`
+	ProjectDir      string            `json:"project_dir"`
+	MailProjectKey  string            `json:"mail_project_key"`
+	CoordinatorName string            `json:"coordinator_name"`
+	PaneBindings    map[string]string `json:"pane_bindings"`
+	WouldCreate     bool              `json:"would_create_coordinator,omitempty"`
+	Persisted       bool              `json:"persisted"`
+}
+
+func newCoordinatorBootstrapCmd() *cobra.Command {
+	var opts coordinatorBootstrapOptions
+	cmd := &cobra.Command{
+		Use:   "bootstrap <session>",
+		Short: "Explicitly persist the coordinator sender and live pane identities",
+		Long: `Bootstrap is the only coordinator command allowed to create its Agent Mail
+sender. It requires an explicit canonical mail project key, exact coordinator
+name, and exact live pane-to-agent bindings. Dispatch commands never register
+or invent identities. Use --dry-run to validate without creating or writing.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCoordinatorBootstrap(cmd, args[0], opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.MailProjectKey, "mail-project-key", "", "Canonical Agent Mail project key (required)")
+	cmd.Flags().StringVar(&opts.CoordinatorName, "coordinator-name", "", "Exact durable coordinator Agent Mail name (required)")
+	cmd.Flags().StringVar(&opts.TokenFile, "registration-token-file", "", "Absolute mode-0600 file containing an existing coordinator token")
+	cmd.Flags().StringArrayVar(&opts.Bindings, "bind", nil, "Exact live pane binding PANE_ID=AGENT_NAME (repeatable, required)")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Validate only; do not create an identity or persist state")
+	_ = cmd.MarkFlagRequired("mail-project-key")
+	_ = cmd.MarkFlagRequired("coordinator-name")
+	_ = cmd.MarkFlagRequired("bind")
+	return cmd
+}
+
+func runCoordinatorBootstrap(cmd *cobra.Command, requestedSession string, opts coordinatorBootstrapOptions) error {
+	if err := tmux.EnsureInstalled(); err != nil {
+		return err
+	}
+	resolved, err := ResolveSession(requestedSession, cmd.OutOrStdout())
+	if err != nil {
+		return err
+	}
+	if resolved.Session == "" {
+		return errors.New("session is required")
+	}
+	session := resolved.Session
+	projectDir, err := resolveCoordinatorProjectKey(cmd.Context(), session, resolved.Inferred)
+	if err != nil {
+		return err
+	}
+	mailProjectKey := filepath.Clean(strings.TrimSpace(opts.MailProjectKey))
+	if !filepath.IsAbs(mailProjectKey) {
+		return markCLIInvalidInput(fmt.Errorf("--mail-project-key must be an absolute canonical key"))
+	}
+	coordinatorName := strings.TrimSpace(opts.CoordinatorName)
+	if coordinatorName == "" {
+		return markCLIInvalidInput(fmt.Errorf("--coordinator-name is required"))
+	}
+
+	panes, err := coordinatorGetPanes(session)
+	if err != nil {
+		return fmt.Errorf("getting coordinator panes: %w", err)
+	}
+	bindings, publicBindings, err := validateCoordinatorBootstrapBindings(cmd.Context(), projectDir, panes, opts.Bindings)
+	if err != nil {
+		return markCLIInvalidInput(err)
+	}
+
+	client := newAgentMailClient(mailProjectKey)
+	roster, err := client.ListAgents(cmd.Context(), mailProjectKey)
+	if err != nil {
+		return fmt.Errorf("listing Agent Mail roster for %s: %w", mailProjectKey, err)
+	}
+	rosterByName := make(map[string]agentmail.Agent, len(roster))
+	for _, agent := range roster {
+		rosterByName[agent.Name] = agent
+	}
+	for paneID, binding := range bindings {
+		if _, ok := rosterByName[binding.AgentName]; !ok {
+			return fmt.Errorf("pane %s identity %q is absent from Agent Mail project %s; bootstrap never mints pane identities", paneID, binding.AgentName, mailProjectKey)
+		}
+	}
+
+	existing, err := agentmail.LoadCoordinatorSessionState(session, projectDir)
+	if err != nil {
+		return err
+	}
+	registrationToken := ""
+	if existing != nil {
+		if existing.MailProjectKey != mailProjectKey || existing.Coordinator.AgentName != coordinatorName {
+			return fmt.Errorf("persisted coordinator identity is %s in %s; refusing to replace it with %s in %s", existing.Coordinator.AgentName, existing.MailProjectKey, coordinatorName, mailProjectKey)
+		}
+		registrationToken = existing.Coordinator.RegistrationToken
+	}
+	if opts.TokenFile != "" {
+		importedToken, tokenErr := readCoordinatorRegistrationToken(opts.TokenFile)
+		if tokenErr != nil {
+			return tokenErr
+		}
+		if registrationToken != "" && registrationToken != importedToken {
+			return fmt.Errorf("token file does not match the persisted coordinator token")
+		}
+		registrationToken = importedToken
+	}
+	_, coordinatorExists := rosterByName[coordinatorName]
+	wouldCreate := !coordinatorExists && existing == nil && registrationToken == ""
+	if coordinatorExists && registrationToken == "" {
+		return fmt.Errorf("coordinator name %q already exists but no registration token was supplied; refusing to mint a duplicate", coordinatorName)
+	}
+	if !coordinatorExists && registrationToken != "" {
+		return fmt.Errorf("registration token supplied for absent coordinator %q", coordinatorName)
+	}
+
+	result := coordinatorBootstrapResult{
+		Success: true, DryRun: opts.DryRun, Session: session, ProjectDir: projectDir,
+		MailProjectKey: mailProjectKey, CoordinatorName: coordinatorName,
+		PaneBindings: publicBindings, WouldCreate: wouldCreate,
+	}
+	if opts.DryRun {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+	}
+
+	client.SetRegistrationToken(mailProjectKey, coordinatorName, registrationToken)
+	registered, err := client.RegisterAgent(cmd.Context(), agentmail.RegisterAgentOptions{
+		ProjectKey: mailProjectKey, Program: "ntm", Model: "coordinator", Name: coordinatorName,
+		TaskDescription: fmt.Sprintf("NTM session coordinator for %s", session),
+	})
+	if err != nil {
+		return fmt.Errorf("registering exact coordinator identity %q: %w", coordinatorName, err)
+	}
+	if registered.Name != coordinatorName {
+		return fmt.Errorf("Agent Mail returned coordinator %q, want exact name %q", registered.Name, coordinatorName)
+	}
+	if registered.Program != "" && registered.Program != "ntm" || registered.Model != "" && registered.Model != "coordinator" {
+		return fmt.Errorf("Agent Mail coordinator identity has program=%q model=%q, want ntm/coordinator", registered.Program, registered.Model)
+	}
+	if registered.RegistrationToken != "" {
+		registrationToken = registered.RegistrationToken
+	}
+	if registrationToken == "" {
+		return fmt.Errorf("Agent Mail did not return a coordinator registration token")
+	}
+
+	state := &agentmail.CoordinatorSessionState{
+		Version: 1, SessionName: session, ProjectDir: projectDir, MailProjectKey: mailProjectKey,
+		Coordinator: agentmail.CoordinatorIdentity{
+			AgentName: coordinatorName, RegistrationToken: registrationToken, Program: "ntm", Model: "coordinator",
+		},
+		PaneBindings: bindings,
+	}
+	if existing != nil {
+		state.CreatedAt = existing.CreatedAt
+	}
+	if err := agentmail.SaveCoordinatorSessionState(state); err != nil {
+		return err
+	}
+	result.Persisted = true
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+}
+
+func validateCoordinatorBootstrapBindings(ctx context.Context, projectDir string, panes []tmux.Pane, specs []string) (map[string]agentmail.CoordinatorPaneBinding, map[string]string, error) {
+	live := make(map[string]tmux.Pane, len(panes))
+	for _, pane := range panes {
+		live[pane.ID] = pane
+	}
+	bindings := make(map[string]agentmail.CoordinatorPaneBinding, len(specs))
+	public := make(map[string]string, len(specs))
+	seenNames := make(map[string]string, len(specs))
+	for _, spec := range specs {
+		paneID, agentName, ok := strings.Cut(spec, "=")
+		paneID, agentName = strings.TrimSpace(paneID), strings.TrimSpace(agentName)
+		if !ok || paneID == "" || agentName == "" {
+			return nil, nil, fmt.Errorf("invalid --bind %q; want PANE_ID=AGENT_NAME", spec)
+		}
+		pane, ok := live[paneID]
+		if !ok || pane.PID <= 0 {
+			return nil, nil, fmt.Errorf("bound pane %s is not live with a stable pid", paneID)
+		}
+		if previous, duplicate := seenNames[agentName]; duplicate && previous != paneID {
+			return nil, nil, fmt.Errorf("agent %q is bound to both %s and %s", agentName, previous, paneID)
+		}
+		paneDir, err := coordinatorPaneCurrentDir(paneID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading project for pane %s: %w", paneID, err)
+		}
+		matches, err := coordinatorProjectDirsMatch(ctx, projectDir, paneDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !matches {
+			return nil, nil, fmt.Errorf("pane %s is in cross-project directory %q; refusing binding", paneID, strings.TrimSpace(paneDir))
+		}
+		bindings[paneID] = agentmail.CoordinatorPaneBinding{
+			AgentName: agentName, PanePID: pane.PID, ProjectDir: filepath.Clean(projectDir), ImportedAt: time.Now().UTC(),
+		}
+		public[paneID] = agentName
+		seenNames[agentName] = paneID
+	}
+	if len(bindings) == 0 {
+		return nil, nil, fmt.Errorf("at least one --bind is required")
+	}
+	return bindings, public, nil
+}
+
+func readCoordinatorRegistrationToken(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if !filepath.IsAbs(path) {
+		return "", markCLIInvalidInput(fmt.Errorf("--registration-token-file must be absolute"))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("reading coordinator token file: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return "", fmt.Errorf("coordinator token file must be a mode-0600 regular file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading coordinator token file: %w", err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", fmt.Errorf("coordinator token file is empty")
+	}
+	return token, nil
 }
 
 func runCoordinatorStatus(cmd *cobra.Command, args []string) error {
@@ -121,8 +363,11 @@ func runCoordinatorStatus(cmd *cobra.Command, args []string) error {
 	runtimeConfig.RotationUsageThreshold = 0
 
 	// Create coordinator to get status without enabling configured side effects.
-	mailClient := newAgentMailClient(projectKey)
-	coord := coordinator.New(session, projectKey, mailClient, "NTM-Coordinator").WithConfig(runtimeConfig)
+	coord, _, err := loadBootstrappedCoordinator(session, projectKey)
+	if err != nil {
+		return err
+	}
+	coord.WithConfig(runtimeConfig)
 
 	// Get agent states
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -316,14 +561,17 @@ func runCoordinatorDigest(cmd *cobra.Command, args []string, sendMail bool) erro
 		return fmt.Errorf("getting project root failed")
 	}
 
-	mailClient := newAgentMailClient(projectKey)
 	runtimeConfig := loadCoordinatorRuntimeConfig()
 	runtimeConfig.AutoAssign = false
 	runtimeConfig.SendDigests = false
 	// Digest is a read-only surface: never let its brief coordinator run
 	// enqueue context rotations (bd-rpmg8).
 	runtimeConfig.RotationUsageThreshold = 0
-	coord := coordinator.New(session, projectKey, mailClient, "NTM-Coordinator").WithConfig(runtimeConfig)
+	coord, _, err := loadBootstrappedCoordinator(session, projectKey)
+	if err != nil {
+		return err
+	}
+	coord.WithConfig(runtimeConfig)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -408,9 +656,11 @@ func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
 	}
 
 	runtimeConfig, ntmConfig := loadCoordinatorRuntimeConfigWithNTM()
-	coord := coordinator.New(session, projectKey, newAgentMailClient(projectKey), "NTM-Coordinator").
-		WithConfig(runtimeConfig).
-		WithNTMConfig(ntmConfig)
+	coord, _, err := loadBootstrappedCoordinator(session, projectKey)
+	if err != nil {
+		return err
+	}
+	coord.WithConfig(runtimeConfig).WithNTMConfig(ntmConfig)
 	if once {
 		assignments, cycleErr := coord.RunCycle(cmd.Context())
 		runErr := coordinatorRunFailure(assignments, cycleErr)
@@ -479,6 +729,21 @@ func coordinatorRunFailure(assignments []coordinator.AssignmentResult, cycleErr 
 	return nil
 }
 
+func loadBootstrappedCoordinator(session, projectDir string) (*coordinator.SessionCoordinator, *agentmail.CoordinatorSessionState, error) {
+	state, err := agentmail.LoadCoordinatorSessionState(session, projectDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	if state == nil {
+		return nil, nil, fmt.Errorf("coordinator is not bootstrapped for session %q and project %q; run `ntm coordinator bootstrap %s --mail-project-key <canonical-key> --coordinator-name <name> --bind <pane-id>=<agent-name>`", session, projectDir, session)
+	}
+	client := newAgentMailClient(state.MailProjectKey)
+	client.SetRegistrationToken(state.MailProjectKey, state.Coordinator.AgentName, state.Coordinator.RegistrationToken)
+	coord := coordinator.New(session, projectDir, client, state.Coordinator.AgentName).
+		WithAgentMailScope(state.MailProjectKey, state.Coordinator.AgentName, state.PaneBindings)
+	return coord, state, nil
+}
+
 func resolveCoordinatorProjectKey(ctx context.Context, session string, inferred bool) (string, error) {
 	session = strings.TrimSpace(session)
 	if session == "" {
@@ -491,6 +756,24 @@ func resolveCoordinatorProjectKey(ctx context.Context, session string, inferred 
 		}
 		if len(panes) == 0 {
 			return "", fmt.Errorf("resolve live coordinator project for %s: session has no panes", session)
+		}
+		// A session may intentionally contain an unrelated utility pane. When
+		// the configured session checkout is live in at least one pane, use it
+		// as the coordinator target and let bootstrap bindings select the exact
+		// in-project panes. Never let an unrelated pane redefine the project.
+		if cfg != nil {
+			configured := filepath.Clean(cfg.GetProjectDir(session))
+			if util.ProjectDirScore(configured) > 0 {
+				for _, pane := range panes {
+					paneDir, pathErr := coordinatorPaneCurrentDir(pane.ID)
+					if pathErr != nil {
+						continue
+					}
+					if same, _ := coordinatorProjectDirsMatch(ctx, configured, paneDir); same {
+						return configured, nil
+					}
+				}
+			}
 		}
 		projectKey, err := robot.ResolveLiveSessionProject(session, panes, coordinatorPaneCurrentDir)
 		if err != nil {
@@ -515,6 +798,26 @@ func resolveCoordinatorProjectKey(ctx context.Context, session string, inferred 
 		return "", errors.New("getting project root failed")
 	}
 	return projectKey, nil
+}
+
+func coordinatorProjectDirsMatch(ctx context.Context, targetDir, candidateDir string) (bool, error) {
+	targetRoot := filepath.Clean(util.ResolveProjectDir(strings.TrimSpace(targetDir)))
+	candidateRoot := filepath.Clean(util.ResolveProjectDir(strings.TrimSpace(candidateDir)))
+	if !filepath.IsAbs(targetRoot) || !filepath.IsAbs(candidateRoot) {
+		return false, nil
+	}
+	if targetRoot == candidateRoot {
+		return true, nil
+	}
+	targetCommon, targetErr := ntmgit.CommonDir(ctx, targetRoot)
+	candidateCommon, candidateErr := ntmgit.CommonDir(ctx, candidateRoot)
+	if targetErr != nil || candidateErr != nil {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	return targetCommon != "" && targetCommon == candidateCommon, nil
 }
 
 func loadCoordinatorRuntimeConfig() coordinator.CoordinatorConfig {
@@ -646,12 +949,17 @@ func runCoordinatorConflicts(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting project root failed")
 	}
 
-	mailClient := newAgentMailClient(projectKey)
+	_, state, err := loadBootstrappedCoordinator(session, projectKey)
+	if err != nil {
+		return err
+	}
+	mailClient := newAgentMailClient(state.MailProjectKey)
+	mailClient.SetRegistrationToken(state.MailProjectKey, state.Coordinator.AgentName, state.Coordinator.RegistrationToken)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	detector := coordinator.NewConflictDetector(mailClient, projectKey)
+	detector := coordinator.NewConflictDetector(mailClient, state.MailProjectKey)
 	conflicts, err := detector.DetectConflicts(ctx)
 	if err != nil {
 		return fmt.Errorf("detecting conflicts: %w", err)

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -182,6 +183,30 @@ func TestCoordinatorBootstrapImportsOnlyExactInProjectPaneIdentities(t *testing.
 	_, _, err = validateCoordinatorBootstrapBindings(t.Context(), projectDir, panes, append(specs, "%66=WrongProject"))
 	if err == nil || !strings.Contains(err.Error(), "cross-project") {
 		t.Fatalf("cross-project pane binding error = %v", err)
+	}
+}
+
+func TestCoordinatorBootstrapPanesFindsExplicitBindingInDetachedSession(t *testing.T) {
+	previousAll := coordinatorGetAllPanes
+	t.Cleanup(func() { coordinatorGetAllPanes = previousAll })
+	coordinatorGetAllPanes = func(context.Context) (map[string][]tmux.Pane, error) {
+		return map[string][]tmux.Pane{
+			"bbi-infrastructure":                 {{ID: "%44", PID: 4400}},
+			"bbi-infrastructure--lms-argo-wedge": {{ID: "%155", PID: 15500}},
+			"mereka-lms":                         {{ID: "%66", PID: 6600}},
+		}, nil
+	}
+
+	panes, err := coordinatorBootstrapPanes(t.Context(), []tmux.Pane{{ID: "%44", PID: 4400}}, []string{"%44=AzureCreek", "%155=YellowOx"})
+	if err != nil {
+		t.Fatalf("coordinatorBootstrapPanes: %v", err)
+	}
+	got := make(map[string]int, len(panes))
+	for _, pane := range panes {
+		got[pane.ID] = pane.PID
+	}
+	if got["%44"] != 4400 || got["%155"] != 15500 {
+		t.Fatalf("expanded panes = %+v, want primary and explicitly named detached pane available", got)
 	}
 }
 

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Dicklesworthstone/ntm/internal/agentmail"
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	"github.com/Dicklesworthstone/ntm/internal/coordinator"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
@@ -146,6 +147,75 @@ func TestCoordinatorRunCommandExposesDeterministicOnceMode(t *testing.T) {
 	}
 	if flag := cmd.Flags().Lookup("once"); flag == nil || flag.DefValue != "false" {
 		t.Fatalf("--once flag = %+v", flag)
+	}
+}
+
+func TestCoordinatorBootstrapImportsOnlyExactInProjectPaneIdentities(t *testing.T) {
+	projectDir := t.TempDir()
+	otherDir := t.TempDir()
+	previousPath := coordinatorPaneCurrentDir
+	coordinatorPaneCurrentDir = func(paneID string) (string, error) {
+		if paneID == "%66" {
+			return otherDir, nil
+		}
+		return projectDir, nil
+	}
+	t.Cleanup(func() { coordinatorPaneCurrentDir = previousPath })
+	panes := []tmux.Pane{
+		{ID: "%44", PID: 4400}, {ID: "%45", PID: 4500}, {ID: "%46", PID: 4600},
+		{ID: "%51", PID: 5100}, {ID: "%66", PID: 6600}, {ID: "%129", PID: 12900},
+	}
+	specs := []string{"%44=AzureCreek", "%45=TopazAnchor", "%46=CrimsonOak", "%51=IvoryTern", "%129=CoralFox"}
+	bindings, public, err := validateCoordinatorBootstrapBindings(t.Context(), projectDir, panes, specs)
+	if err != nil {
+		t.Fatalf("validateCoordinatorBootstrapBindings: %v", err)
+	}
+	if len(bindings) != 5 || len(public) != 5 {
+		t.Fatalf("bindings = %+v, want exact five", public)
+	}
+	if _, ok := bindings["%66"]; ok {
+		t.Fatal("unbound LMS pane %66 was imported")
+	}
+	if bindings["%44"].AgentName != "AzureCreek" || bindings["%129"].AgentName != "CoralFox" {
+		t.Fatalf("exact identities changed: %+v", public)
+	}
+	_, _, err = validateCoordinatorBootstrapBindings(t.Context(), projectDir, panes, append(specs, "%66=WrongProject"))
+	if err == nil || !strings.Contains(err.Error(), "cross-project") {
+		t.Fatalf("cross-project pane binding error = %v", err)
+	}
+}
+
+func TestLoadBootstrappedCoordinatorFailsClosedWithoutIdentity(t *testing.T) {
+	isolateSessionAgentStorage(t)
+	projectDir := t.TempDir()
+	coord, state, err := loadBootstrappedCoordinator("missing-coordinator", projectDir)
+	if err == nil || coord != nil || state != nil || !strings.Contains(err.Error(), "not bootstrapped") {
+		t.Fatalf("loadBootstrappedCoordinator = (%v, %+v, %v), want fail closed", coord, state, err)
+	}
+}
+
+func TestLoadBootstrappedCoordinatorHydratesExactPersistedSender(t *testing.T) {
+	isolateSessionAgentStorage(t)
+	projectDir := t.TempDir()
+	state := &agentmail.CoordinatorSessionState{
+		Version: 1, SessionName: "persisted-coordinator", ProjectDir: projectDir,
+		MailProjectKey: "/repos/github.com/biji-biji-initiative/bbi-infrastructure",
+		Coordinator: agentmail.CoordinatorIdentity{
+			AgentName: "SilverHarbor", RegistrationToken: "coordinator-token", Program: "ntm", Model: "coordinator",
+		},
+		PaneBindings: map[string]agentmail.CoordinatorPaneBinding{
+			"%44": {AgentName: "AzureCreek", PanePID: 4400, ProjectDir: projectDir},
+		},
+	}
+	if err := agentmail.SaveCoordinatorSessionState(state); err != nil {
+		t.Fatal(err)
+	}
+	coord, loaded, err := loadBootstrappedCoordinator(state.SessionName, projectDir)
+	if err != nil {
+		t.Fatalf("loadBootstrappedCoordinator: %v", err)
+	}
+	if coord == nil || loaded.MailProjectKey == loaded.ProjectDir || loaded.Coordinator.AgentName != "SilverHarbor" {
+		t.Fatalf("loaded coordinator scope = %+v", loaded)
 	}
 }
 

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -274,6 +274,7 @@ func TestCoordinatorRunFailureIncludesAssignmentFailures(t *testing.T) {
 	}{
 		{name: "empty success"},
 		{name: "assignment success", assignments: []coordinator.AssignmentResult{{Success: true}}},
+		{name: "pressure deferral", assignments: []coordinator.AssignmentResult{{Deferred: true, ReasonCode: "critical_pressure"}}},
 		{name: "assignment failure", assignments: []coordinator.AssignmentResult{{Success: false}}, wantError: true},
 		{name: "cycle failure", cycleErr: errors.New("observe failed"), wantError: true},
 	}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -136,11 +136,11 @@ func startDashboardReservationWatcher(session, projectDir string) func() {
 		return nil
 	}
 
-	amOpts := []agentmail.Option{
-		agentmail.WithBaseURL(cfg.AgentMail.URL),
-		agentmail.WithProjectKey(projectDir),
+	amOpts := []agentmail.Option{agentmail.WithProjectKey(projectDir)}
+	if cfg.AgentMail.URL != "" && os.Getenv("AGENT_MAIL_URL") == "" {
+		amOpts = append(amOpts, agentmail.WithBaseURL(cfg.AgentMail.URL))
 	}
-	if cfg.AgentMail.Token != "" {
+	if cfg.AgentMail.Token != "" && os.Getenv("AGENT_MAIL_TOKEN") == "" && os.Getenv("MCP_AGENT_MAIL_TOKEN") == "" {
 		amOpts = append(amOpts, agentmail.WithToken(cfg.AgentMail.Token))
 	}
 	amClient := agentmail.NewClient(amOpts...)

--- a/internal/cli/identity_liveness.go
+++ b/internal/cli/identity_liveness.go
@@ -75,6 +75,12 @@ func nextPaneIndices(panes []tmux.Pane, registry *agentmail.SessionAgentRegistry
 // Empty inputs and duplicates are dropped, so a plain spawn yields exactly the
 // session key (plus its resolved form when the path is a symlink).
 func identityPublishKeys(sessionKey, paneDir string) []string {
+	if override := agentmail.InvocationProjectKey(""); override != "" {
+		// The explicit invocation scope is authoritative. Do not also publish
+		// identities under the physical checkout/worktree keys: a public Agent
+		// Mail deployment resolves the pane through the canonical key only.
+		return []string{override}
+	}
 	var keys []string
 	seen := make(map[string]struct{}, 4)
 	add := func(key string) {

--- a/internal/cli/identity_liveness_test.go
+++ b/internal/cli/identity_liveness_test.go
@@ -119,6 +119,16 @@ func TestIdentityPublishKeys(t *testing.T) {
 	}
 }
 
+func TestIdentityPublishKeys_UsesCanonicalInvocationOverrideOnly(t *testing.T) {
+	const canonical = "/repos/github.com/biji-biji-initiative/bbi-infrastructure"
+	t.Setenv(agentmail.ProjectKeyOverrideEnv, canonical)
+
+	got := identityPublishKeys("/home/ubuntu/work/bbi-infrastructure", "/tmp/bbi-worktree")
+	if !reflect.DeepEqual(got, []string{canonical}) {
+		t.Fatalf("identity keys = %v, want only canonical public key %q", got, canonical)
+	}
+}
+
 func TestIdentityPublishKeys_ResolvesSymlinks(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires privileges on windows")

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -250,7 +250,7 @@ func newAgentMailClient(projectKey string) *agentmail.Client {
 		if cfg.AgentMail.URL != "" && os.Getenv("AGENT_MAIL_URL") == "" {
 			opts = append(opts, agentmail.WithBaseURL(cfg.AgentMail.URL))
 		}
-		if cfg.AgentMail.Token != "" && os.Getenv("AGENT_MAIL_TOKEN") == "" {
+		if cfg.AgentMail.Token != "" && os.Getenv("AGENT_MAIL_TOKEN") == "" && os.Getenv("MCP_AGENT_MAIL_TOKEN") == "" {
 			opts = append(opts, agentmail.WithToken(cfg.AgentMail.Token))
 		}
 	}

--- a/internal/cli/spawn.go
+++ b/internal/cli/spawn.go
@@ -4235,16 +4235,7 @@ func registerSessionAgent(parentCtx context.Context, sessionName, workingDir str
 		}
 		return
 	}
-	var opts []agentmail.Option
-	if cfg != nil {
-		if cfg.AgentMail.URL != "" {
-			opts = append(opts, agentmail.WithBaseURL(cfg.AgentMail.URL))
-		}
-		if cfg.AgentMail.Token != "" {
-			opts = append(opts, agentmail.WithToken(cfg.AgentMail.Token))
-		}
-	}
-	client := agentmail.NewClient(opts...)
+	client := newAgentMailClient(workingDir)
 	ctx, cancel := context.WithTimeout(parentCtx, 15*time.Second)
 	defer cancel()
 
@@ -4362,16 +4353,7 @@ func (c *spawnIdentityCoordinator) ensureInit(parentCtx context.Context) {
 	}
 	c.enabled = true
 
-	var opts []agentmail.Option
-	if cfg != nil {
-		if cfg.AgentMail.URL != "" {
-			opts = append(opts, agentmail.WithBaseURL(cfg.AgentMail.URL))
-		}
-		if cfg.AgentMail.Token != "" {
-			opts = append(opts, agentmail.WithToken(cfg.AgentMail.Token))
-		}
-	}
-	c.client = agentmail.NewClient(opts...)
+	c.client = newAgentMailClient(c.workingDir)
 
 	// Check availability first (uses cached result)
 	if !c.client.IsAvailable() {

--- a/internal/cli/spawn_identity_order_test.go
+++ b/internal/cli/spawn_identity_order_test.go
@@ -250,6 +250,78 @@ func TestSpawnIdentityCoordinator_PublishesIdentityAtPrepareTime(t *testing.T) {
 	}
 }
 
+// A public project key is intentionally server-governed. If the selected key
+// is rejected (for example, it has not been admitted to the shared namespace),
+// spawn must retain NTM's fail-open launch policy and must not publish an
+// identity under the physical checkout as an accidental fallback.
+func TestSpawnIdentityCoordinator_CanonicalOverrideRejectionFailsOpen(t *testing.T) {
+	isolateIdentityDirs(t)
+	const canonical = "/repos/github.com/biji-biji-initiative/bbi-infrastructure"
+	t.Setenv(agentmail.ProjectKeyOverrideEnv, canonical)
+
+	var mu sync.Mutex
+	seenHumanKey := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     interface{} `json:"id"`
+			Params struct {
+				Name      string                 `json:"name"`
+				Arguments map[string]interface{} `json:"arguments"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if req.Params.Name == "health_check" {
+			raw, _ := json.Marshal(map[string]string{"status": "ok"})
+			_ = json.NewEncoder(w).Encode(agentmail.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: raw})
+			return
+		}
+		if req.Params.Name == "ensure_project" {
+			mu.Lock()
+			seenHumanKey, _ = req.Params.Arguments["human_key"].(string)
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(agentmail.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &agentmail.JSONRPCError{Code: -32041, Message: "UNREGISTERED_PROJECT"}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(agentmail.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &agentmail.JSONRPCError{Code: -32601, Message: "unexpected tool"}})
+	}))
+	t.Cleanup(srv.Close)
+
+	oldCfg := cfg
+	t.Cleanup(func() { cfg = oldCfg })
+	cfg = config.Default()
+	cfg.AgentMail.Enabled = true
+	cfg.AgentMail.AutoRegister = true
+	cfg.AgentMail.URL = srv.URL + "/"
+
+	physical := t.TempDir()
+	paneID := "%8"
+	coordinator := newSpawnIdentityCoordinator(physical, "canonical_override_rejection")
+	coordinator.prepareAgent(context.Background(), spawnedAgentInfo{
+		paneIndex: 1, paneID: paneID, paneTitle: "canonical_override_rejection__cc_1", agentType: "cc", model: "opus",
+	})
+
+	status := coordinator.finalStatus()
+	if status == nil || !status.Available || status.ProjectRegistered || status.AgentsFailed != 1 {
+		t.Fatalf("rejected canonical registration must fail open with one failed identity: %+v", status)
+	}
+	mu.Lock()
+	gotHumanKey := seenHumanKey
+	mu.Unlock()
+	if gotHumanKey != canonical {
+		t.Fatalf("ensure_project human_key = %q, want canonical key %q", gotHumanKey, canonical)
+	}
+	if _, err := os.Stat(agentmail.CanonicalIdentityPath(physical, paneID)); !os.IsNotExist(err) {
+		t.Fatalf("physical identity must not be published after canonical rejection: %v", err)
+	}
+	if _, err := os.Stat(agentmail.CanonicalIdentityPath(canonical, paneID)); !os.IsNotExist(err) {
+		t.Fatalf("canonical identity must not be published when registration failed: %v", err)
+	}
+}
+
 // TestSpawnIdentityCoordinator_DisabledIsInert: with no config (or Agent Mail
 // off) the coordinator must not touch the network or filesystem and must
 // report a nil status, matching the historical registerSpawnedAgents

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -210,6 +210,7 @@ func (c *SessionCoordinator) filterActionableRecommendations(ctx context.Context
 		}
 		live := recommendation
 		var trackerStatus string
+		var trackerAssignee string
 		var err error
 		switch {
 		case c.workItemDetailsFn != nil:
@@ -217,6 +218,7 @@ func (c *SessionCoordinator) filterActionableRecommendations(ctx context.Context
 			details, err = c.workItemDetailsFn(ctx, recommendation.ID)
 			if details != nil {
 				trackerStatus = details.Status
+				trackerAssignee = details.Assignee
 				live.Title = details.Title
 				live.Status = details.Status
 				live.Labels = append([]string(nil), details.Labels...)
@@ -231,6 +233,7 @@ func (c *SessionCoordinator) filterActionableRecommendations(ctx context.Context
 			details, err = bv.GetBeadAssignmentDetailsContext(ctx, c.projectKey, recommendation.ID)
 			if details != nil {
 				trackerStatus = details.Status
+				trackerAssignee = details.Assignee
 				live.Title = details.Title
 				live.Status = details.Status
 				live.Labels = append([]string(nil), details.Labels...)
@@ -243,6 +246,12 @@ func (c *SessionCoordinator) filterActionableRecommendations(ctx context.Context
 		}
 		switch strings.ToLower(strings.TrimSpace(trackerStatus)) {
 		case "open":
+			// An open row can still be owned by another actor. Treat the live
+			// assignee as part of the authorization boundary so the planner
+			// cannot select it and then abort the whole cycle at atomic claim.
+			if strings.TrimSpace(trackerAssignee) != "" {
+				continue
+			}
 			// Type evidence is part of the authorization boundary, not a
 			// display field: without it the container (epic) gate below cannot
 			// prove this item is implementation work. bv's actionable-plan

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/bv"
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	"github.com/Dicklesworthstone/ntm/internal/persona"
+	"github.com/Dicklesworthstone/ntm/internal/pressure"
 	"github.com/Dicklesworthstone/ntm/internal/redaction"
 )
 
@@ -77,19 +78,63 @@ type WorkAssignment struct {
 
 // AssignmentResult contains the result of an assignment attempt.
 type AssignmentResult struct {
-	Success        bool            `json:"success"`
-	Assignment     *WorkAssignment `json:"assignment,omitempty"`
-	Error          string          `json:"error,omitempty"`
-	Reservations   []string        `json:"reservations,omitempty"`
-	MessageSent    bool            `json:"message_sent"`
-	ClaimActor     string          `json:"claim_actor,omitempty"`
-	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	Success          bool            `json:"success"`
+	Assignment       *WorkAssignment `json:"assignment,omitempty"`
+	Error            string          `json:"error,omitempty"`
+	Reservations     []string        `json:"reservations,omitempty"`
+	MessageSent      bool            `json:"message_sent"`
+	ClaimActor       string          `json:"claim_actor,omitempty"`
+	IdempotencyKey   string          `json:"idempotency_key,omitempty"`
+	Deferred         bool            `json:"deferred,omitempty"`
+	ReasonCode       string          `json:"reason_code,omitempty"`
+	PressureLevel    string          `json:"pressure_level,omitempty"`
+	PressureLimit    []string        `json:"pressure_limiting,omitempty"`
+	PressureOverride bool            `json:"pressure_override,omitempty"`
+}
+
+// AssignmentPressure is the exact live host-pressure evidence used by the
+// coordinator admission gate.
+type AssignmentPressure struct {
+	Available bool
+	Level     string
+	Limiting  []string
+}
+
+func liveCoordinatorAssignmentPressure(ctx context.Context) AssignmentPressure {
+	if ctx == nil || ctx.Err() != nil {
+		return AssignmentPressure{}
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	governor := pressure.New(pressure.Config{
+		Mode: pressure.ModeObserve, Providers: []pressure.Provider{pressure.NewSystemProvider()},
+	})
+	snapshot := governor.Refresh(probeCtx)
+	if len(snapshot.Readings) == 0 {
+		return AssignmentPressure{}
+	}
+	limiting := make([]string, 0, len(snapshot.Limiting))
+	for _, source := range snapshot.Limiting {
+		limiting = append(limiting, string(source))
+	}
+	return AssignmentPressure{Available: true, Level: snapshot.Overall.String(), Limiting: limiting}
 }
 
 // AssignWork assigns verified actionable work to idle agents.
 func (c *SessionCoordinator) AssignWork(ctx context.Context) ([]AssignmentResult, error) {
 	if !c.config.AutoAssign {
 		return nil, nil
+	}
+	assignmentPressure := AssignmentPressure{}
+	if c.assignmentPressureFn != nil {
+		assignmentPressure = c.assignmentPressureFn(ctx)
+	}
+	criticalPressure := assignmentPressure.Available && strings.EqualFold(strings.TrimSpace(assignmentPressure.Level), "critical")
+	if criticalPressure && !c.config.AllowCriticalPressure {
+		return []AssignmentResult{{
+			Deferred: true, ReasonCode: "critical_pressure", PressureLevel: assignmentPressure.Level,
+			PressureLimit: append([]string(nil), assignmentPressure.Limiting...),
+		}}, nil
 	}
 	store, err := assignmentstore.LoadStoreStrict(c.session)
 	if err != nil {
@@ -161,6 +206,11 @@ func (c *SessionCoordinator) AssignWork(ctx context.Context) ([]AssignmentResult
 	// snapshot.
 	for _, scored := range ScoreAndSelectAssignments(assignmentCandidates, recommendations, DefaultScoreConfig(), nil) {
 		result := c.attemptAssignment(ctx, scored.Assignment, scored.Recommendation)
+		if criticalPressure {
+			result.PressureLevel = assignmentPressure.Level
+			result.PressureLimit = append([]string(nil), assignmentPressure.Limiting...)
+			result.PressureOverride = true
+		}
 		results = append(results, result)
 
 		if result.Success {

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -594,7 +594,7 @@ func (c *SessionCoordinator) releaseTerminalAssignmentReservations(ctx context.C
 		return fmt.Errorf("reconcile reservation for %s: %w", current.BeadID, err)
 	}
 	lease.Requested = requested
-	port := &coordinatorAgentMailReservationPort{client: c.reservationClient, projectKey: agentmail.CanonicalProjectKey(c.projectKey)}
+	port := &coordinatorAgentMailReservationPort{client: c.reservationClient, projectKey: c.mailProjectKey}
 	reconciled, err := port.ReconcileReservation(ctx, assignmentstore.ReservationRequest{
 		BeadID: current.BeadID, BeadTitle: current.BeadTitle, AgentName: lease.AgentName,
 		Target: lease.Target, RequestedPaths: requested, TTL: time.Hour,
@@ -642,7 +642,7 @@ func (c *SessionCoordinator) releaseCoordinatorLease(ctx context.Context, curren
 	if c.reservationClient == nil {
 		return errors.New("agent mail reservation client is not configured")
 	}
-	manager := assignpkg.NewFileReservationManager(c.reservationClient, c.projectKey)
+	manager := assignpkg.NewFileReservationManager(c.reservationClient, c.mailProjectKey)
 	_, err := manager.ReleaseExactForBead(ctx, current, lease.ReservationIDs, lease.Granted)
 	return err
 }
@@ -1008,16 +1008,16 @@ func (c *SessionCoordinator) newAtomicAssignmentCoordinator(store *assignmentsto
 			BeadID: claim.ID, Actor: claim.Actor, Status: claim.Status, ClaimedAt: claim.ClaimedAt,
 		}, nil
 	})
-	reservationPort := &coordinatorAgentMailReservationPort{client: c.reservationClient, projectKey: agentmail.CanonicalProjectKey(c.projectKey)}
+	reservationPort := &coordinatorAgentMailReservationPort{client: c.reservationClient, projectKey: c.mailProjectKey}
 	dispatchPort := assignmentstore.DispatchFunc(func(ctx context.Context, req assignmentstore.DispatchRequest) (assignmentstore.DispatchReceipt, error) {
 		started := time.Now()
-		project, err := c.mailClient.EnsureProject(ctx, c.projectKey)
+		project, err := c.mailClient.EnsureProject(ctx, c.mailProjectKey)
 		if err != nil {
 			return assignmentstore.DispatchReceipt{Duration: time.Since(started)}, assignmentstore.GuaranteeNoActuation(
 				fmt.Errorf("ensure Agent Mail dispatch project: %w", err),
 			)
 		}
-		projectID, projectErr := validatedCoordinatorAgentMailProjectID(project, c.projectKey)
+		projectID, projectErr := validatedCoordinatorAgentMailProjectID(project, c.mailProjectKey)
 		if projectErr != nil {
 			return assignmentstore.DispatchReceipt{Duration: time.Since(started)}, assignmentstore.GuaranteeNoActuation(
 				fmt.Errorf("validate Agent Mail dispatch project: %w", projectErr),
@@ -1025,7 +1025,7 @@ func (c *SessionCoordinator) newAtomicAssignmentCoordinator(store *assignmentsto
 		}
 		subject := fmt.Sprintf("Work Assignment: %s", req.BeadID)
 		sent, err := c.mailClient.SendMessage(ctx, agentmail.SendMessageOptions{
-			ProjectKey:  c.projectKey,
+			ProjectKey:  c.mailProjectKey,
 			SenderName:  c.agentName,
 			To:          []string{req.AgentName},
 			Subject:     subject,
@@ -1038,7 +1038,7 @@ func (c *SessionCoordinator) newAtomicAssignmentCoordinator(store *assignmentsto
 			return receipt, err
 		}
 		deliveryID, receiptErr := validatedAgentMailDeliveryID(
-			sent, c.projectKey, projectID, c.agentName, req.AgentName, subject, req.Prompt,
+			sent, c.mailProjectKey, projectID, c.agentName, req.AgentName, subject, req.Prompt,
 		)
 		if receiptErr != nil {
 			return receipt, receiptErr

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -1811,6 +1811,19 @@ func TestFilterActionableRecommendationsExcludesLiveAssignedOpenWork(t *testing.
 	}
 }
 
+func TestAssignWorkDefersHonestlyUnderCriticalHostPressure(t *testing.T) {
+	c := New("critical-pressure", t.TempDir(), nil, "IvoryAnchor")
+	c.config.AutoAssign = true
+	c.assignmentPressureFn = func(context.Context) AssignmentPressure {
+		return AssignmentPressure{Available: true, Level: "critical", Limiting: []string{"load"}}
+	}
+
+	results, err := c.AssignWork(t.Context())
+	if err != nil || len(results) != 1 || !results[0].Deferred || results[0].Success || results[0].ReasonCode != "critical_pressure" || results[0].PressureLevel != "critical" || !reflect.DeepEqual(results[0].PressureLimit, []string{"load"}) {
+		t.Fatalf("critical-pressure results=%+v error=%v", results, err)
+	}
+}
+
 func TestAssignWorkDoesNotMutateSharedActionableRecommendations(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	shared := []bv.TriageRecommendation{{

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -1790,6 +1790,27 @@ func TestFilterActionableRecommendationsUsesLiveDependencyAndLabelTruth(t *testi
 	}
 }
 
+func TestFilterActionableRecommendationsExcludesLiveAssignedOpenWork(t *testing.T) {
+	t.Parallel()
+	c := New("recommendation-live-assignee", t.TempDir(), nil, "CoordinatorAgent")
+	details := map[string]*bv.BeadAssignmentDetails{
+		"ntm-ready":   {ID: "ntm-ready", Title: "Unassigned work", IssueType: "task", Status: "open"},
+		"ntm-claimed": {ID: "ntm-claimed", Title: "Externally owned", IssueType: "task", Status: "open", Assignee: "partners@mereka.my"},
+	}
+	c.workItemDetailsFn = func(_ context.Context, beadID string) (*bv.BeadAssignmentDetails, error) {
+		copy := *details[beadID]
+		return &copy, nil
+	}
+
+	filtered, terminal, err := c.filterActionableRecommendations(t.Context(), []bv.TriageRecommendation{
+		{ID: "ntm-claimed", Title: "Stale unassigned", Type: "task", Status: "open"},
+		{ID: "ntm-ready", Title: "Stale ready", Type: "task", Status: "open"},
+	}, nil)
+	if err != nil || terminal || len(filtered) != 1 || filtered[0].ID != "ntm-ready" {
+		t.Fatalf("filtered=%+v terminal=%v error=%v, want only live unassigned work", filtered, terminal, err)
+	}
+}
+
 func TestAssignWorkDoesNotMutateSharedActionableRecommendations(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	shared := []bv.TriageRecommendation{{

--- a/internal/coordinator/conflicts.go
+++ b/internal/coordinator/conflicts.go
@@ -267,7 +267,7 @@ func (c *SessionCoordinator) runConflictCycle(ctx context.Context) []ConflictOut
 	detect := c.detectConflictsFn
 	if detect == nil {
 		if c.conflictDetector == nil {
-			c.conflictDetector = NewConflictDetector(c.mailClient, c.projectKey)
+			c.conflictDetector = NewConflictDetector(c.mailClient, c.mailProjectKey)
 		}
 		detect = c.conflictDetector.DetectConflicts
 	}
@@ -504,7 +504,7 @@ func (c *SessionCoordinator) NegotiateConflict(ctx context.Context, conflict *Co
 	// Send negotiation request
 	body := c.formatNegotiationRequest(conflict, requester, lowestPriority)
 	_, err := c.mailClient.SendMessage(ctx, agentmail.SendMessageOptions{
-		ProjectKey:  c.projectKey,
+		ProjectKey:  c.mailProjectKey,
 		SenderName:  c.agentName,
 		To:          []string{lowestPriority.AgentName},
 		Subject:     fmt.Sprintf("File Reservation Conflict: %s", conflict.Pattern),
@@ -544,7 +544,7 @@ func (c *SessionCoordinator) NotifyConflict(ctx context.Context, conflict *Confl
 
 	body := c.formatConflictNotification(conflict)
 	_, err := c.mailClient.SendMessage(ctx, agentmail.SendMessageOptions{
-		ProjectKey:  c.projectKey,
+		ProjectKey:  c.mailProjectKey,
 		SenderName:  c.agentName,
 		To:          recipients,
 		Subject:     fmt.Sprintf("⚠️ Reservation Conflict Detected: %s", conflict.Pattern),

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,15 +18,20 @@ import (
 	"github.com/Dicklesworthstone/ntm/internal/bv"
 	"github.com/Dicklesworthstone/ntm/internal/config"
 	"github.com/Dicklesworthstone/ntm/internal/events"
+	ntmgit "github.com/Dicklesworthstone/ntm/internal/git"
 	"github.com/Dicklesworthstone/ntm/internal/persona"
 	"github.com/Dicklesworthstone/ntm/internal/robot"
 	"github.com/Dicklesworthstone/ntm/internal/status"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
+	"github.com/Dicklesworthstone/ntm/internal/util"
 )
 
 var (
 	getPanesWithActivity         = tmux.GetPanesWithActivity
 	captureForHealthCheckWithCtx = tmux.CaptureForHealthCheckContext
+	coordinatorPaneCurrentDir    = func(ctx context.Context, paneID string) (string, error) {
+		return tmux.DefaultClient.RunContext(ctx, "display-message", "-p", "-t", tmux.ExactTarget(paneID), "#{pane_current_path}")
+	}
 )
 
 // SessionCoordinator manages agent coordination for a tmux session.
@@ -33,9 +40,15 @@ type SessionCoordinator struct {
 	lifecycleMu sync.Mutex
 
 	// Identity
-	session    string // tmux session name
-	agentName  string // Agent Mail identity (e.g., "OrangeFox")
-	projectKey string // Absolute path to working directory
+	session        string // tmux session name
+	agentName      string // Agent Mail identity (e.g., "OrangeFox")
+	projectKey     string // Absolute path to physical working directory (bv/br/config)
+	mailProjectKey string // Canonical Agent Mail namespace; may be a virtual /repos key
+
+	// authoritativePaneBindings is set only from explicit coordinator
+	// bootstrap state. When true, legacy local pane registries are ignored.
+	authoritativePaneBindings bool
+	paneBindings              map[string]agentmail.CoordinatorPaneBinding
 
 	// Clients
 	mailClient        *agentmail.Client
@@ -229,6 +242,7 @@ func New(session, projectKey string, mailClient *agentmail.Client, agentName str
 		session:             session,
 		agentName:           agentName,
 		projectKey:          projectKey,
+		mailProjectKey:      projectKey,
 		mailClient:          mailClient,
 		reservationClient:   mailClient,
 		operatorGatedLabels: append([]string(nil), bv.OperatorGatedLabelsForProject(projectKey)...),
@@ -236,6 +250,20 @@ func New(session, projectKey string, mailClient *agentmail.Client, agentName str
 		config:              DefaultCoordinatorConfig(),
 		events:              make(chan CoordinatorEvent, 100),
 		stopCh:              make(chan struct{}),
+	}
+	return c
+}
+
+// WithAgentMailScope separates the physical checkout used by local project
+// tools from the canonical Agent Mail namespace and installs only the pane
+// bindings explicitly verified by `ntm coordinator bootstrap`.
+func (c *SessionCoordinator) WithAgentMailScope(mailProjectKey, agentName string, bindings map[string]agentmail.CoordinatorPaneBinding) *SessionCoordinator {
+	c.mailProjectKey = strings.TrimSpace(mailProjectKey)
+	c.agentName = strings.TrimSpace(agentName)
+	c.authoritativePaneBindings = true
+	c.paneBindings = make(map[string]agentmail.CoordinatorPaneBinding, len(bindings))
+	for paneID, binding := range bindings {
+		c.paneBindings[paneID] = binding
 	}
 	return c
 }
@@ -494,7 +522,7 @@ func (c *SessionCoordinator) maybeCheckMailNudge(ctx context.Context) {
 		return
 	}
 	if c.mailNudge == nil {
-		c.mailNudge = newMailNudgeChecker(c.session, c.projectKey, c.config, c.mailClient)
+		c.mailNudge = newMailNudgeChecker(c.session, c.mailProjectKey, c.config, c.mailClient)
 	}
 	checker := c.mailNudge
 	c.mu.Unlock()
@@ -578,6 +606,21 @@ func (c *SessionCoordinator) updateAgentStatesContext(ctx context.Context) error
 		if pane.AgentType == string(tmux.AgentUser) || pane.AgentType == string(tmux.AgentUnknown) {
 			continue
 		}
+		if c.authoritativePaneBindings {
+			binding, ok := c.paneBindings[pane.Pane.ID]
+			if !ok || binding.PanePID <= 0 || pane.Metadata.PID != binding.PanePID {
+				continue
+			}
+			currentDir, pathErr := coordinatorPaneCurrentDir(ctx, pane.Pane.ID)
+			if pathErr != nil {
+				slog.Warn("coordinator skipped pane with unreadable project", "session", c.session, "pane_id", pane.Pane.ID, "error", pathErr)
+				continue
+			}
+			belongs, pathErr := coordinatorProjectsMatch(ctx, c.projectKey, currentDir)
+			if pathErr != nil || !belongs {
+				continue
+			}
+		}
 		state := c.monitor.resultFromPaneObservation(pane)
 		updates = append(updates, agentUpdate{
 			paneID:    pane.Pane.ID,
@@ -594,9 +637,13 @@ func (c *SessionCoordinator) updateAgentStatesContext(ctx context.Context) error
 			observationErrors = append(observationErrors, coordinatorPaneObservationError(pane.Pane.ID, message))
 		}
 	}
-	registry, registryErr := agentmail.LoadSessionAgentRegistry(c.session, c.projectKey)
-	if registryErr != nil {
-		slog.Warn("coordinator could not load Agent Mail pane registry", "session", c.session, "error", registryErr)
+	var registry *agentmail.SessionAgentRegistry
+	if !c.authoritativePaneBindings {
+		var registryErr error
+		registry, registryErr = agentmail.LoadSessionAgentRegistry(c.session, c.mailProjectKey)
+		if registryErr != nil {
+			slog.Warn("coordinator could not load Agent Mail pane registry", "session", c.session, "error", registryErr)
+		}
 	}
 
 	c.mu.Lock()
@@ -649,7 +696,9 @@ func (c *SessionCoordinator) updateAgentStatesContext(ctx context.Context) error
 		agent.ObservationError = state.ErrorMessage
 		agent.SafeToDispatch = state.SafeToDispatch
 		agent.Healthy = state.Healthy
-		if registry != nil {
+		if c.authoritativePaneBindings {
+			agent.AgentMailName = c.paneBindings[update.paneID].AgentName
+		} else if registry != nil {
 			if agentName, ok := registry.GetAgent(update.paneTitle, update.paneID); ok {
 				agent.AgentMailName = agentName
 			} else {
@@ -684,6 +733,28 @@ func (c *SessionCoordinator) updateAgentStatesContext(ctx context.Context) error
 		c.emitEvent(transition.agent, transition.prevStatus)
 	}
 	return errors.Join(observationErrors...)
+}
+
+func coordinatorProjectsMatch(ctx context.Context, targetDir, paneDir string) (bool, error) {
+	targetDir = strings.TrimSpace(targetDir)
+	paneDir = strings.TrimSpace(paneDir)
+	if !filepath.IsAbs(targetDir) || !filepath.IsAbs(paneDir) {
+		return false, nil
+	}
+	targetRoot := filepath.Clean(util.ResolveProjectDir(targetDir))
+	paneRoot := filepath.Clean(util.ResolveProjectDir(paneDir))
+	if targetRoot == paneRoot {
+		return true, nil
+	}
+	targetCommon, targetErr := ntmgit.CommonDir(ctx, targetRoot)
+	paneCommon, paneErr := ntmgit.CommonDir(ctx, paneRoot)
+	if targetErr != nil || paneErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		return false, nil
+	}
+	return targetCommon != "" && targetCommon == paneCommon, nil
 }
 
 // markAgentObservationsUnavailable makes a whole-session observation failure

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -60,6 +60,7 @@ type SessionCoordinator struct {
 	actionableRecommendationsFn func(context.Context, string, int) ([]bv.TriageRecommendation, error)
 	workItemStatusFn            func(context.Context, string) (string, error)
 	workItemDetailsFn           func(context.Context, string) (*bv.BeadAssignmentDetails, error)
+	assignmentPressureFn        func(context.Context) AssignmentPressure
 	claimBeadForAssignmentFn    func(context.Context, string, string, string, []string) (bv.BeadClaimResult, error)
 	releaseWorkItemClaimFn      func(context.Context, string, string, string) (bool, error)
 	operatorGatedLabels         []string
@@ -149,6 +150,9 @@ type CoordinatorConfig struct {
 	AutoAssign     bool    `toml:"auto_assign"`      // Automatically assign work to idle agents
 	IdleThreshold  float64 `toml:"idle_threshold"`   // Seconds of inactivity before considering idle
 	AssignOnlyIdle bool    `toml:"assign_only_idle"` // Only assign to truly idle agents
+	// AllowCriticalPressure is runtime-only and may be enabled only by the
+	// bounded `coordinator run --once --allow-critical-pressure` CLI path.
+	AllowCriticalPressure bool `toml:"-"`
 
 	// Conflict handling
 	ConflictNotify    bool `toml:"conflict_notify"`    // Notify when conflicts detected
@@ -240,17 +244,18 @@ type busCoordinatorEvent struct {
 // New creates a new SessionCoordinator.
 func New(session, projectKey string, mailClient *agentmail.Client, agentName string) *SessionCoordinator {
 	c := &SessionCoordinator{
-		session:             session,
-		agentName:           agentName,
-		projectKey:          projectKey,
-		mailProjectKey:      projectKey,
-		mailClient:          mailClient,
-		reservationClient:   mailClient,
-		operatorGatedLabels: append([]string(nil), bv.OperatorGatedLabelsForProject(projectKey)...),
-		agents:              make(map[string]*AgentState),
-		config:              DefaultCoordinatorConfig(),
-		events:              make(chan CoordinatorEvent, 100),
-		stopCh:              make(chan struct{}),
+		session:              session,
+		agentName:            agentName,
+		projectKey:           projectKey,
+		mailProjectKey:       projectKey,
+		mailClient:           mailClient,
+		reservationClient:    mailClient,
+		operatorGatedLabels:  append([]string(nil), bv.OperatorGatedLabelsForProject(projectKey)...),
+		assignmentPressureFn: liveCoordinatorAssignmentPressure,
+		agents:               make(map[string]*AgentState),
+		config:               DefaultCoordinatorConfig(),
+		events:               make(chan CoordinatorEvent, 100),
+		stopCh:               make(chan struct{}),
 	}
 	return c
 }
@@ -540,6 +545,10 @@ func (c *SessionCoordinator) reportAssignmentCycle(results []AssignmentResult, e
 		return
 	}
 	for _, result := range results {
+		if result.Deferred {
+			slog.Info("coordinator auto-assignment deferred", "session", c.session, "reason", result.ReasonCode, "pressure", result.PressureLevel, "limiting", result.PressureLimit)
+			continue
+		}
 		if !result.Success {
 			beadID := ""
 			if result.Assignment != nil {

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	getPanesWithActivity         = tmux.GetPanesWithActivity
+	getAllPanesContext           = tmux.GetAllPanesContext
 	captureForHealthCheckWithCtx = tmux.CaptureForHealthCheckContext
 	coordinatorPaneCurrentDir    = func(ctx context.Context, paneID string) (string, error) {
 		return tmux.DefaultClient.RunContext(ctx, "display-message", "-p", "-t", tmux.ExactTarget(paneID), "#{pane_current_path}")
@@ -586,6 +587,9 @@ func coordinatorPaneObservationError(paneID, message string) error {
 func (c *SessionCoordinator) updateAgentStatesContext(ctx context.Context) error {
 	if c.monitor == nil {
 		return errors.New("agent monitor is not configured")
+	}
+	if c.authoritativePaneBindings {
+		c.monitor.SetPaneBindings(c.paneBindings)
 	}
 	observation, err := c.monitor.ObserveSession(ctx)
 	if err != nil {

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -452,6 +452,59 @@ func TestAuthoritativeCoordinatorBindingsSkipUnboundCrossProjectAndRecycledPanes
 	}
 }
 
+func TestAuthoritativeCoordinatorBindingsObserveDetachedSameProjectSession(t *testing.T) {
+	projectDir := t.TempDir()
+	originalGetPanes := getPanesWithActivity
+	originalGetAllPanes := getAllPanesContext
+	originalCapture := captureForHealthCheckWithCtx
+	originalCurrentDir := coordinatorPaneCurrentDir
+	t.Cleanup(func() {
+		getPanesWithActivity = originalGetPanes
+		getAllPanesContext = originalGetAllPanes
+		captureForHealthCheckWithCtx = originalCapture
+		coordinatorPaneCurrentDir = originalCurrentDir
+	})
+	getPanesWithActivity = func(session string) ([]tmux.PaneActivity, error) {
+		switch session {
+		case "bbi-infrastructure":
+			return []tmux.PaneActivity{{Pane: tmux.Pane{ID: "%44", Index: 1, PID: 4400, Type: tmux.AgentCodex}}}, nil
+		case "bbi-infrastructure--lms-argo-wedge":
+			return []tmux.PaneActivity{
+				{Pane: tmux.Pane{ID: "%155", Index: 1, PID: 15500, Type: tmux.AgentCodex}},
+				{Pane: tmux.Pane{ID: "%156", Index: 2, PID: 15600, Type: tmux.AgentCodex}},
+			}, nil
+		default:
+			return nil, fmt.Errorf("unexpected session %q", session)
+		}
+	}
+	getAllPanesContext = func(context.Context) (map[string][]tmux.Pane, error) {
+		return map[string][]tmux.Pane{
+			"bbi-infrastructure":                 {{ID: "%44", PID: 4400}},
+			"bbi-infrastructure--lms-argo-wedge": {{ID: "%155", PID: 15500}, {ID: "%156", PID: 15600}},
+		}, nil
+	}
+	captureForHealthCheckWithCtx = func(context.Context, string) (string, error) {
+		return "completed\n────────────\n› \n────────────", nil
+	}
+	coordinatorPaneCurrentDir = func(context.Context, string) (string, error) { return projectDir, nil }
+
+	bindings := map[string]agentmail.CoordinatorPaneBinding{
+		"%44":  {AgentName: "AzureCreek", PanePID: 4400, ProjectDir: projectDir},
+		"%155": {AgentName: "YellowOx", PanePID: 15500, ProjectDir: projectDir},
+		"%156": {AgentName: "NobleAnchor", PanePID: 15600, ProjectDir: projectDir},
+	}
+	c := New("bbi-infrastructure", projectDir, nil, "IvoryAnchor").
+		WithAgentMailScope("/repos/github.com/biji-biji-initiative/bbi-infrastructure", "IvoryAnchor", bindings)
+	c.monitor = NewAgentMonitor(c.session, nil, c.projectKey)
+	if err := c.updateAgentStatesContext(context.Background()); err != nil {
+		t.Fatalf("updateAgentStatesContext: %v", err)
+	}
+	agents := c.GetAgents()
+	if len(agents) != 3 || agents["%44"].AgentMailName != "AzureCreek" || agents["%155"].AgentMailName != "YellowOx" || agents["%156"].AgentMailName != "NobleAnchor" {
+		t.Fatalf("authoritative multi-session agents = %+v", agents)
+	}
+}
+
 func TestEmitEvent_PublishesToEventsBus(t *testing.T) {
 	c := New("test-session", "/tmp/test", nil, "TestAgent")
 

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -407,6 +407,51 @@ func TestUpdateAgentStatesLoadsPersistedAgentMailIdentity(t *testing.T) {
 	}
 }
 
+func TestAuthoritativeCoordinatorBindingsSkipUnboundCrossProjectAndRecycledPanes(t *testing.T) {
+	projectDir := t.TempDir()
+	otherDir := t.TempDir()
+	originalGetPanes := getPanesWithActivity
+	originalCapture := captureForHealthCheckWithCtx
+	originalCurrentDir := coordinatorPaneCurrentDir
+	t.Cleanup(func() {
+		getPanesWithActivity = originalGetPanes
+		captureForHealthCheckWithCtx = originalCapture
+		coordinatorPaneCurrentDir = originalCurrentDir
+	})
+	getPanesWithActivity = func(string) ([]tmux.PaneActivity, error) {
+		return []tmux.PaneActivity{
+			{Pane: tmux.Pane{ID: "%44", Index: 1, PID: 4400, Title: "train", Type: tmux.AgentCodex}},
+			{Pane: tmux.Pane{ID: "%45", Index: 2, PID: 4500, Title: "unbound", Type: tmux.AgentCodex}},
+			{Pane: tmux.Pane{ID: "%66", Index: 3, PID: 6600, Title: "lms", Type: tmux.AgentCodex}},
+			{Pane: tmux.Pane{ID: "%129", Index: 4, PID: 9999, Title: "recycled", Type: tmux.AgentCodex}},
+		}, nil
+	}
+	captureForHealthCheckWithCtx = func(context.Context, string) (string, error) {
+		return "completed\n────────────\n› \n────────────", nil
+	}
+	coordinatorPaneCurrentDir = func(_ context.Context, paneID string) (string, error) {
+		if paneID == "%66" {
+			return otherDir, nil
+		}
+		return projectDir, nil
+	}
+	bindings := map[string]agentmail.CoordinatorPaneBinding{
+		"%44":  {AgentName: "AzureCreek", PanePID: 4400, ProjectDir: projectDir},
+		"%66":  {AgentName: "CrossProject", PanePID: 6600, ProjectDir: projectDir},
+		"%129": {AgentName: "CoralFox", PanePID: 12900, ProjectDir: projectDir},
+	}
+	c := New("bbi-infrastructure", projectDir, nil, "SilverHarbor").
+		WithAgentMailScope("/repos/github.com/biji-biji-initiative/bbi-infrastructure", "SilverHarbor", bindings)
+	c.monitor = NewAgentMonitor(c.session, nil, c.projectKey)
+	if err := c.updateAgentStatesContext(context.Background()); err != nil {
+		t.Fatalf("updateAgentStatesContext: %v", err)
+	}
+	agents := c.GetAgents()
+	if len(agents) != 1 || agents["%44"] == nil || agents["%44"].AgentMailName != "AzureCreek" {
+		t.Fatalf("authoritative agents = %+v, want only %%44/AzureCreek", agents)
+	}
+}
+
 func TestEmitEvent_PublishesToEventsBus(t *testing.T) {
 	c := New("test-session", "/tmp/test", nil, "TestAgent")
 

--- a/internal/coordinator/deadlock_digest.go
+++ b/internal/coordinator/deadlock_digest.go
@@ -116,7 +116,7 @@ func (c *SessionCoordinator) populateDeadlockAlerts(ctx context.Context, digest 
 	}
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	reservations, err := c.mailClient.ListReservations(ctx, c.projectKey, "", true)
+	reservations, err := c.mailClient.ListReservations(ctx, c.mailProjectKey, "", true)
 	if err != nil {
 		return
 	}

--- a/internal/coordinator/digest.go
+++ b/internal/coordinator/digest.go
@@ -222,7 +222,7 @@ func (c *SessionCoordinator) SendDigest(ctx context.Context) error {
 
 	// Send to human
 	_, err := c.mailClient.SendMessage(ctx, agentmail.SendMessageOptions{
-		ProjectKey:  c.projectKey,
+		ProjectKey:  c.mailProjectKey,
 		SenderName:  c.agentName,
 		To:          []string{c.config.HumanAgent},
 		Subject:     fmt.Sprintf("Session Digest: %s", c.session),

--- a/internal/coordinator/monitor.go
+++ b/internal/coordinator/monitor.go
@@ -3,6 +3,8 @@ package coordinator
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/Dicklesworthstone/ntm/internal/agentmail"
@@ -19,6 +21,8 @@ type AgentMonitor struct {
 	detector    *status.UnifiedDetector
 	observer    *status.SessionObserver
 	activityMon *robot.ActivityMonitor
+	bindingsMu  sync.RWMutex
+	boundPanes  map[string]struct{}
 }
 
 // AgentStatusResult holds the result of checking an agent's status.
@@ -40,26 +44,100 @@ type AgentStatusResult struct {
 // NewAgentMonitor creates a new agent monitor.
 func NewAgentMonitor(session string, mailClient *agentmail.Client, projectKey string) *AgentMonitor {
 	detector := status.NewDetector()
+	monitor := &AgentMonitor{}
 	observer := status.NewSessionObserverWithDependencies(
 		detector,
 		status.DefaultSessionObserverConfig(detector.Config()),
 		status.SessionObserverDependencies{
-			ListPanes: func(_ context.Context, session string) ([]tmux.PaneActivity, error) {
-				return getPanesWithActivity(session)
+			ListPanes: func(ctx context.Context, session string) ([]tmux.PaneActivity, error) {
+				return monitor.listPanes(ctx, session)
 			},
 			CapturePane: func(ctx context.Context, paneID string, _ int) (string, error) {
 				return captureForHealthCheckWithCtx(ctx, paneID)
 			},
 		},
 	)
-	return &AgentMonitor{
-		session:     session,
-		projectKey:  projectKey,
-		mailClient:  mailClient,
-		detector:    detector,
-		observer:    observer,
-		activityMon: robot.NewActivityMonitor(nil),
+	monitor.session = session
+	monitor.projectKey = projectKey
+	monitor.mailClient = mailClient
+	monitor.detector = detector
+	monitor.observer = observer
+	monitor.activityMon = robot.NewActivityMonitor(nil)
+	return monitor
+}
+
+// SetPaneBindings installs the exact stable pane IDs authorized by bootstrap.
+func (m *AgentMonitor) SetPaneBindings(bindings map[string]agentmail.CoordinatorPaneBinding) {
+	m.bindingsMu.Lock()
+	defer m.bindingsMu.Unlock()
+	m.boundPanes = make(map[string]struct{}, len(bindings))
+	for paneID := range bindings {
+		m.boundPanes[paneID] = struct{}{}
 	}
+}
+
+func (m *AgentMonitor) bindingSnapshot() map[string]struct{} {
+	m.bindingsMu.RLock()
+	defer m.bindingsMu.RUnlock()
+	result := make(map[string]struct{}, len(m.boundPanes))
+	for paneID := range m.boundPanes {
+		result[paneID] = struct{}{}
+	}
+	return result
+}
+
+// listPanes observes the primary session and, only when an authoritative pane
+// is absent there, discovers its owning session by tmux-global stable pane ID.
+// The coordinator still validates the bound PID and project directory before
+// admitting the resulting observation.
+func (m *AgentMonitor) listPanes(ctx context.Context, session string) ([]tmux.PaneActivity, error) {
+	primary, err := getPanesWithActivity(session)
+	if err != nil {
+		return nil, err
+	}
+	missing := m.bindingSnapshot()
+	if len(missing) == 0 {
+		return primary, nil
+	}
+	for _, pane := range primary {
+		delete(missing, pane.Pane.ID)
+	}
+	if len(missing) == 0 {
+		return primary, nil
+	}
+
+	bySession, err := getAllPanesContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("discovering bound pane sessions: %w", err)
+	}
+	result := append([]tmux.PaneActivity(nil), primary...)
+	for candidateSession, panes := range bySession {
+		if candidateSession == session {
+			continue
+		}
+		needed := false
+		for _, pane := range panes {
+			if _, ok := missing[pane.ID]; ok {
+				needed = true
+				break
+			}
+		}
+		if !needed {
+			continue
+		}
+		observed, observeErr := getPanesWithActivity(candidateSession)
+		if observeErr != nil {
+			return nil, fmt.Errorf("observing bound panes in session %q: %w", candidateSession, observeErr)
+		}
+		for _, pane := range observed {
+			if _, ok := missing[pane.Pane.ID]; !ok {
+				continue
+			}
+			result = append(result, pane)
+			delete(missing, pane.Pane.ID)
+		}
+	}
+	return result, nil
 }
 
 // ObserveSession returns the canonical point-in-time observation used by the

--- a/internal/robot/routing.go
+++ b/internal/robot/routing.go
@@ -520,7 +520,8 @@ const reservationAffinityRefreshTimeout = 3 * time.Second
 // resolves the project key SESSION-FIRST with the same precedence the CLI
 // uses (persisted session registry, then configured session dir, then cwd —
 // bd-2rtl8), constructs an Agent Mail client from the same config/env
-// precedence the CLI uses (env AGENT_MAIL_URL/AGENT_MAIL_TOKEN override
+// precedence the CLI uses (env AGENT_MAIL_URL/AGENT_MAIL_TOKEN or
+// MCP_AGENT_MAIL_TOKEN override
 // config), attaches the process-shared TTL ReservationCache with one
 // best-effort TTL-bounded refresh, and loads the persisted pane→agent-name
 // mapping from the session agent registry. Everything is best-effort: any
@@ -543,7 +544,7 @@ func (s *AgentScorer) wireReservationAffinity(cfg *config.Config, session string
 	if cfg.AgentMail.URL != "" && os.Getenv("AGENT_MAIL_URL") == "" {
 		opts = append(opts, agentmail.WithBaseURL(cfg.AgentMail.URL))
 	}
-	if cfg.AgentMail.Token != "" && os.Getenv("AGENT_MAIL_TOKEN") == "" {
+	if cfg.AgentMail.Token != "" && os.Getenv("AGENT_MAIL_TOKEN") == "" && os.Getenv("MCP_AGENT_MAIL_TOKEN") == "" {
 		opts = append(opts, agentmail.WithToken(cfg.AgentMail.Token))
 	}
 	client := agentmail.NewClient(opts...)

--- a/internal/tui/dashboard/dashboard.go
+++ b/internal/tui/dashboard/dashboard.go
@@ -703,10 +703,10 @@ func (m *Model) newAgentMailClient(projectKey string) *agentmail.Client {
 		if !m.cfg.AgentMail.Enabled {
 			return nil
 		}
-		if m.cfg.AgentMail.URL != "" {
+		if m.cfg.AgentMail.URL != "" && os.Getenv("AGENT_MAIL_URL") == "" {
 			opts = append(opts, agentmail.WithBaseURL(m.cfg.AgentMail.URL))
 		}
-		if m.cfg.AgentMail.Token != "" {
+		if m.cfg.AgentMail.Token != "" && os.Getenv("AGENT_MAIL_TOKEN") == "" && os.Getenv("MCP_AGENT_MAIL_TOKEN") == "" {
 			opts = append(opts, agentmail.WithToken(m.cfg.AgentMail.Token))
 		}
 	}


### PR DESCRIPTION
## Problem

A fleet using a canonical non-filesystem Agent Mail project key could not use NTM worker/controller identity setup safely: NTM derived physical worktree keys, normal spawn paths could override the public token, and controller launch had no identity bootstrap.

## Change

- Add an invocation-scoped canonical Agent Mail project-key override without changing default behavior.
- Preserve escaped resource URI keys and scope identity files to the canonical key.
- Prefer MCP_AGENT_MAIL_TOKEN over stale configured tokens across spawn, routing, and dashboards.
- Publish controller identity before its agent command is sent.

## Verification

- Full internal agentmail suite.
- Focused CLI, robot, and dashboard tests.
- go build ./cmd/ntm.
- git diff --check.

This does not claim to authenticate direct robot actuation; that is a separate control-plane issue.