### PR TITLE
fix(assign): skip packet tracking beads

### DIFF
--- a/internal/bv/bead_status_test.go
+++ b/internal/bv/bead_status_test.go
@@ -285,6 +285,7 @@ func TestOperatorGatedLabelsCanonicalVocabulary(t *testing.T) {
 		"needs-operator",
 		"operator-action",
 		"operator-gated",
+		"packet-tracked",
 	}
 	got := OperatorGatedLabels()
 	if !reflect.DeepEqual(got, want) {

--- a/internal/bv/bead_status_test.go
+++ b/internal/bv/bead_status_test.go
@@ -416,6 +416,28 @@ func TestValidateBeadAssignmentAuthorizationAllowsExplicitStaleOwnershipState(t 
 	}
 }
 
+func TestValidateBeadAssignmentAuthorizationRejectsPacketTrackedBead(t *testing.T) {
+	t.Parallel()
+
+	details := &BeadAssignmentDetails{
+		ID:     "agent-factory-packet",
+		Status: "open",
+		Labels: []string{"packet-tracked"},
+	}
+	err := ValidateBeadAssignmentAuthorizationWithOperatorGatedLabels(
+		details,
+		BeadAssignmentAuthorization{BeadID: details.ID},
+		nil,
+	)
+	var eligibilityErr *AssignmentEligibilityError
+	if !errors.Is(err, ErrBeadAssignmentIneligible) || !errors.As(err, &eligibilityErr) {
+		t.Fatalf("authorization error=%v, want typed assignment-ineligible error", err)
+	}
+	if !reflect.DeepEqual(eligibilityErr.OperatorLabels, []string{"packet-tracked"}) {
+		t.Fatalf("operator labels=%v, want [packet-tracked]", eligibilityErr.OperatorLabels)
+	}
+}
+
 func TestClaimBeadForAssignmentTransactionRejectsDirectStartBlockers(t *testing.T) {
 	requireRealBR(t)
 

--- a/internal/bv/bv.go
+++ b/internal/bv/bv.go
@@ -994,6 +994,7 @@ var defaultOperatorGatedLabels = []string{
 	"human-input",
 	"business-input",
 	"blocked-on-operator",
+	"packet-tracked",
 }
 
 var (

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -159,6 +159,28 @@ func TestBlockedBeadsReasonString(t *testing.T) {
 	}
 }
 
+func TestPacketTrackedBeadIsExcludedFromDirectAssignment(t *testing.T) {
+	t.Parallel()
+
+	recommendation := bv.TriageRecommendation{
+		ID:     "agent-factory-packet",
+		Title:  "Mission packet tracking bead",
+		Status: "open",
+		Labels: []string{"packet-tracked"},
+	}
+	skipped := classifyTriageRecForAssignmentWithGate(
+		recommendation,
+		nil,
+		func(label string) bool { return bv.IsOperatorGatedLabelInPolicy(label, nil) },
+	)
+	if skipped == nil {
+		t.Fatal("packet-tracked bead remained eligible for direct assignment")
+	}
+	if skipped.Reason != "operator_gated" {
+		t.Fatalf("packet-tracked skip reason=%q, want operator_gated", skipped.Reason)
+	}
+}
+
 // TestAssignOutputEnhancedStructure tests the output structure is correct for JSON
 func TestAssignOutputEnhancedStructure(t *testing.T) {
 	output := AssignOutputEnhanced{
@@ -1982,6 +2004,11 @@ func TestWatchLoopShouldStopUsesFilteredActionableCandidates(t *testing.T) {
 		{
 			name:     "operator-gated-only queue is drained",
 			recs:     []bv.TriageRecommendation{{ID: "gated", Status: "open", Labels: []string{"operator-gated"}}},
+			wantStop: true,
+		},
+		{
+			name:     "packet-tracked-only queue is drained",
+			recs:     []bv.TriageRecommendation{{ID: "packet", Status: "open", Labels: []string{"packet-tracked"}}},
 			wantStop: true,
 		},
 		{

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -159,7 +159,7 @@ func TestBlockedBeadsReasonString(t *testing.T) {
 	}
 }
 
-func TestPacketTrackedBeadIsExcludedFromDirectAssignment(t *testing.T) {
+func TestPacketTrackedBeadNeverEntersAssignmentPlanAcrossRepeatedScans(t *testing.T) {
 	t.Parallel()
 
 	recommendation := bv.TriageRecommendation{
@@ -168,16 +168,18 @@ func TestPacketTrackedBeadIsExcludedFromDirectAssignment(t *testing.T) {
 		Status: "open",
 		Labels: []string{"packet-tracked"},
 	}
-	skipped := classifyTriageRecForAssignmentWithGate(
-		recommendation,
-		nil,
-		func(label string) bool { return bv.IsOperatorGatedLabelInPolicy(label, nil) },
-	)
-	if skipped == nil {
-		t.Fatal("packet-tracked bead remained eligible for direct assignment")
-	}
-	if skipped.Reason != "operator_gated" {
-		t.Fatalf("packet-tracked skip reason=%q, want operator_gated", skipped.Reason)
+	for scan := 1; scan <= 3; scan++ {
+		ready, skipped := partitionActionableRecommendationsForAssignment(
+			[]bv.TriageRecommendation{recommendation},
+			nil,
+			func(label string) bool { return bv.IsOperatorGatedLabelInPolicy(label, nil) },
+		)
+		if len(ready) != 0 {
+			t.Fatalf("scan %d offered packet-tracked bead for assignment: %+v", scan, ready)
+		}
+		if len(skipped) != 1 || skipped[0].BeadID != recommendation.ID || skipped[0].Reason != "operator_gated" {
+			t.Fatalf("scan %d skipped=%+v, want one operator_gated packet", scan, skipped)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat the packet-tracked label as a built-in operator gate
- exclude packet tracking beads from direct assign, assign --watch, and coordinator recommendation paths through the shared canonical gate
- add focused regressions for direct assignment and watch-loop draining; the coordinator's canonical-vocabulary regression covers every built-in label

## Verification
- targeted: go test -run 'TestOperatorGatedLabelsCanonicalVocabulary|TestPacketTrackedBeadIsExcludedFromDirectAssignment|TestWatchLoopShouldStopUsesFilteredActionableCandidates|TestRecommendationPassesSemanticGatesUsesCanonicalOperatorLabels' ./internal/bv ./internal/cli ./internal/coordinator
- full: go test -short ./... (receipt-bound run in progress)

Tracking: agent-factory-yv4v