### PR TITLE
fix(bv): retry Beads write-lock timeouts

### DIFF
--- a/internal/bv/bv.go
+++ b/internal/bv/bv.go
@@ -2294,7 +2294,9 @@ func isNoBeadsDBError(streams ...string) bool {
 
 func isTransientBeadsDBError(streams ...string) bool {
 	s := strings.ToLower(strings.Join(streams, "\n"))
-	return strings.Contains(s, "database is busy") || strings.Contains(s, "database is locked")
+	return strings.Contains(s, "database is busy") ||
+		strings.Contains(s, "database is locked") ||
+		strings.Contains(s, "waiting for write lock")
 }
 
 func transientBeadsDBBackoff(attempt int) time.Duration {

--- a/internal/bv/bv_helpers_test.go
+++ b/internal/bv/bv_helpers_test.go
@@ -322,6 +322,43 @@ func TestRunBdContextCancelsDuringTransientRetryBackoff(t *testing.T) {
 	}
 }
 
+func TestRunBdContextRetriesBeadsWriteLockTimeout(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	binDir := t.TempDir()
+	attempts := filepath.Join(t.TempDir(), "attempts")
+	script := `#!/bin/sh
+printf 'x\n' >> "` + attempts + `"
+count=$(wc -l < "` + attempts + `")
+if [ "$count" -lt 3 ]; then
+  printf 'CONFIG_ERROR: Timed out after 5000ms waiting for write lock .beads/.write.lock\n' >&2
+  exit 1
+fi
+printf '{"issues":[],"total":0,"limit":100000,"offset":0,"has_more":false}\n'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "br"), []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake br: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	output, err := RunBdContext(t.Context(), dir, "ready", "--json", "--limit", "100000")
+	if err != nil {
+		t.Fatalf("RunBdContext returned the transient write-lock timeout: %v", err)
+	}
+	if !strings.Contains(output, `"issues":[]`) {
+		t.Fatalf("RunBdContext output=%q, want successful third attempt", output)
+	}
+	data, err := os.ReadFile(attempts)
+	if err != nil {
+		t.Fatalf("read fake br attempts: %v", err)
+	}
+	if got := strings.Count(string(data), "x"); got != 3 {
+		t.Fatalf("fake br attempts=%d, want exactly 3", got)
+	}
+}
+
 func TestGetRecentlyCompletedListContext(t *testing.T) {
 	t.Run("returns_limited_completed_rows", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/bv/triage_test.go
+++ b/internal/bv/triage_test.go
@@ -956,12 +956,19 @@ func TestGetActionableRecommendationsSkipsPlanRowsClosedSinceSnapshot(t *testing
 				`{"triage":{"recommendations":[{"id":"tracked","title":"tracked","status":"open","priority":1}]}}`,
 				`[{"id":"tracked","status":"`+status+`"}]`)
 
-			recs, err := GetActionableRecommendationsContext(t.Context(), t.TempDir(), 0)
-			if err != nil {
-				t.Fatalf("lifecycle %s: unexpected error: %v", status, err)
+			scans := 1
+			if status == "closed" || status == "in_progress" {
+				scans = 3
 			}
-			if len(recs) != 0 {
-				t.Fatalf("lifecycle %s: recommendations = %+v, want stale row dropped", status, recs)
+			projectDir := t.TempDir()
+			for scan := 1; scan <= scans; scan++ {
+				recs, err := GetActionableRecommendationsContext(t.Context(), projectDir, 0)
+				if err != nil {
+					t.Fatalf("lifecycle %s scan %d: unexpected error: %v", status, scan, err)
+				}
+				if len(recs) != 0 {
+					t.Fatalf("lifecycle %s scan %d: recommendations = %+v, want stale row dropped", status, scan, recs)
+				}
 			}
 		})
 	}

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -2146,11 +2146,12 @@ func TestWatchLoopSurvivesThreeScansWithTransientBeadsWriteLockTimeout(t *testin
 	}
 	binDir := t.TempDir()
 	attempts := filepath.Join(t.TempDir(), "attempts")
+	scanMarker := filepath.Join(t.TempDir(), "scan")
 	brScript := `#!/bin/sh
-printf 'x\n' >> "` + attempts + `"
-count=$(wc -l < "` + attempts + `")
-remainder=$((count % 3))
-if [ "$remainder" -ne 0 ]; then
+scan=$(cat "` + scanMarker + `")
+printf '%s\n' "$scan" >> "` + attempts + `"
+count=$(grep -c "^${scan}$" "` + attempts + `")
+if [ "$count" -lt 3 ]; then
   printf 'CONFIG_ERROR: Timed out after 5000ms waiting for write lock .beads/.write.lock\n' >&2
   exit 1
 fi
@@ -2161,7 +2162,12 @@ printf '{"issues":[],"total":0,"limit":100000,"offset":0,"has_more":false}\n'
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
+	var probes atomic.Int32
 	runWatchLoopThroughThreeSuccessfulScans(t, func(ctx context.Context) error {
+		scan := probes.Add(1)
+		if err := os.WriteFile(scanMarker, []byte(fmt.Sprintf("%d\n", scan)), 0o600); err != nil {
+			return fmt.Errorf("write scan marker: %w", err)
+		}
 		_, err := bv.RunBdContext(ctx, projectDir, "ready", "--json", "--limit", "100000")
 		return err
 	})
@@ -2170,8 +2176,9 @@ printf '{"issues":[],"total":0,"limit":100000,"offset":0,"has_more":false}\n'
 	if err != nil {
 		t.Fatalf("read fake br attempts: %v", err)
 	}
-	if got := strings.Count(string(data), "x"); got != 9 {
-		t.Fatalf("fake br attempts=%d, want three retries across each of three scans", got)
+	want := "1\n1\n1\n2\n2\n2\n3\n3\n3\n"
+	if got := string(data); got != want {
+		t.Fatalf("fake br attempts by scan=%q, want %q", got, want)
 	}
 }
 

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -2067,6 +2067,114 @@ func TestWatchLoopRunStopsOnAutomatedAssignmentSafetyErrors(t *testing.T) {
 	}
 }
 
+func runWatchLoopThroughThreeSuccessfulScans(t *testing.T, probe func(context.Context) error) {
+	t.Helper()
+	isolateSessionAgentStorage(t)
+
+	store := assignment.NewStore("watch-three-scan-" + strings.ReplaceAll(t.Name(), "/", "-"))
+	loop := NewWatchLoop("watch-three-scan", store, &AutoReassignOptions{
+		Session: "watch-three-scan",
+		Quiet:   true,
+	})
+	loop.stopWhenDone = false
+	loop.scanInterval = time.Millisecond
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	var scans atomic.Int32
+	loop.scanFn = func(scanCtx context.Context) error {
+		if err := probe(scanCtx); err != nil {
+			return err
+		}
+		if scans.Add(1) == 3 {
+			cancel()
+		}
+		return nil
+	}
+
+	err := loop.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WatchLoop.Run() error=%v, want cancellation after third successful scan", err)
+	}
+	if got := scans.Load(); got != 3 {
+		t.Fatalf("successful scans=%d, want exactly 3", got)
+	}
+}
+
+func TestWatchLoopSurvivesThreeScansWithInProgressPlanItem(t *testing.T) {
+	projectDir := t.TempDir()
+	binDir := t.TempDir()
+	bvScript := `#!/bin/sh
+case "$1" in
+  --robot-triage) printf '%s\n' '{"triage":{"recommendations":[{"id":"tracked","title":"tracked","status":"open","priority":1}]}}' ;;
+  --robot-plan) printf '%s\n' '{"plan":{"tracks":[{"track_id":"t1","items":[{"id":"tracked","title":"tracked","status":"open","priority":1}]}]}}' ;;
+  *) printf 'unexpected bv args: %s\n' "$*" >&2; exit 64 ;;
+esac
+`
+	brScript := `#!/bin/sh
+case "$*" in
+  *" --all "*) printf '%s\n' '[{"id":"tracked","status":"in_progress"}]' ;;
+  *" ready "*|*" --status open "*) printf '%s\n' '[]' ;;
+  *) printf 'unexpected br args: %s\n' "$*" >&2; exit 64 ;;
+esac
+`
+	for name, script := range map[string]string{"bv": bvScript, "br": brScript} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o700); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bv.InvalidateTriageCache()
+	t.Cleanup(bv.InvalidateTriageCache)
+
+	runWatchLoopThroughThreeSuccessfulScans(t, func(ctx context.Context) error {
+		recommendations, err := bv.GetActionableRecommendationsContext(ctx, projectDir, 0)
+		if err != nil {
+			return err
+		}
+		if len(recommendations) != 0 {
+			return fmt.Errorf("in-progress plan item remained actionable: %+v", recommendations)
+		}
+		return nil
+	})
+}
+
+func TestWatchLoopSurvivesThreeScansWithTransientBeadsWriteLockTimeout(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(projectDir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	binDir := t.TempDir()
+	attempts := filepath.Join(t.TempDir(), "attempts")
+	brScript := `#!/bin/sh
+printf 'x\n' >> "` + attempts + `"
+count=$(wc -l < "` + attempts + `")
+remainder=$((count % 3))
+if [ "$remainder" -ne 0 ]; then
+  printf 'CONFIG_ERROR: Timed out after 5000ms waiting for write lock .beads/.write.lock\n' >&2
+  exit 1
+fi
+printf '{"issues":[],"total":0,"limit":100000,"offset":0,"has_more":false}\n'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "br"), []byte(brScript), 0o700); err != nil {
+		t.Fatalf("write fake br: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	runWatchLoopThroughThreeSuccessfulScans(t, func(ctx context.Context) error {
+		_, err := bv.RunBdContext(ctx, projectDir, "ready", "--json", "--limit", "100000")
+		return err
+	})
+
+	data, err := os.ReadFile(attempts)
+	if err != nil {
+		t.Fatalf("read fake br attempts: %v", err)
+	}
+	if got := strings.Count(string(data), "x"); got != 9 {
+		t.Fatalf("fake br attempts=%d, want three retries across each of three scans", got)
+	}
+}
+
 func TestCountSkippedByReason(t *testing.T) {
 	items := []SkippedItem{
 		{BeadID: "a", Reason: "blocked_by_dependency"},


### PR DESCRIPTION
## Summary

- Treat Beads Timed out ... waiting for write lock diagnostics as transient contention.
- Reuse the existing bounded, context-cancellable retry path.
- Keep stale in_progress plan items nonfatal across three real watch-loop scans.
- Bind the write-lock regression to three retries within each individual scan.

## Verification

- go build ./cmd/ntm
- go test ./internal/cli -run TestWatchLoopSurvivesThreeScans -count=1
- go test ./internal/bv -run 'TestRunBdContextRetriesBeadsWriteLockTimeout|TestGetActionableRecommendationsSkipsPlanRowsClosedSinceSnapshot' -count=1
- Mutation proof: removing the write-lock classifier makes TestWatchLoopSurvivesThreeScansWithTransientBeadsWriteLockTimeout fail with context deadline exceeded.

The full short internal/bv + internal/cli run has two failures already present at upstream main 75a6f92c: TestGetReadySnapshotContextUsesOneDirectReadyResult and TestGetBlockedSnapshotContextRetainsRestrictiveEvidence. Both reject the newly added --lock-timeout 5000 argument; this branch adds no failure delta.