### PR TITLE
fix(spawn): refuse occupied launch panes

### DIFF
--- a/internal/cli/spawn.go
+++ b/internal/cli/spawn.go
@@ -909,24 +909,60 @@ func validateSpawnPaneCapacity(panes []tmux.Pane, startIdx, agentCount int) erro
 	return nil
 }
 
-func validateSpawnGrokPaneBaselines(panes []tmux.Pane, startIdx int, agents []FlatAgent) error {
+func validateSpawnPaneBaselines(panes []tmux.Pane, startIdx int, agents []FlatAgent) error {
 	for agentOffset, launch := range agents {
-		if launch.Type != AgentTypeGrok {
-			continue
-		}
 		paneOffset := startIdx + agentOffset
 		if paneOffset < 0 || paneOffset >= len(panes) {
 			return fmt.Errorf(
-				"no assigned pane for Grok Build agent %d at offset %d",
+				"no assigned pane for %s agent %d at offset %d",
+				launch.Type,
 				launch.Index,
 				paneOffset,
 			)
 		}
 		if err := tmux.ValidatePaneLaunchBaseline(panes[paneOffset]); err != nil {
-			return fmt.Errorf("validate Grok Build agent %d: %w", launch.Index, err)
+			return fmt.Errorf("validate %s agent %d: %w", launch.Type, launch.Index, err)
 		}
 	}
 	return nil
+}
+
+type spawnPaneBaselineLister func(context.Context, string) ([]tmux.Pane, error)
+
+// validateCurrentSpawnPaneBaseline re-reads the exact pane immediately before
+// launch. The batch-level check above prevents a known occupied target from
+// causing a partial launch, while this second check closes the preparation
+// race: command construction and identity registration can take long enough
+// for another process to occupy a pane that was a shell in the first snapshot.
+// A failed lookup is a refusal; launch commands are never retargeted.
+func validateCurrentSpawnPaneBaseline(
+	ctx context.Context,
+	session, paneID string,
+	listPanes spawnPaneBaselineLister,
+) error {
+	if ctx == nil {
+		return errors.New("spawn pane launch preflight requires a context")
+	}
+	if strings.TrimSpace(session) == "" || strings.TrimSpace(paneID) == "" {
+		return errors.New("spawn pane launch preflight requires a session and exact pane ID")
+	}
+	if listPanes == nil {
+		return errors.New("spawn pane launch preflight requires a pane lister")
+	}
+	panes, err := listPanes(ctx, session)
+	if err != nil {
+		return fmt.Errorf("re-read spawn pane %s: %w", paneID, err)
+	}
+	for _, pane := range panes {
+		if pane.ID != paneID {
+			continue
+		}
+		if err := tmux.ValidatePaneLaunchBaseline(pane); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("spawn pane %s disappeared before launch", paneID)
 }
 
 // expandProfileAgents converts an ordered persona list (from --profile-set or
@@ -2722,8 +2758,8 @@ func spawnSessionLogicContextWithOutput(ctx context.Context, opts SpawnOptions, 
 	if err := validateSpawnPaneCapacity(panes, startIdx, len(opts.Agents)); err != nil {
 		return outputError(err)
 	}
-	if err := validateSpawnGrokPaneBaselines(panes, startIdx, opts.Agents); err != nil {
-		return outputError(fmt.Errorf("validating Grok Build launch panes: %w", err))
+	if err := validateSpawnPaneBaselines(panes, startIdx, opts.Agents); err != nil {
+		return outputError(fmt.Errorf("validating agent launch panes: %w", err))
 	}
 
 	agentNum := startIdx
@@ -2875,12 +2911,6 @@ func spawnSessionLogicContextWithOutput(ctx context.Context, opts SpawnOptions, 
 		}
 
 		pane := panes[agentNum]
-		if agent.Type == AgentTypeGrok {
-			if err := tmux.ValidatePaneLaunchBaseline(pane); err != nil {
-				return outputError(fmt.Errorf("launching %s agent: %w", agent.Type, err))
-			}
-		}
-
 		if testPacing.agentDelay > 0 && staggerAgentIdx > 0 {
 			if err := waitContextDelay(ctx, testPacing.agentDelay); err != nil {
 				return outputError(fmt.Errorf("agent launch pacing canceled: %w", err))
@@ -3231,6 +3261,19 @@ func spawnSessionLogicContextWithOutput(ctx context.Context, opts SpawnOptions, 
 			model:         agent.Model,
 			resolvedModel: resolvedModel,
 		})
+
+		// Re-read the physical pane after every potentially slow preparation
+		// step and immediately before actuation. tmux send-keys succeeding says
+		// nothing about what received the bytes: without this check a launch
+		// line can be submitted as a prompt to an already-running agent.
+		if err := validateCurrentSpawnPaneBaseline(
+			ctx, opts.Session, pane.ID, tmux.GetPanesContext,
+		); err != nil {
+			return outputError(fmt.Errorf(
+				"refusing to launch %s agent in pane %s: %w",
+				agent.Type, pane.ID, err,
+			))
+		}
 
 		if err := tmux.SendKeysContext(ctx, pane.ID, cmd, true); err != nil {
 			launchErr := fmt.Errorf(

--- a/internal/cli/spawn_identity_order_test.go
+++ b/internal/cli/spawn_identity_order_test.go
@@ -4,7 +4,9 @@ package cli
 // process (tmux.SendKeysContext) before creating and publishing its Agent
 // Mail pane identity, so an agent that resolved its identity during startup
 // could read a previous occupant's name or find none. The text output path
-// also called registerSpawnedAgents twice.
+// also called registerSpawnedAgents twice. agent-factory-wsnk adds a second
+// ordering invariant: the exact pane is revalidated after identity preparation
+// and immediately before the launch bytes are sent.
 //
 // The fix introduces spawnIdentityCoordinator: identities are prepared and
 // published per-pane immediately before the launch keystrokes, and the three
@@ -60,7 +62,7 @@ func spawnFuncDecl(t *testing.T, funcName string) (*token.FileSet, *ast.FuncDecl
 func TestSpawnPublishesIdentityBeforeLaunch(t *testing.T) {
 	fset, fn := spawnFuncDecl(t, "spawnSessionLogicContextWithOutput")
 
-	var firstSendKeys, prepareCall token.Pos
+	var firstSendKeys, prepareCall, launchPreflightCall token.Pos
 	registerCalls := 0
 	ast.Inspect(fn, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
@@ -79,6 +81,9 @@ func TestSpawnPublishesIdentityBeforeLaunch(t *testing.T) {
 			if fun.Name == "registerSpawnedAgents" {
 				registerCalls++
 			}
+			if fun.Name == "validateCurrentSpawnPaneBaseline" {
+				launchPreflightCall = call.Pos()
+			}
 		}
 		return true
 	})
@@ -92,9 +97,17 @@ func TestSpawnPublishesIdentityBeforeLaunch(t *testing.T) {
 	if firstSendKeys == token.NoPos {
 		t.Fatal("spawnSessionLogicContextWithOutput must call tmux.SendKeysContext")
 	}
+	if launchPreflightCall == token.NoPos {
+		t.Fatal("spawnSessionLogicContextWithOutput must revalidate the exact pane before launch")
+	}
 	if fset.Position(prepareCall).Offset >= fset.Position(firstSendKeys).Offset {
 		t.Errorf("prepareAgent (%v) must precede the first tmux.SendKeysContext (%v): agents may not launch before their pane identity is published",
 			fset.Position(prepareCall), fset.Position(firstSendKeys))
+	}
+	if fset.Position(prepareCall).Offset >= fset.Position(launchPreflightCall).Offset ||
+		fset.Position(launchPreflightCall).Offset >= fset.Position(firstSendKeys).Offset {
+		t.Errorf("launch preflight (%v) must run after identity preparation (%v) and immediately before send-keys (%v)",
+			fset.Position(launchPreflightCall), fset.Position(prepareCall), fset.Position(firstSendKeys))
 	}
 }
 

--- a/internal/cli/spawn_test.go
+++ b/internal/cli/spawn_test.go
@@ -651,44 +651,94 @@ func TestValidateSpawnPaneCapacity(t *testing.T) {
 	}
 }
 
-func TestValidateSpawnGrokPaneBaselinesPreflightsCompleteAssignment(t *testing.T) {
+func TestValidateSpawnPaneBaselinesPreflightsCompleteAssignment(t *testing.T) {
 	agents := []FlatAgent{
 		{Type: AgentTypeClaude, Index: 1},
-		{Type: AgentTypeGrok, Index: 1},
+		{Type: AgentTypeCodex, Index: 1},
 	}
 
-	t.Run("late occupied Grok target rejects mixed batch", func(t *testing.T) {
+	t.Run("late occupied target rejects mixed batch", func(t *testing.T) {
 		panes := []tmux.Pane{
 			{ID: "%idle", Index: 0, Command: "zsh"},
-			{ID: "%occupied", Index: 1, Command: "sleep"},
+			{ID: "%occupied", Index: 1, Command: "claude"},
 		}
-		err := validateSpawnGrokPaneBaselines(panes, 0, agents)
+		err := validateSpawnPaneBaselines(panes, 0, agents)
 		if err == nil {
-			t.Fatal("validateSpawnGrokPaneBaselines() error = nil")
+			t.Fatal("validateSpawnPaneBaselines() error = nil")
 		}
-		for _, want := range []string{"Grok Build agent 1", "%occupied", "sleep", "non-shell"} {
+		for _, want := range []string{"cod agent 1", "%occupied", "claude", "non-shell"} {
 			if !strings.Contains(err.Error(), want) {
-				t.Fatalf("validateSpawnGrokPaneBaselines() error = %q, want %q", err, want)
+				t.Fatalf("validateSpawnPaneBaselines() error = %q, want %q", err, want)
 			}
 		}
 	})
 
-	t.Run("user pane offset reaches assigned Grok shell", func(t *testing.T) {
+	t.Run("user pane offset reaches assigned agent shells", func(t *testing.T) {
 		panes := []tmux.Pane{
 			{ID: "%user", Index: 0, Command: "zsh"},
 			{ID: "%claude", Index: 1, Command: "bash"},
-			{ID: "%grok", Index: 2, Command: "fish"},
+			{ID: "%codex", Index: 2, Command: "fish"},
 		}
-		if err := validateSpawnGrokPaneBaselines(panes, 1, agents); err != nil {
-			t.Fatalf("validateSpawnGrokPaneBaselines() error = %v", err)
+		if err := validateSpawnPaneBaselines(panes, 1, agents); err != nil {
+			t.Fatalf("validateSpawnPaneBaselines() error = %v", err)
 		}
 	})
 
-	t.Run("missing assigned Grok pane fails closed", func(t *testing.T) {
+	t.Run("missing assigned pane fails closed", func(t *testing.T) {
 		panes := []tmux.Pane{{ID: "%claude", Index: 0, Command: "zsh"}}
-		err := validateSpawnGrokPaneBaselines(panes, 0, agents)
-		if err == nil || !strings.Contains(err.Error(), "no assigned pane for Grok Build agent 1 at offset 1") {
-			t.Fatalf("validateSpawnGrokPaneBaselines() error = %v", err)
+		err := validateSpawnPaneBaselines(panes, 0, agents)
+		if err == nil || !strings.Contains(err.Error(), "no assigned pane for cod agent 1 at offset 1") {
+			t.Fatalf("validateSpawnPaneBaselines() error = %v", err)
+		}
+	})
+}
+
+func TestValidateCurrentSpawnPaneBaselineRefusesInsteadOfRetargeting(t *testing.T) {
+	ctx := t.Context()
+	t.Run("occupied interactive CLI", func(t *testing.T) {
+		list := func(context.Context, string) ([]tmux.Pane, error) {
+			return []tmux.Pane{
+				{ID: "%other", Command: "zsh"},
+				{ID: "%target", Command: "claude"},
+			}, nil
+		}
+		err := validateCurrentSpawnPaneBaseline(ctx, "project", "%target", list)
+		if err == nil {
+			t.Fatal("validateCurrentSpawnPaneBaseline() error = nil")
+		}
+		for _, want := range []string{"%target", "claude", "non-shell", "idle shell"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("validateCurrentSpawnPaneBaseline() error = %q, want %q", err, want)
+			}
+		}
+	})
+
+	t.Run("exact target remains an idle shell", func(t *testing.T) {
+		list := func(context.Context, string) ([]tmux.Pane, error) {
+			return []tmux.Pane{{ID: "%target", Command: "/bin/zsh"}}, nil
+		}
+		if err := validateCurrentSpawnPaneBaseline(ctx, "project", "%target", list); err != nil {
+			t.Fatalf("validateCurrentSpawnPaneBaseline() error = %v", err)
+		}
+	})
+
+	t.Run("missing target is not replaced with another pane", func(t *testing.T) {
+		list := func(context.Context, string) ([]tmux.Pane, error) {
+			return []tmux.Pane{{ID: "%other", Command: "zsh"}}, nil
+		}
+		err := validateCurrentSpawnPaneBaseline(ctx, "project", "%target", list)
+		if err == nil || !strings.Contains(err.Error(), "pane %target disappeared") {
+			t.Fatalf("validateCurrentSpawnPaneBaseline() error = %v", err)
+		}
+	})
+
+	t.Run("unreadable topology fails closed", func(t *testing.T) {
+		list := func(context.Context, string) ([]tmux.Pane, error) {
+			return nil, errors.New("tmux unavailable")
+		}
+		err := validateCurrentSpawnPaneBaseline(ctx, "project", "%target", list)
+		if err == nil || !strings.Contains(err.Error(), "tmux unavailable") {
+			t.Fatalf("validateCurrentSpawnPaneBaseline() error = %v", err)
 		}
 	})
 }

--- a/internal/robot/spawn.go
+++ b/internal/robot/spawn.go
@@ -249,41 +249,37 @@ func validateSpawnRequest(opts SpawnOptions) (string, error) {
 	return strategy, nil
 }
 
-func validateGrokSpawnPaneBaselines(panes []tmux.Pane, opts SpawnOptions) error {
-	if opts.GrokCount <= 0 {
-		return nil
-	}
-	start := opts.CCCount + opts.CodCount + opts.GmiCount + opts.AgyCount
+func validateSpawnPaneBaselines(panes []tmux.Pane, opts SpawnOptions) error {
+	start := 0
 	if !opts.NoUserPane {
 		start++
 	}
-	for i := 0; i < opts.GrokCount; i++ {
+	total := opts.CCCount + opts.CodCount + opts.GmiCount + opts.AgyCount + opts.GrokCount
+	for i := 0; i < total; i++ {
 		paneIndex := start + i
 		if paneIndex >= len(panes) {
-			return fmt.Errorf("requested Grok Build pane %d is unavailable", i+1)
+			return fmt.Errorf("requested agent pane %d is unavailable", i+1)
 		}
 		if err := tmux.ValidatePaneLaunchBaseline(panes[paneIndex]); err != nil {
-			return fmt.Errorf("validate Grok Build agent %d: %w", i+1, err)
+			return fmt.Errorf("validate agent pane %d: %w", i+1, err)
 		}
 	}
 	return nil
 }
 
-func validateExistingGrokSpawnPaneBaselines(panes []tmux.Pane, opts SpawnOptions) error {
-	if opts.GrokCount <= 0 {
-		return nil
-	}
-	start := opts.CCCount + opts.CodCount + opts.GmiCount + opts.AgyCount
+func validateExistingSpawnPaneBaselines(panes []tmux.Pane, opts SpawnOptions) error {
+	start := 0
 	if !opts.NoUserPane {
 		start++
 	}
-	for i := 0; i < opts.GrokCount; i++ {
+	total := opts.CCCount + opts.CodCount + opts.GmiCount + opts.AgyCount + opts.GrokCount
+	for i := 0; i < total; i++ {
 		paneIndex := start + i
 		if paneIndex >= len(panes) {
 			break
 		}
 		if err := tmux.ValidatePaneLaunchBaseline(panes[paneIndex]); err != nil {
-			return fmt.Errorf("validate Grok Build agent %d: %w", i+1, err)
+			return fmt.Errorf("validate agent pane %d: %w", i+1, err)
 		}
 	}
 	return nil
@@ -871,12 +867,12 @@ func GetSpawn(ctx context.Context, opts SpawnOptions, cfg *config.Config) (*Spaw
 		}
 		return output, nil
 	}
-	if err := validateExistingGrokSpawnPaneBaselines(panes, opts); err != nil {
-		output.Error = fmt.Sprintf("validating existing Grok Build launch panes: %v", err)
+	if err := validateExistingSpawnPaneBaselines(panes, opts); err != nil {
+		output.Error = fmt.Sprintf("validating existing agent launch panes: %v", err)
 		output.RobotResponse = NewErrorResponse(
 			err,
 			ErrCodeInternalError,
-			"Use an idle shell pane before launching Grok Build",
+			"Use idle shell panes before launching agents",
 		)
 		return output, nil
 	}
@@ -926,12 +922,12 @@ func GetSpawn(ctx context.Context, opts SpawnOptions, cfg *config.Config) (*Spaw
 		)
 		return output, nil
 	}
-	if err := validateGrokSpawnPaneBaselines(panes, opts); err != nil {
-		output.Error = fmt.Sprintf("validating Grok Build launch panes: %v", err)
+	if err := validateSpawnPaneBaselines(panes, opts); err != nil {
+		output.Error = fmt.Sprintf("validating agent launch panes: %v", err)
 		output.RobotResponse = NewErrorResponse(
 			err,
 			ErrCodeInternalError,
-			"Use an idle shell pane before launching Grok Build",
+			"Use idle shell panes before launching agents",
 		)
 		return output, nil
 	}
@@ -1236,12 +1232,10 @@ func launchAgent(ctx context.Context, pane tmux.Pane, session, agentType string,
 		agent.Error = fmt.Sprintf("launch canceled: %v", err)
 		return agent, fmt.Errorf("launch canceled: %w", err)
 	}
-	if agentTypeShort(agentType) == "grok" {
-		if err := tmux.ValidatePaneLaunchBaseline(pane); err != nil {
-			agent.Error = fmt.Sprintf("launching: %v", err)
-			agent.StartupMs = time.Since(startTime).Milliseconds()
-			return agent, fmt.Errorf("launching Grok Build: %w", err)
-		}
+	if err := tmux.ValidatePaneLaunchBaseline(pane); err != nil {
+		agent.Error = fmt.Sprintf("launching: %v", err)
+		agent.StartupMs = time.Since(startTime).Milliseconds()
+		return agent, fmt.Errorf("launching %s: %w", agentType, err)
 	}
 
 	// Persist the type before launch so wrappers and self-managed TUI titles

--- a/internal/robot/spawn_test.go
+++ b/internal/robot/spawn_test.go
@@ -251,21 +251,58 @@ func TestGetSpawnGrokUsesConfiguredDefaultModelWithFakeLifecycle(t *testing.T) {
 	}
 }
 
-func TestLaunchAgentGrokRejectsBusyPaneBeforeMutation(t *testing.T) {
-	agent, err := launchAgent(
-		t.Context(),
-		tmux.Pane{ID: "%9", WindowIndex: 0, Index: 2, Command: "claude"},
-		"busy-session",
-		"grok",
-		1,
-		t.TempDir(),
-		"grok --always-approve",
-	)
-	if err == nil || !strings.Contains(err.Error(), "pre-launch current command") {
-		t.Fatalf("launchAgent error=%v, want pre-launch baseline rejection", err)
+func TestLaunchAgentRejectsBusyPaneBeforeMutationForEveryAgentType(t *testing.T) {
+	for _, agentType := range []string{"claude", "codex", "gemini", "antigravity", "grok"} {
+		t.Run(agentType, func(t *testing.T) {
+			agent, err := launchAgent(
+				t.Context(),
+				tmux.Pane{ID: "%9", WindowIndex: 0, Index: 2, Command: "claude"},
+				"busy-session",
+				agentType,
+				1,
+				t.TempDir(),
+				"agent-command",
+			)
+			if err == nil || !strings.Contains(err.Error(), "pre-launch current command") {
+				t.Fatalf("launchAgent error=%v, want pre-launch baseline rejection", err)
+			}
+			if !strings.Contains(agent.Error, "pre-launch current command") {
+				t.Fatalf("spawned agent error=%q, want baseline rejection", agent.Error)
+			}
+		})
 	}
-	if !strings.Contains(agent.Error, "pre-launch current command") {
-		t.Fatalf("spawned agent error=%q, want baseline rejection", agent.Error)
+}
+
+func TestGetSpawnClaudeRejectsBusyExistingPaneBeforeTopologyOrLaunch(t *testing.T) {
+	panes := []tmux.Pane{{ID: "%1", WindowIndex: 0, Index: 0, Command: "claude"}}
+	deps := testSpawnLifecycleDependencies(panes)
+	splitCalls := 0
+	layoutCalls := 0
+	launchCalls := 0
+	deps.SplitWindow = func(context.Context, string, string) (string, error) {
+		splitCalls++
+		return "%new", nil
+	}
+	deps.ApplyTiledLayout = func(context.Context, string) error {
+		layoutCalls++
+		return nil
+	}
+	deps.LaunchAgent = func(context.Context, tmux.Pane, string, string, int, string, string) (SpawnedAgent, error) {
+		launchCalls++
+		return SpawnedAgent{}, nil
+	}
+
+	out, err := GetSpawn(t.Context(), SpawnOptions{
+		Session: "claude-busy", CCCount: 2, NoUserPane: true, WorkingDir: t.TempDir(), LifecycleDeps: deps,
+	}, testSpawnConfig())
+	if err != nil {
+		t.Fatalf("GetSpawn returned transport error: %v", err)
+	}
+	if out.Success || !strings.Contains(out.Error, "pre-launch current command") {
+		t.Fatalf("GetSpawn output=%+v, want occupied-pane rejection", out)
+	}
+	if splitCalls != 0 || layoutCalls != 0 || launchCalls != 0 {
+		t.Fatalf("occupied Claude lifecycle calls: split=%d layout=%d launch=%d, want zero", splitCalls, layoutCalls, launchCalls)
 	}
 }
 


### PR DESCRIPTION
## Problem

`ntm spawn` reused an existing session pane without verifying that the pane still ran a shell. `tmux send-keys` then succeeded even when an interactive agent CLI was listening, submitting the raw launch command as a prompt.

Reproduction on v1.31.0:

1. Start an exact disposable pane with `tmux new-session -d -s wsnk-repro cat`.
2. Run `ntm spawn wsnk-repro --cc=1 --no-user --no-hooks --no-cass-context --no-recovery --privacy` against that existing session.
3. The command returns success, `pane_current_command` remains `cat`, and capture-pane contains the full Claude launch line (twice) rather than a launched process.

The captured line included `--dangerously-skip-permissions`; it was harmless only because `cat` received it as input.

## Fix

- Preflight every assigned pane for every agent family before launching any member of the batch.
- Re-read the exact physical CLI pane after slow preparation and immediately before `send-keys`.
- Refuse on an occupied, missing, or unreadable target. Never retarget.
- Apply the same all-agent baseline rule to robot spawn and its launch helper.

With this branch, the same live probe returns rc=1 naming pane `%1088` and current command `cat`; the pane capture remains empty.

## Tests

- `go test -short ./internal/cli ./internal/robot ./internal/tmux -count=1` — PASS.
- `go vet ./...` — PASS.
- `go test -short ./...` — all packages pass except two `internal/bv` tests already failing unchanged on pristine base 75a6f92c: `TestGetReadySnapshotContextUsesOneDirectReadyResult` and `TestGetBlockedSnapshotContextRetainsRestrictiveEvidence` (their fake br scripts do not accept the new `--lock-timeout 5000` argv).

Workshop tracking: agent-factory-wsnk.