### PR TITLE
fix(assign): skip packet tracking beads

### DIFF
--- a/internal/bv/bead_status_test.go
+++ b/internal/bv/bead_status_test.go
@@ -285,6 +285,7 @@ func TestOperatorGatedLabelsCanonicalVocabulary(t *testing.T) {
 		"needs-operator",
 		"operator-action",
 		"operator-gated",
+		"packet-tracked",
 	}
 	got := OperatorGatedLabels()
 	if !reflect.DeepEqual(got, want) {

--- a/internal/bv/bead_status_test.go
+++ b/internal/bv/bead_status_test.go
@@ -416,6 +416,28 @@ func TestValidateBeadAssignmentAuthorizationAllowsExplicitStaleOwnershipState(t 
 	}
 }
 
+func TestValidateBeadAssignmentAuthorizationRejectsPacketTrackedBead(t *testing.T) {
+	t.Parallel()
+
+	details := &BeadAssignmentDetails{
+		ID:     "agent-factory-packet",
+		Status: "open",
+		Labels: []string{"packet-tracked"},
+	}
+	err := ValidateBeadAssignmentAuthorizationWithOperatorGatedLabels(
+		details,
+		BeadAssignmentAuthorization{BeadID: details.ID},
+		nil,
+	)
+	var eligibilityErr *AssignmentEligibilityError
+	if !errors.Is(err, ErrBeadAssignmentIneligible) || !errors.As(err, &eligibilityErr) {
+		t.Fatalf("authorization error=%v, want typed assignment-ineligible error", err)
+	}
+	if !reflect.DeepEqual(eligibilityErr.OperatorLabels, []string{"packet-tracked"}) {
+		t.Fatalf("operator labels=%v, want [packet-tracked]", eligibilityErr.OperatorLabels)
+	}
+}
+
 func TestClaimBeadForAssignmentTransactionRejectsDirectStartBlockers(t *testing.T) {
 	requireRealBR(t)
 

--- a/internal/bv/bv.go
+++ b/internal/bv/bv.go
@@ -994,6 +994,7 @@ var defaultOperatorGatedLabels = []string{
 	"human-input",
 	"business-input",
 	"blocked-on-operator",
+	"packet-tracked",
 }
 
 var (

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -159,6 +159,28 @@ func TestBlockedBeadsReasonString(t *testing.T) {
 	}
 }
 
+func TestPacketTrackedBeadIsExcludedFromDirectAssignment(t *testing.T) {
+	t.Parallel()
+
+	recommendation := bv.TriageRecommendation{
+		ID:     "agent-factory-packet",
+		Title:  "Mission packet tracking bead",
+		Status: "open",
+		Labels: []string{"packet-tracked"},
+	}
+	skipped := classifyTriageRecForAssignmentWithGate(
+		recommendation,
+		nil,
+		func(label string) bool { return bv.IsOperatorGatedLabelInPolicy(label, nil) },
+	)
+	if skipped == nil {
+		t.Fatal("packet-tracked bead remained eligible for direct assignment")
+	}
+	if skipped.Reason != "operator_gated" {
+		t.Fatalf("packet-tracked skip reason=%q, want operator_gated", skipped.Reason)
+	}
+}
+
 // TestAssignOutputEnhancedStructure tests the output structure is correct for JSON
 func TestAssignOutputEnhancedStructure(t *testing.T) {
 	output := AssignOutputEnhanced{
@@ -1982,6 +2004,11 @@ func TestWatchLoopShouldStopUsesFilteredActionableCandidates(t *testing.T) {
 		{
 			name:     "operator-gated-only queue is drained",
 			recs:     []bv.TriageRecommendation{{ID: "gated", Status: "open", Labels: []string{"operator-gated"}}},
+			wantStop: true,
+		},
+		{
+			name:     "packet-tracked-only queue is drained",
+			recs:     []bv.TriageRecommendation{{ID: "packet", Status: "open", Labels: []string{"packet-tracked"}}},
 			wantStop: true,
 		},
 		{

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -159,7 +159,7 @@ func TestBlockedBeadsReasonString(t *testing.T) {
 	}
 }
 
-func TestPacketTrackedBeadIsExcludedFromDirectAssignment(t *testing.T) {
+func TestPacketTrackedBeadNeverEntersAssignmentPlanAcrossRepeatedScans(t *testing.T) {
 	t.Parallel()
 
 	recommendation := bv.TriageRecommendation{
@@ -168,16 +168,18 @@ func TestPacketTrackedBeadIsExcludedFromDirectAssignment(t *testing.T) {
 		Status: "open",
 		Labels: []string{"packet-tracked"},
 	}
-	skipped := classifyTriageRecForAssignmentWithGate(
-		recommendation,
-		nil,
-		func(label string) bool { return bv.IsOperatorGatedLabelInPolicy(label, nil) },
-	)
-	if skipped == nil {
-		t.Fatal("packet-tracked bead remained eligible for direct assignment")
-	}
-	if skipped.Reason != "operator_gated" {
-		t.Fatalf("packet-tracked skip reason=%q, want operator_gated", skipped.Reason)
+	for scan := 1; scan <= 3; scan++ {
+		ready, skipped := partitionActionableRecommendationsForAssignment(
+			[]bv.TriageRecommendation{recommendation},
+			nil,
+			func(label string) bool { return bv.IsOperatorGatedLabelInPolicy(label, nil) },
+		)
+		if len(ready) != 0 {
+			t.Fatalf("scan %d offered packet-tracked bead for assignment: %+v", scan, ready)
+		}
+		if len(skipped) != 1 || skipped[0].BeadID != recommendation.ID || skipped[0].Reason != "operator_gated" {
+			t.Fatalf("scan %d skipped=%+v, want one operator_gated packet", scan, skipped)
+		}
 	}
 }
 


### PR DESCRIPTION
# Proposed upstream pull request

Repository: `Dicklesworthstone/ntm`

Title: `fix(assign): skip packet tracking beads`

## Summary

- Add `packet-tracked` to ntm's built-in operator-gated label vocabulary.
- Exclude a packet-tracked bead from direct assignment, auto-assignment,
  coordinator scans, and `assign --watch` through the shared assignment gate.
- Preserve the final guarded claim as a second fail-closed check if a stale
  recommendation reaches execution.

## Problem

Mission packet `agent-factory-el73` was filed as a tracking bead even though a
mission packet is worked as a whole in its own window. The assignment rail saw
an open, unblocked bead and offered it to an iris worker. A comment convention
cannot stop that recurrence because ntm plans from authoritative Beads fields.

George's 2026-09-02 ruling removes tracking beads from the mission-packet v2
contract. `packet-tracked` remains a defense for an already-created bead or any
other non-rail work represented in the Beads store.

## Implementation

ntm already has one canonical operator-gate vocabulary and routes assignment
planning, watch completion, newly unblocked work, and the final transactional
claim through it. Adding `packet-tracked` there gives every rail path the same
answer without a packet-specific branch in the coordinator.

The regressions prove that:

- three consecutive scans produce no ready candidate for an open
  `packet-tracked` bead;
- watch mode treats a queue containing only that bead as drained;
- the final authorization gate returns the typed assignment-ineligible error;
- the built-in label cannot be removed by project configuration.

## Verification

- `go test -short ./internal/bv ./internal/cli -count=1` with an isolated,
  empty user-persona config
- the Agent Factory carrier's mission-packet contract probe constructs a valid
  v2 packet, adds `references.bead`, and proves the live validator refuses it.

Upstream base: `29be5f2b542ce634c932c4b47d8b8a3c84f70c2a`

Patch head: `7af568ff8f57083a6ca1899a369ba657f439949b`
