### PR TITLE
fix: retry safe composer dispatch failures

### DIFF
--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -3066,16 +3066,26 @@ type cliAtomicPaneDispatchPort struct {
 	redactionConfig redaction.Config
 	observer        assignSessionObserver
 	bypassIdleGate  bool
+	listPanes       func(context.Context, string) ([]tmux.Pane, error)
+	deliverer       dispatchsvc.Deliverer
 }
 
 func (p *cliAtomicPaneDispatchPort) prepare(ctx context.Context, req assignment.DispatchRequest) (*dispatchsvc.Service, *dispatchsvc.Prepared, error) {
-	panes, err := tmux.GetPanesContext(ctx, p.session)
+	listPanes := p.listPanes
+	if listPanes == nil {
+		listPanes = tmux.GetPanesContext
+	}
+	panes, err := listPanes(ctx, p.session)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load dispatch topology: %w", err)
 	}
+	deliverer := p.deliverer
+	if deliverer == nil {
+		deliverer = dispatchsvc.TMUXDeliverer{}
+	}
 	service, err := dispatchsvc.NewService(dispatchsvc.Ports{
 		Redactor: shellFinalMessageRedactor(p.redactionConfig), Protocols: shellDispatchProtocolPlanner{},
-		Deliverer: dispatchsvc.TMUXDeliverer{},
+		Deliverer: deliverer,
 	})
 	if err != nil {
 		return nil, nil, err
@@ -3148,6 +3158,9 @@ func (p *cliAtomicPaneDispatchPort) Dispatch(ctx context.Context, req assignment
 	result, dispatchErr := service.Dispatch(ctx, prepared)
 	receipt := assignment.DispatchReceipt{Duration: time.Since(started)}
 	if dispatchErr != nil {
+		if dispatchsvc.IsGuaranteedNoDeliveryActuation(dispatchErr) {
+			return receipt, assignment.GuaranteeNoActuation(dispatchErr)
+		}
 		return receipt, dispatchErr
 	}
 	delivery, err := validateSinglePaneDispatchResult(result, req.Target)

--- a/internal/cli/assign_test.go
+++ b/internal/cli/assign_test.go
@@ -3256,6 +3256,48 @@ func TestCLIAtomicDispatchReobservesAndRejectsBusyPaneBeforeActuation(t *testing
 	}
 }
 
+func TestCLIAtomicPaneDispatchPortMakesPreActuationRefusalRetryable(t *testing.T) {
+	const session = "composer-retry"
+	panes := []tmux.Pane{{ID: "%41", WindowIndex: 0, Index: 1, Type: tmux.AgentCodex}}
+	tests := []struct {
+		name          string
+		deliveryError error
+		wantRetryable bool
+	}{
+		{
+			name:          "known pre-actuation refusal",
+			deliveryError: dispatchsvc.GuaranteeNoDeliveryActuation(errors.New("codex 0.152 composer not ready")),
+			wantRetryable: true,
+		},
+		{
+			name:          "unmarked delivery failure",
+			deliveryError: errors.New("connection lost with delivery outcome unknown"),
+			wantRetryable: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			port := &cliAtomicPaneDispatchPort{
+				session:         session,
+				redactionConfig: redaction.Config{Mode: redaction.ModeOff},
+				bypassIdleGate:  true,
+				listPanes: func(context.Context, string) ([]tmux.Pane, error) {
+					return panes, nil
+				},
+				deliverer: dispatchsvc.DelivererFunc(func(context.Context, dispatchsvc.Delivery) error {
+					return test.deliveryError
+				}),
+			}
+			_, err := port.Dispatch(t.Context(), assignment.DispatchRequest{
+				BeadID: "bd-composer-retry", Target: "%41", AgentType: "codex", Prompt: "work", IdempotencyKey: "composer-retry-key",
+			})
+			if got := assignment.IsGuaranteedNoActuation(err); got != test.wantRetryable {
+				t.Fatalf("assignment retry classification = %v for error %v, want %v", got, err, test.wantRetryable)
+			}
+		})
+	}
+}
+
 func TestCLIAtomicPreflightBlocksSensitiveReservationPathBeforeTopologyLookup(t *testing.T) {
 	port := &cliAtomicPaneDispatchPort{redactionConfig: redaction.DefaultConfig()}
 	_, err := port.Preflight(t.Context(), assignment.DispatchRequest{

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -342,6 +342,9 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 		if !coordinatorAssignmentIsRecoverable(recorded) {
 			continue
 		}
+		if !coordinatorDispatchRetryReady(recorded, time.Now()) {
+			continue
+		}
 		target := strings.TrimSpace(recorded.OccupancyKey)
 		if target == "" {
 			target = strings.TrimSpace(recorded.DispatchTarget)
@@ -364,6 +367,29 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 		results = append(results, c.recoverPendingAssignment(ctx, store, recorded, work))
 	}
 	return results
+}
+
+const (
+	coordinatorDispatchRetryInitial = 5 * time.Second
+	coordinatorDispatchRetryMaximum = time.Minute
+)
+
+// coordinatorDispatchRetryReady applies bounded exponential backoff to a
+// known pre-actuation dispatch failure. DispatchAttempts is incremented before
+// each transport call, and DispatchStartedAt is therefore the durable clock
+// anchor for recovery after a coordinator restart.
+func coordinatorDispatchRetryReady(recorded *assignmentstore.Assignment, now time.Time) bool {
+	if recorded == nil || recorded.LastDispatchError == "" || recorded.DispatchStartedAt == nil {
+		return true
+	}
+	delay := coordinatorDispatchRetryInitial
+	for attempt := 1; attempt < recorded.DispatchAttempts && delay < coordinatorDispatchRetryMaximum; attempt++ {
+		delay *= 2
+		if delay > coordinatorDispatchRetryMaximum {
+			delay = coordinatorDispatchRetryMaximum
+		}
+	}
+	return !now.Before(recorded.DispatchStartedAt.Add(delay))
 }
 
 func pendingRecoveryIdentityError(recorded *assignmentstore.Assignment, candidate *AgentState) error {

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -1259,6 +1259,89 @@ func TestAssignWorkKeepsUnknownDispatchFailClosed(t *testing.T) {
 	}
 }
 
+func TestCoordinatorDispatchRetryBackoff(t *testing.T) {
+	now := time.Now().UTC()
+	recorded := &assignmentstore.Assignment{
+		DispatchState: assignmentstore.DispatchPending, DispatchAttempts: 1,
+		DispatchStartedAt: &now, LastDispatchError: "codex 0.152 composer not ready",
+	}
+	if coordinatorDispatchRetryReady(recorded, now.Add(coordinatorDispatchRetryInitial-time.Millisecond)) {
+		t.Fatal("first retry became eligible before initial backoff")
+	}
+	if !coordinatorDispatchRetryReady(recorded, now.Add(coordinatorDispatchRetryInitial)) {
+		t.Fatal("first retry did not become eligible at initial backoff")
+	}
+
+	recorded.DispatchAttempts = 9
+	if coordinatorDispatchRetryReady(recorded, now.Add(coordinatorDispatchRetryMaximum-time.Millisecond)) {
+		t.Fatal("retry became eligible before capped backoff")
+	}
+	if !coordinatorDispatchRetryReady(recorded, now.Add(coordinatorDispatchRetryMaximum)) {
+		t.Fatal("retry did not become eligible at capped backoff")
+	}
+}
+
+func TestAssignWorkDefersThenRetriesKnownPreActuationFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const session = "coordinator-retry-backoff"
+	request := assignmentstore.AtomicRequest{
+		BeadID: "ntm-retry", BeadTitle: "Retry delivery", Target: "%94", OccupancyKey: "%94", Pane: 1,
+		AgentType: "cod", AgentName: "BlueLake", Actor: "BlueLake", Prompt: "retry me",
+		IdempotencyKey: "coordinator-retry-key",
+	}
+	store := assignmentstore.NewStore(session)
+	actor := assignmentstore.StableClaimActor(request.Actor, request.IdempotencyKey)
+	if _, err := store.RecordAtomicIntent(request, actor, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicIntent: %v", err)
+	}
+	if _, err := store.RecordAtomicClaim(request, assignmentstore.ClaimReceipt{
+		BeadID: request.BeadID, Actor: actor, Status: "in_progress", ClaimedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("RecordAtomicClaim: %v", err)
+	}
+	if err := store.RecordAtomicDispatchStarted(request.BeadID, request.IdempotencyKey, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicDispatchStarted: %v", err)
+	}
+	if err := store.RecordAtomicDispatchFailed(request.BeadID, request.IdempotencyKey, assignmentstore.GuaranteeNoActuation(errors.New("composer not ready"))); err != nil {
+		t.Fatalf("RecordAtomicDispatchFailed: %v", err)
+	}
+
+	c := New(session, t.TempDir(), &agentmail.Client{}, "CoordinatorAgent")
+	addEligibleCoordinatorAgent(c, request.Target, request.AgentName)
+	factoryCalls := 0
+	c.atomicCoordinatorFactory = func(store *assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
+		factoryCalls++
+		return assignmentstore.NewAtomicCoordinator(
+			store,
+			assignmentstore.ClaimFunc(func(context.Context, string, string) (assignmentstore.ClaimReceipt, error) {
+				t.Fatal("retry repeated a completed claim")
+				return assignmentstore.ClaimReceipt{}, nil
+			}),
+			nil,
+			assignmentstore.DispatchFunc(func(context.Context, assignmentstore.DispatchRequest) (assignmentstore.DispatchReceipt, error) {
+				return assignmentstore.DispatchReceipt{DeliveryID: "retry-delivered"}, nil
+			}),
+			nil,
+		)
+	}
+	results, err := c.AssignWork(t.Context())
+	if err != nil || len(results) != 0 || factoryCalls != 0 {
+		t.Fatalf("within backoff results=%+v error=%v factoryCalls=%d", results, err, factoryCalls)
+	}
+
+	recorded := store.Get(request.BeadID)
+	old := time.Now().UTC().Add(-coordinatorDispatchRetryInitial - time.Second)
+	recorded.DispatchStartedAt = &old
+	store.Assignments[request.BeadID] = recorded
+	if err := store.Save(); err != nil {
+		t.Fatalf("age retry barrier: %v", err)
+	}
+	results, err = c.AssignWork(t.Context())
+	if err != nil || len(results) != 1 || !results[0].Success || factoryCalls != 1 {
+		t.Fatalf("after backoff results=%+v error=%v factoryCalls=%d", results, err, factoryCalls)
+	}
+}
+
 func TestAssignWorkReleasesTerminalLeaseBeforePaneReuse(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	const session = "coordinator-terminal-lease-release"

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -46,6 +46,30 @@ type Error struct {
 	Err    error
 }
 
+type guaranteedNoDeliveryActuationError struct {
+	err error
+}
+
+func (e *guaranteedNoDeliveryActuationError) Error() string { return e.err.Error() }
+func (e *guaranteedNoDeliveryActuationError) Unwrap() error { return e.err }
+
+// GuaranteeNoDeliveryActuation marks a delivery failure that happened before
+// any byte of the requested message was typed into the target. Callers with a
+// durable idempotency barrier may safely retry only errors carrying this mark.
+func GuaranteeNoDeliveryActuation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &guaranteedNoDeliveryActuationError{err: err}
+}
+
+// IsGuaranteedNoDeliveryActuation reports whether retrying the requested
+// message cannot duplicate a prior delivery.
+func IsGuaranteedNoDeliveryActuation(err error) bool {
+	var target *guaranteedNoDeliveryActuationError
+	return errors.As(err, &target)
+}
+
 func (e *Error) Error() string {
 	if e == nil {
 		return "dispatch error"
@@ -348,13 +372,13 @@ func RefuseDeadAgentPane(pane tmux.Pane) error {
 
 func (TMUXDeliverer) Deliver(ctx context.Context, delivery Delivery) error {
 	if err := contextError(ctx); err != nil {
-		return err
+		return GuaranteeNoDeliveryActuation(err)
 	}
 	if err := validateTMUXDeliveryProtocol(delivery); err != nil {
-		return err
+		return GuaranteeNoDeliveryActuation(err)
 	}
 	if err := RefuseDeadAgentPane(delivery.Target.Pane); err != nil {
-		return err
+		return GuaranteeNoDeliveryActuation(err)
 	}
 	target := delivery.Target.Ref.ID
 	if target == "" {
@@ -367,10 +391,12 @@ func (TMUXDeliverer) Deliver(ctx context.Context, delivery Delivery) error {
 	// unknown agent types, so it can only refuse when the screen positively
 	// shows neither a composer nor working-state chrome.
 	if ready, reason := tmux.ComposerReadyForDelivery(ctx, target, delivery.Target.AgentType, delivery.Target.Pane.Width); !ready {
-		return fmt.Errorf("pane %s not ready for delivery: %s", target, reason)
+		return GuaranteeNoDeliveryActuation(fmt.Errorf("pane %s not ready for delivery: %s", target, reason))
 	}
 	if err := ClearComposerForDelivery(ctx, target, delivery); err != nil {
-		return err
+		// ClearComposer may press control keys, but it never types the requested
+		// message. Re-running the clear choreography cannot duplicate delivery.
+		return GuaranteeNoDeliveryActuation(err)
 	}
 	switch delivery.Protocol {
 	case ProtocolStageOnly:
@@ -383,7 +409,7 @@ func (TMUXDeliverer) Deliver(ctx context.Context, delivery Delivery) error {
 		}
 		return VerifyAgentSubmission(ctx, target, delivery.Message, delivery.Target.AgentType, delivery.Target.Pane.Width)
 	default:
-		return fmt.Errorf("unsupported delivery protocol %q", delivery.Protocol)
+		return GuaranteeNoDeliveryActuation(fmt.Errorf("unsupported delivery protocol %q", delivery.Protocol))
 	}
 }
 

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1151,7 +1151,28 @@ func TestTMUXDelivererRejectsInvalidOrUnrepresentableProtocols(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("Deliver() error = %v, want substring %q", err, tc.want)
 			}
+			if !IsGuaranteedNoDeliveryActuation(err) {
+				t.Fatalf("Deliver() error = %v, want guaranteed-no-delivery-actuation classification", err)
+			}
 		})
+	}
+}
+
+func TestDeliveryActuationClassificationSurvivesServiceWrapping(t *testing.T) {
+	service, err := NewService(Ports{
+		Redactor: AllowAllRedactor{},
+		Deliverer: DelivererFunc(func(context.Context, Delivery) error {
+			return GuaranteeNoDeliveryActuation(errors.New("codex 0.152 composer not ready"))
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = service.Execute(context.Background(), Request{
+		Session: "proj", Panes: []tmux.Pane{testPane("%1", 0, 0, tmux.AgentCodex, "")}, Message: "work", Submit: true,
+	})
+	if !IsGuaranteedNoDeliveryActuation(err) {
+		t.Fatalf("wrapped service error = %v, want guaranteed-no-delivery-actuation classification", err)
 	}
 }
 

--- a/internal/robot/bulk_assign.go
+++ b/internal/robot/bulk_assign.go
@@ -2547,6 +2547,9 @@ func (p *robotAtomicPaneDispatchPort) Dispatch(ctx context.Context, req assignme
 		receipt.DeliveryID = assignment.DispatchDeliveryID(delivery.Target.Ref.StableKey(), string(delivery.Protocol), req.IdempotencyKey)
 	}
 	if dispatchErr != nil {
+		if dispatchsvc.IsGuaranteedNoDeliveryActuation(dispatchErr) {
+			return receipt, assignment.GuaranteeNoActuation(dispatchErr)
+		}
 		return receipt, dispatchErr
 	}
 	if result.Delivered != 1 || len(result.Receipts) != 1 || result.Receipts[0].Status != dispatchsvc.ReceiptDelivered {

--- a/internal/robot/bulk_assign_test.go
+++ b/internal/robot/bulk_assign_test.go
@@ -1695,6 +1695,29 @@ func TestBulkAssignFailureClassReportsAmbiguousDispatchTruthfully(t *testing.T) 
 	}
 }
 
+func TestRobotAtomicPaneDispatchPortMakesPreActuationRefusalRetryable(t *testing.T) {
+	const session = "composer-retry"
+	panes := []tmux.Pane{{ID: "%41", WindowIndex: 0, Index: 1, Type: tmux.AgentCodex}}
+	port := newRobotAtomicPaneDispatchPort(
+		session,
+		func(context.Context, string) ([]tmux.Pane, error) { return panes, nil },
+		func(context.Context, string) (statuspkg.SessionObservation, error) {
+			return bulkSafeObservation(session, panes), nil
+		},
+		redaction.Config{Mode: redaction.ModeOff},
+		dispatchsvc.DelivererFunc(func(context.Context, dispatchsvc.Delivery) error {
+			return dispatchsvc.GuaranteeNoDeliveryActuation(errors.New("codex 0.152 composer not ready"))
+		}),
+		nil,
+	)
+	_, err := port.Dispatch(t.Context(), assignment.DispatchRequest{
+		BeadID: "bd-composer-retry", Target: "%41", AgentType: "codex", Prompt: "work", IdempotencyKey: "composer-retry-key",
+	})
+	if !assignment.IsGuaranteedNoActuation(err) {
+		t.Fatalf("dispatch error = %v, want assignment retry classification", err)
+	}
+}
+
 func TestBulkAssignClaimConflictNeverReservesOrDispatches(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	plan := allocateBulkAssignBeads(

--- a/internal/tmux/composer_versions_test.go
+++ b/internal/tmux/composer_versions_test.go
@@ -1,0 +1,43 @@
+package tmux
+
+import "testing"
+
+// Frames captured from the deployed composers on iris on 2026-09-02. These
+// are contract fixtures: coordinator delivery must recognize the exact Codex
+// 0.152.x and Claude Code 2.1.x footer/composer layouts.
+const (
+	codex0152IdleFrame = "• Working (1m 4s • esc to interrupt)\n\n\n› Ask Codex to do anything\n\n  gpt-5.6-sol high · /data/projects/agent-factory\n"
+	codex0152HeldFrame = "• Working (1m 4s • esc to interrupt)\n\n\n› BUILD DISPATCH agent-factory-qt1k\n\n  gpt-5.6-sol high · /data/projects/agent-factory\n"
+	claude21IdleFrame  = "────────────────────────────────────────\n❯\u00a0\n────────────────────────────────────────\n  ⏵⏵ bypass permissions on · shift+tab to cycle\n"
+	claude21HeldFrame  = "────────────────────────────────────────\n❯\u00a0BUILD DISPATCH agent-factory-qt1k\n────────────────────────────────────────\n  ⏵⏵ bypass permissions on · shift+tab to cycle\n"
+)
+
+func TestDeployedComposerFramesCodex0152AndClaude21(t *testing.T) {
+	tests := []struct {
+		name, frame, message string
+		agent                AgentType
+		holds                bool
+	}{
+		{"codex 0.152 idle", codex0152IdleFrame, "BUILD DISPATCH agent-factory-qt1k", AgentCodex, false},
+		{"codex 0.152 held", codex0152HeldFrame, "BUILD DISPATCH agent-factory-qt1k", AgentCodex, true},
+		{"claude 2.1 idle nonbreaking space", claude21IdleFrame, "BUILD DISPATCH agent-factory-qt1k", AgentClaude, false},
+		{"claude 2.1 held nonbreaking space", claude21HeldFrame, "BUILD DISPATCH agent-factory-qt1k", AgentClaude, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !composerVisibleForDelivery(test.frame, composerMarkersForAgent(test.agent)) {
+				t.Fatalf("deployed %s frame was not recognized as a composer", test.agent)
+			}
+			var holds bool
+			switch test.agent.Canonical() {
+			case AgentCodex:
+				holds = codexComposerHoldsPayload(test.frame, test.message)
+			case AgentClaude:
+				holds = claudeComposerHoldsPayload(test.frame, test.message)
+			}
+			if holds != test.holds {
+				t.Fatalf("payload detection = %v, want %v", holds, test.holds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- recognize deployed Codex 0.152.x and Claude Code 2.1.x composer frames with contract fixtures
- distinguish pre-message composer/readiness failures from genuinely ambiguous post-send failures
- return safe refusals to pending and retry them with bounded exponential backoff
- preserve the existing fail-closed, at-most-once behavior for true dispatch ambiguity

## Tests
- targeted tmux, dispatch, robot, and coordinator regression tests pass
- broad package run has two failures that reproduce unchanged at pinned upstream main: `TestGetSendIdempotency_PreflightFailureReleasesClaim` and live-spawn `TestSpawnOptions_MultipleAgentTypes`

Tracking: agent-factory-qt1k