### PR TITLE
fix(coordinator): reap stranded dispatch rows

### DIFF
--- a/internal/assignment/store.go
+++ b/internal/assignment/store.go
@@ -28,7 +28,7 @@ const (
 	// assignmentsDirName is the directory name for assignment storage
 	assignmentsDirName     = "assignments"
 	fileExtension          = ".json"
-	assignmentStoreVersion = 9
+	assignmentStoreVersion = 10
 
 	// assignmentStoreGenerationVersion is the first schema version whose
 	// snapshots carry a monotonic persistence generation. The generation makes
@@ -135,6 +135,20 @@ type Assignment struct {
 	CompletionLeaseExpiresAt *time.Time           `json:"completion_lease_expires_at,omitempty"`
 }
 
+// DispatchFailureBlock is a durable, bead-scoped circuit breaker for a
+// server-declared permanent dispatch failure. It deliberately lives outside
+// an assignment row: operators may clear/reap that row to release its claim,
+// but doing so must not reset the dispatch-attempt ceiling and immediately
+// place the same bead again under the same failure condition.
+type DispatchFailureBlock struct {
+	BeadID       string    `json:"bead_id"`
+	FailureClass string    `json:"failure_class"`
+	Reason       string    `json:"reason"`
+	Target       string    `json:"target,omitempty"`
+	Generation   uint64    `json:"generation"`
+	BlockedAt    time.Time `json:"blocked_at"`
+}
+
 // AssignmentUpdate describes mutable assignment metadata that can be updated
 // after the initial assignment record is created.
 type AssignmentUpdate struct {
@@ -199,12 +213,14 @@ func cloneAssignment(a *Assignment) *Assignment {
 
 // AssignmentStore manages bead-to-agent assignments for a session
 type AssignmentStore struct {
-	SessionName           string                 `json:"session_name"`
-	Assignments           map[string]*Assignment `json:"assignments"`                   // bead_id -> active or terminal assignment
-	ClearedGenerations    map[string]uint64      `json:"cleared_generations,omitempty"` // bead_id -> completed explicit clears
-	PersistenceGeneration uint64                 `json:"persistence_generation,omitempty"`
-	UpdatedAt             time.Time              `json:"updated_at"`
-	Version               int                    `json:"version"` // Schema version for migrations
+	SessionName                    string                          `json:"session_name"`
+	Assignments                    map[string]*Assignment          `json:"assignments"`                   // bead_id -> active or terminal assignment
+	ClearedGenerations             map[string]uint64               `json:"cleared_generations,omitempty"` // bead_id -> completed explicit clears
+	DispatchFailureBlocks          map[string]DispatchFailureBlock `json:"dispatch_failure_blocks,omitempty"`
+	DispatchFailureClearGeneration map[string]uint64               `json:"dispatch_failure_clear_generations,omitempty"`
+	PersistenceGeneration          uint64                          `json:"persistence_generation,omitempty"`
+	UpdatedAt                      time.Time                       `json:"updated_at"`
+	Version                        int                             `json:"version"` // Schema version for migrations
 
 	mutex                sync.RWMutex
 	path                 string                 // Path to persistence file
@@ -299,15 +315,17 @@ func newStore(sessionName string, createSessionDir bool) *AssignmentStore {
 	}
 
 	return &AssignmentStore{
-		SessionName:           sessionName,
-		Assignments:           make(map[string]*Assignment),
-		ClearedGenerations:    make(map[string]uint64),
-		PersistenceGeneration: 0,
-		UpdatedAt:             time.Now().UTC(),
-		Version:               assignmentStoreVersion,
-		path:                  filepath.Join(sessionDir, assignmentsDirName+fileExtension),
-		baseline:              make(map[string]*Assignment),
-		replace:               make(map[string]struct{}),
+		SessionName:                    sessionName,
+		Assignments:                    make(map[string]*Assignment),
+		ClearedGenerations:             make(map[string]uint64),
+		DispatchFailureBlocks:          make(map[string]DispatchFailureBlock),
+		DispatchFailureClearGeneration: make(map[string]uint64),
+		PersistenceGeneration:          0,
+		UpdatedAt:                      time.Now().UTC(),
+		Version:                        assignmentStoreVersion,
+		path:                           filepath.Join(sessionDir, assignmentsDirName+fileExtension),
+		baseline:                       make(map[string]*Assignment),
+		replace:                        make(map[string]struct{}),
 	}
 }
 
@@ -414,6 +432,8 @@ func (s *AssignmentStore) applySnapshotLocked(loaded *AssignmentStore) {
 	s.SessionName = loaded.SessionName
 	s.Assignments = cloneAssignmentMap(loaded.Assignments)
 	s.ClearedGenerations = cloneClearedGenerationMap(loaded.ClearedGenerations)
+	s.DispatchFailureBlocks = cloneDispatchFailureBlockMap(loaded.DispatchFailureBlocks)
+	s.DispatchFailureClearGeneration = cloneClearedGenerationMap(loaded.DispatchFailureClearGeneration)
 	s.PersistenceGeneration = loaded.PersistenceGeneration
 	s.UpdatedAt = loaded.UpdatedAt
 	s.Version = loaded.Version
@@ -425,6 +445,12 @@ func (s *AssignmentStore) applySnapshotLocked(loaded *AssignmentStore) {
 	}
 	if s.ClearedGenerations == nil {
 		s.ClearedGenerations = make(map[string]uint64)
+	}
+	if s.DispatchFailureBlocks == nil {
+		s.DispatchFailureBlocks = make(map[string]DispatchFailureBlock)
+	}
+	if s.DispatchFailureClearGeneration == nil {
+		s.DispatchFailureClearGeneration = make(map[string]uint64)
 	}
 	for _, assignment := range s.Assignments {
 		normalizeFailureReason(assignment)
@@ -460,10 +486,14 @@ func (s *AssignmentStore) saveLocked() error {
 	}
 	latest := latestSnapshot.Assignments
 	latestClearedGenerations := latestSnapshot.ClearedGenerations
+	latestDispatchFailureBlocks := latestSnapshot.DispatchFailureBlocks
+	latestDispatchFailureClearGeneration := latestSnapshot.DispatchFailureClearGeneration
 	merged, mergeErr := mergeAssignmentDeltas(latest, s.baseline, s.Assignments, s.replace)
 	if mergeErr != nil {
 		s.Assignments = cloneAssignmentMap(latest)
 		s.ClearedGenerations = cloneClearedGenerationMap(latestClearedGenerations)
+		s.DispatchFailureBlocks = cloneDispatchFailureBlockMap(latestDispatchFailureBlocks)
+		s.DispatchFailureClearGeneration = cloneClearedGenerationMap(latestDispatchFailureClearGeneration)
 		s.PersistenceGeneration = latestSnapshot.PersistenceGeneration
 		s.UpdatedAt = latestSnapshot.UpdatedAt
 		s.Version = latestSnapshot.Version
@@ -472,6 +502,8 @@ func (s *AssignmentStore) saveLocked() error {
 		return &PersistenceError{Operation: "merge before save", Path: s.path, Cause: mergeErr}
 	}
 	mergedClearedGenerations := mergeClearedGenerations(latestClearedGenerations, s.ClearedGenerations)
+	mergedDispatchFailureBlocks := mergeDispatchFailureBlocks(latestDispatchFailureBlocks, s.DispatchFailureBlocks)
+	mergedDispatchFailureClearGeneration := mergeClearedGenerations(latestDispatchFailureClearGeneration, s.DispatchFailureClearGeneration)
 	if latestSnapshot.PersistenceGeneration == ^uint64(0) {
 		return &PersistenceError{Operation: "save", Path: s.path, Cause: errors.New("persistence generation exhausted")}
 	}
@@ -480,12 +512,14 @@ func (s *AssignmentStore) saveLocked() error {
 	updatedAt := time.Now().UTC()
 
 	snapshot := &AssignmentStore{
-		SessionName:           s.SessionName,
-		Assignments:           merged,
-		ClearedGenerations:    mergedClearedGenerations,
-		PersistenceGeneration: nextGeneration,
-		UpdatedAt:             updatedAt,
-		Version:               assignmentStoreVersion,
+		SessionName:                    s.SessionName,
+		Assignments:                    merged,
+		ClearedGenerations:             mergedClearedGenerations,
+		DispatchFailureBlocks:          mergedDispatchFailureBlocks,
+		DispatchFailureClearGeneration: mergedDispatchFailureClearGeneration,
+		PersistenceGeneration:          nextGeneration,
+		UpdatedAt:                      updatedAt,
+		Version:                        assignmentStoreVersion,
 	}
 	data, err := json.MarshalIndent(snapshot, "", "  ")
 	if err != nil {
@@ -568,6 +602,8 @@ func (s *AssignmentStore) saveLocked() error {
 	}
 	s.Assignments = merged
 	s.ClearedGenerations = mergedClearedGenerations
+	s.DispatchFailureBlocks = mergedDispatchFailureBlocks
+	s.DispatchFailureClearGeneration = mergedDispatchFailureClearGeneration
 	s.baseline = cloneAssignmentMap(merged)
 	s.replace = make(map[string]struct{})
 	s.PersistenceGeneration = nextGeneration
@@ -591,6 +627,26 @@ func cloneClearedGenerationMap(input map[string]uint64) map[string]uint64 {
 		cloned[beadID] = generation
 	}
 	return cloned
+}
+
+func cloneDispatchFailureBlockMap(input map[string]DispatchFailureBlock) map[string]DispatchFailureBlock {
+	cloned := make(map[string]DispatchFailureBlock, len(input))
+	for beadID, block := range input {
+		cloned[beadID] = block
+	}
+	return cloned
+}
+
+func mergeDispatchFailureBlocks(latest, current map[string]DispatchFailureBlock) map[string]DispatchFailureBlock {
+	merged := cloneDispatchFailureBlockMap(latest)
+	for beadID, block := range current {
+		prior, exists := merged[beadID]
+		if !exists || block.Generation > prior.Generation ||
+			(block.Generation == prior.Generation && block.BlockedAt.After(prior.BlockedAt)) {
+			merged[beadID] = block
+		}
+	}
+	return merged
 }
 
 func mergeClearedGenerations(latest, current map[string]uint64) map[string]uint64 {
@@ -625,10 +681,12 @@ func readAssignmentStateForMerge(path, expectedSession string) (*AssignmentStore
 	}
 	if selection == nil {
 		return &AssignmentStore{
-			SessionName:        expectedSession,
-			Assignments:        make(map[string]*Assignment),
-			ClearedGenerations: make(map[string]uint64),
-			Version:            assignmentStoreVersion,
+			SessionName:                    expectedSession,
+			Assignments:                    make(map[string]*Assignment),
+			ClearedGenerations:             make(map[string]uint64),
+			DispatchFailureBlocks:          make(map[string]DispatchFailureBlock),
+			DispatchFailureClearGeneration: make(map[string]uint64),
+			Version:                        assignmentStoreVersion,
 		}, nil
 	}
 	if selection.promoteBackup {
@@ -759,6 +817,20 @@ func decodeAssignmentSnapshot(data []byte, expectedSession string) (*AssignmentS
 	}
 	if loaded.ClearedGenerations == nil {
 		loaded.ClearedGenerations = make(map[string]uint64)
+	}
+	if loaded.DispatchFailureBlocks == nil {
+		loaded.DispatchFailureBlocks = make(map[string]DispatchFailureBlock)
+	}
+	if loaded.DispatchFailureClearGeneration == nil {
+		loaded.DispatchFailureClearGeneration = make(map[string]uint64)
+	}
+	for beadID, block := range loaded.DispatchFailureBlocks {
+		if strings.TrimSpace(beadID) == "" || strings.TrimSpace(block.BeadID) != beadID {
+			return nil, fmt.Errorf("dispatch failure block %q has mismatched bead ID %q", beadID, block.BeadID)
+		}
+		if strings.TrimSpace(block.FailureClass) == "" || block.Generation == 0 || block.BlockedAt.IsZero() {
+			return nil, fmt.Errorf("dispatch failure block %q is incomplete", beadID)
+		}
 	}
 	for beadID, assignment := range loaded.Assignments {
 		if err := validateCompletionOutboxAssignment(assignment); err != nil {
@@ -1212,17 +1284,27 @@ func (s *AssignmentStore) BeginClearForceIfStatus(ctx context.Context, beadID st
 // does not create a completion outbox entry because most reconciliation callers
 // have no event consumer that can acknowledge one.
 func (s *AssignmentStore) BeginTerminalReconciliationIfCurrent(ctx context.Context, observed *Assignment, terminalStatus AssignmentStatus, reason string) (*Assignment, bool, error) {
-	return s.beginTerminalReconciliationIfCurrent(ctx, observed, terminalStatus, reason, false)
+	return s.beginTerminalReconciliationIfCurrent(ctx, observed, terminalStatus, reason, false, nil)
+}
+
+// BeginDispatchBlockedTerminalReconciliationIfCurrent atomically installs a
+// durable bead/failure-class circuit breaker with the terminal-reconciliation
+// barrier. Clearing the assignment row later does not clear this block.
+func (s *AssignmentStore) BeginDispatchBlockedTerminalReconciliationIfCurrent(ctx context.Context, observed *Assignment, reason string, block DispatchFailureBlock) (*Assignment, bool, error) {
+	if strings.TrimSpace(block.FailureClass) == "" {
+		return nil, false, errors.New("dispatch failure class is required")
+	}
+	return s.beginTerminalReconciliationIfCurrent(ctx, observed, StatusFailed, reason, false, &block)
 }
 
 // BeginTerminalReconciliationWithCompletionEventIfCurrent establishes the same
 // exact-generation barrier and also creates a durable completion outbox entry.
 // Only callers with an acknowledge-capable completion-event consumer may use it.
 func (s *AssignmentStore) BeginTerminalReconciliationWithCompletionEventIfCurrent(ctx context.Context, observed *Assignment, terminalStatus AssignmentStatus, reason string) (*Assignment, bool, error) {
-	return s.beginTerminalReconciliationIfCurrent(ctx, observed, terminalStatus, reason, true)
+	return s.beginTerminalReconciliationIfCurrent(ctx, observed, terminalStatus, reason, true, nil)
 }
 
-func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Context, observed *Assignment, terminalStatus AssignmentStatus, reason string, createCompletionEvent bool) (*Assignment, bool, error) {
+func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Context, observed *Assignment, terminalStatus AssignmentStatus, reason string, createCompletionEvent bool, dispatchBlock *DispatchFailureBlock) (*Assignment, bool, error) {
 	if observed == nil || strings.TrimSpace(observed.BeadID) == "" {
 		return nil, false, errors.New("observed assignment generation is required")
 	}
@@ -1249,6 +1331,31 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 	}
 	if current.DispatchState == DispatchSending {
 		return nil, false, fmt.Errorf("%w: cannot retire %s while dispatch outcome is unknown", ErrDispatchOutcomeUnknown, observed.BeadID)
+	}
+	installDispatchBlock := func() {
+		if dispatchBlock == nil {
+			return
+		}
+		if s.DispatchFailureBlocks == nil {
+			s.DispatchFailureBlocks = make(map[string]DispatchFailureBlock)
+		}
+		if s.DispatchFailureClearGeneration == nil {
+			s.DispatchFailureClearGeneration = make(map[string]uint64)
+		}
+		block := *dispatchBlock
+		block.BeadID = observed.BeadID
+		block.FailureClass = strings.TrimSpace(block.FailureClass)
+		if block.BlockedAt.IsZero() {
+			block.BlockedAt = time.Now().UTC()
+		} else {
+			block.BlockedAt = block.BlockedAt.UTC()
+		}
+		generation := s.DispatchFailureClearGeneration[observed.BeadID] + 1
+		if existing := s.DispatchFailureBlocks[observed.BeadID]; existing.Generation >= generation {
+			generation = existing.Generation
+		}
+		block.Generation = generation
+		s.DispatchFailureBlocks[observed.BeadID] = block
 	}
 	ensureCompletionEvent := func() (bool, error) {
 		if !createCompletionEvent || strings.TrimSpace(current.PendingCompletionEventID) != "" {
@@ -1277,6 +1384,12 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 	}
 	if current.ClearState != ClearStateNone {
 		if current.PendingTerminalStatus == terminalStatus && current.PendingTerminalReason == reason {
+			if dispatchBlock != nil {
+				installDispatchBlock()
+				if err := s.saveLocked(); err != nil {
+					return nil, false, err
+				}
+			}
 			if persisted, err := ensureCompletionEvent(); err != nil || !persisted {
 				return nil, false, err
 			}
@@ -1299,6 +1412,8 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 
 	startedAt := time.Now().UTC()
 	previous := cloneAssignment(current)
+	previousBlock, hadPreviousBlock := s.DispatchFailureBlocks[observed.BeadID]
+	installDispatchBlock()
 	current.ClearState = ClearStateReservationReleasing
 	current.ClearStartedAt = &startedAt
 	current.ClearError = ""
@@ -1323,10 +1438,62 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 			return nil, false, nil
 		}
 		s.Assignments[observed.BeadID] = previous
+		if hadPreviousBlock {
+			s.DispatchFailureBlocks[observed.BeadID] = previousBlock
+		} else {
+			delete(s.DispatchFailureBlocks, observed.BeadID)
+		}
 		delete(s.replace, observed.BeadID)
 		return nil, false, err
 	}
 	return cloneAssignment(current), true, nil
+}
+
+// ActiveDispatchFailureBlock returns the bead-scoped dispatch circuit breaker
+// when it has not been explicitly cleared by an operator.
+func (s *AssignmentStore) ActiveDispatchFailureBlock(beadID string) (DispatchFailureBlock, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	block, ok := s.DispatchFailureBlocks[strings.TrimSpace(beadID)]
+	if !ok || block.Generation <= s.DispatchFailureClearGeneration[strings.TrimSpace(beadID)] {
+		return DispatchFailureBlock{}, false
+	}
+	return block, true
+}
+
+// ClearDispatchFailureBlock is the explicit operator escape hatch. It records
+// a monotonic clear generation rather than deleting history, so concurrent
+// saves cannot resurrect or silently lose the clearance.
+func (s *AssignmentStore) ClearDispatchFailureBlock(ctx context.Context, beadID string) (bool, error) {
+	beadID = strings.TrimSpace(beadID)
+	if beadID == "" {
+		return false, errors.New("bead ID is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	operationUnlock, err := acquireAtomicBeadOperationLock(ctx, s.path, beadID)
+	if err != nil {
+		return false, fmt.Errorf("lock dispatch failure block %s: %w", beadID, err)
+	}
+	defer operationUnlock()
+	if err := s.LoadStrict(); err != nil {
+		return false, fmt.Errorf("refresh dispatch failure block %s: %w", beadID, err)
+	}
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	block, ok := s.DispatchFailureBlocks[beadID]
+	if !ok || block.Generation <= s.DispatchFailureClearGeneration[beadID] {
+		return false, nil
+	}
+	if s.DispatchFailureClearGeneration == nil {
+		s.DispatchFailureClearGeneration = make(map[string]uint64)
+	}
+	s.DispatchFailureClearGeneration[beadID] = block.Generation
+	if err := s.saveLocked(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *AssignmentStore) beginClear(ctx context.Context, beadID string, startedAt time.Time, forceOutcomeUnknown bool, expected []AssignmentStatus) (*Assignment, error) {

--- a/internal/assignment/store.go
+++ b/internal/assignment/store.go
@@ -135,7 +135,7 @@ type Assignment struct {
 	CompletionLeaseExpiresAt *time.Time           `json:"completion_lease_expires_at,omitempty"`
 }
 
-// DispatchFailureBlock is a durable, bead-scoped circuit breaker for a
+// DispatchFailureBlock is a durable bead/failure-class circuit breaker for a
 // server-declared permanent dispatch failure. It deliberately lives outside
 // an assignment row: operators may clear/reap that row to release its claim,
 // but doing so must not reset the dispatch-attempt ceiling and immediately
@@ -213,14 +213,14 @@ func cloneAssignment(a *Assignment) *Assignment {
 
 // AssignmentStore manages bead-to-agent assignments for a session
 type AssignmentStore struct {
-	SessionName                    string                          `json:"session_name"`
-	Assignments                    map[string]*Assignment          `json:"assignments"`                   // bead_id -> active or terminal assignment
-	ClearedGenerations             map[string]uint64               `json:"cleared_generations,omitempty"` // bead_id -> completed explicit clears
-	DispatchFailureBlocks          map[string]DispatchFailureBlock `json:"dispatch_failure_blocks,omitempty"`
-	DispatchFailureClearGeneration map[string]uint64               `json:"dispatch_failure_clear_generations,omitempty"`
-	PersistenceGeneration          uint64                          `json:"persistence_generation,omitempty"`
-	UpdatedAt                      time.Time                       `json:"updated_at"`
-	Version                        int                             `json:"version"` // Schema version for migrations
+	SessionName                    string                                     `json:"session_name"`
+	Assignments                    map[string]*Assignment                     `json:"assignments"`                   // bead_id -> active or terminal assignment
+	ClearedGenerations             map[string]uint64                          `json:"cleared_generations,omitempty"` // bead_id -> completed explicit clears
+	DispatchFailureBlocks          map[string]map[string]DispatchFailureBlock `json:"dispatch_failure_blocks,omitempty"`
+	DispatchFailureClearGeneration map[string]map[string]uint64               `json:"dispatch_failure_clear_generations,omitempty"`
+	PersistenceGeneration          uint64                                     `json:"persistence_generation,omitempty"`
+	UpdatedAt                      time.Time                                  `json:"updated_at"`
+	Version                        int                                        `json:"version"` // Schema version for migrations
 
 	mutex                sync.RWMutex
 	path                 string                 // Path to persistence file
@@ -318,8 +318,8 @@ func newStore(sessionName string, createSessionDir bool) *AssignmentStore {
 		SessionName:                    sessionName,
 		Assignments:                    make(map[string]*Assignment),
 		ClearedGenerations:             make(map[string]uint64),
-		DispatchFailureBlocks:          make(map[string]DispatchFailureBlock),
-		DispatchFailureClearGeneration: make(map[string]uint64),
+		DispatchFailureBlocks:          make(map[string]map[string]DispatchFailureBlock),
+		DispatchFailureClearGeneration: make(map[string]map[string]uint64),
 		PersistenceGeneration:          0,
 		UpdatedAt:                      time.Now().UTC(),
 		Version:                        assignmentStoreVersion,
@@ -433,7 +433,7 @@ func (s *AssignmentStore) applySnapshotLocked(loaded *AssignmentStore) {
 	s.Assignments = cloneAssignmentMap(loaded.Assignments)
 	s.ClearedGenerations = cloneClearedGenerationMap(loaded.ClearedGenerations)
 	s.DispatchFailureBlocks = cloneDispatchFailureBlockMap(loaded.DispatchFailureBlocks)
-	s.DispatchFailureClearGeneration = cloneClearedGenerationMap(loaded.DispatchFailureClearGeneration)
+	s.DispatchFailureClearGeneration = cloneDispatchFailureClearGenerationMap(loaded.DispatchFailureClearGeneration)
 	s.PersistenceGeneration = loaded.PersistenceGeneration
 	s.UpdatedAt = loaded.UpdatedAt
 	s.Version = loaded.Version
@@ -447,10 +447,10 @@ func (s *AssignmentStore) applySnapshotLocked(loaded *AssignmentStore) {
 		s.ClearedGenerations = make(map[string]uint64)
 	}
 	if s.DispatchFailureBlocks == nil {
-		s.DispatchFailureBlocks = make(map[string]DispatchFailureBlock)
+		s.DispatchFailureBlocks = make(map[string]map[string]DispatchFailureBlock)
 	}
 	if s.DispatchFailureClearGeneration == nil {
-		s.DispatchFailureClearGeneration = make(map[string]uint64)
+		s.DispatchFailureClearGeneration = make(map[string]map[string]uint64)
 	}
 	for _, assignment := range s.Assignments {
 		normalizeFailureReason(assignment)
@@ -493,7 +493,7 @@ func (s *AssignmentStore) saveLocked() error {
 		s.Assignments = cloneAssignmentMap(latest)
 		s.ClearedGenerations = cloneClearedGenerationMap(latestClearedGenerations)
 		s.DispatchFailureBlocks = cloneDispatchFailureBlockMap(latestDispatchFailureBlocks)
-		s.DispatchFailureClearGeneration = cloneClearedGenerationMap(latestDispatchFailureClearGeneration)
+		s.DispatchFailureClearGeneration = cloneDispatchFailureClearGenerationMap(latestDispatchFailureClearGeneration)
 		s.PersistenceGeneration = latestSnapshot.PersistenceGeneration
 		s.UpdatedAt = latestSnapshot.UpdatedAt
 		s.Version = latestSnapshot.Version
@@ -503,7 +503,7 @@ func (s *AssignmentStore) saveLocked() error {
 	}
 	mergedClearedGenerations := mergeClearedGenerations(latestClearedGenerations, s.ClearedGenerations)
 	mergedDispatchFailureBlocks := mergeDispatchFailureBlocks(latestDispatchFailureBlocks, s.DispatchFailureBlocks)
-	mergedDispatchFailureClearGeneration := mergeClearedGenerations(latestDispatchFailureClearGeneration, s.DispatchFailureClearGeneration)
+	mergedDispatchFailureClearGeneration := mergeDispatchFailureClearGenerations(latestDispatchFailureClearGeneration, s.DispatchFailureClearGeneration)
 	if latestSnapshot.PersistenceGeneration == ^uint64(0) {
 		return &PersistenceError{Operation: "save", Path: s.path, Cause: errors.New("persistence generation exhausted")}
 	}
@@ -629,22 +629,49 @@ func cloneClearedGenerationMap(input map[string]uint64) map[string]uint64 {
 	return cloned
 }
 
-func cloneDispatchFailureBlockMap(input map[string]DispatchFailureBlock) map[string]DispatchFailureBlock {
-	cloned := make(map[string]DispatchFailureBlock, len(input))
-	for beadID, block := range input {
-		cloned[beadID] = block
+func cloneDispatchFailureBlockMap(input map[string]map[string]DispatchFailureBlock) map[string]map[string]DispatchFailureBlock {
+	cloned := make(map[string]map[string]DispatchFailureBlock, len(input))
+	for beadID, byClass := range input {
+		cloned[beadID] = make(map[string]DispatchFailureBlock, len(byClass))
+		for failureClass, block := range byClass {
+			cloned[beadID][failureClass] = block
+		}
 	}
 	return cloned
 }
 
-func mergeDispatchFailureBlocks(latest, current map[string]DispatchFailureBlock) map[string]DispatchFailureBlock {
+func cloneDispatchFailureClearGenerationMap(input map[string]map[string]uint64) map[string]map[string]uint64 {
+	cloned := make(map[string]map[string]uint64, len(input))
+	for beadID, byClass := range input {
+		cloned[beadID] = cloneClearedGenerationMap(byClass)
+	}
+	return cloned
+}
+
+func mergeDispatchFailureBlocks(latest, current map[string]map[string]DispatchFailureBlock) map[string]map[string]DispatchFailureBlock {
 	merged := cloneDispatchFailureBlockMap(latest)
-	for beadID, block := range current {
-		prior, exists := merged[beadID]
-		if !exists || block.Generation > prior.Generation ||
-			(block.Generation == prior.Generation && block.BlockedAt.After(prior.BlockedAt)) {
-			merged[beadID] = block
+	for beadID, byClass := range current {
+		if merged[beadID] == nil {
+			merged[beadID] = make(map[string]DispatchFailureBlock)
 		}
+		for failureClass, block := range byClass {
+			prior, exists := merged[beadID][failureClass]
+			if !exists || block.Generation > prior.Generation ||
+				(block.Generation == prior.Generation && block.BlockedAt.After(prior.BlockedAt)) {
+				merged[beadID][failureClass] = block
+			}
+		}
+	}
+	return merged
+}
+
+func mergeDispatchFailureClearGenerations(latest, current map[string]map[string]uint64) map[string]map[string]uint64 {
+	merged := cloneDispatchFailureClearGenerationMap(latest)
+	for beadID, byClass := range current {
+		if merged[beadID] == nil {
+			merged[beadID] = make(map[string]uint64)
+		}
+		merged[beadID] = mergeClearedGenerations(merged[beadID], byClass)
 	}
 	return merged
 }
@@ -684,8 +711,8 @@ func readAssignmentStateForMerge(path, expectedSession string) (*AssignmentStore
 			SessionName:                    expectedSession,
 			Assignments:                    make(map[string]*Assignment),
 			ClearedGenerations:             make(map[string]uint64),
-			DispatchFailureBlocks:          make(map[string]DispatchFailureBlock),
-			DispatchFailureClearGeneration: make(map[string]uint64),
+			DispatchFailureBlocks:          make(map[string]map[string]DispatchFailureBlock),
+			DispatchFailureClearGeneration: make(map[string]map[string]uint64),
 			Version:                        assignmentStoreVersion,
 		}, nil
 	}
@@ -819,17 +846,22 @@ func decodeAssignmentSnapshot(data []byte, expectedSession string) (*AssignmentS
 		loaded.ClearedGenerations = make(map[string]uint64)
 	}
 	if loaded.DispatchFailureBlocks == nil {
-		loaded.DispatchFailureBlocks = make(map[string]DispatchFailureBlock)
+		loaded.DispatchFailureBlocks = make(map[string]map[string]DispatchFailureBlock)
 	}
 	if loaded.DispatchFailureClearGeneration == nil {
-		loaded.DispatchFailureClearGeneration = make(map[string]uint64)
+		loaded.DispatchFailureClearGeneration = make(map[string]map[string]uint64)
 	}
-	for beadID, block := range loaded.DispatchFailureBlocks {
-		if strings.TrimSpace(beadID) == "" || strings.TrimSpace(block.BeadID) != beadID {
-			return nil, fmt.Errorf("dispatch failure block %q has mismatched bead ID %q", beadID, block.BeadID)
+	for beadID, byClass := range loaded.DispatchFailureBlocks {
+		if strings.TrimSpace(beadID) == "" || len(byClass) == 0 {
+			return nil, fmt.Errorf("dispatch failure blocks for bead %q are incomplete", beadID)
 		}
-		if strings.TrimSpace(block.FailureClass) == "" || block.Generation == 0 || block.BlockedAt.IsZero() {
-			return nil, fmt.Errorf("dispatch failure block %q is incomplete", beadID)
+		for failureClass, block := range byClass {
+			if strings.TrimSpace(block.BeadID) != beadID {
+				return nil, fmt.Errorf("dispatch failure block %q/%q has mismatched bead ID %q", beadID, failureClass, block.BeadID)
+			}
+			if strings.TrimSpace(failureClass) == "" || strings.TrimSpace(block.FailureClass) != failureClass || block.Generation == 0 || block.BlockedAt.IsZero() {
+				return nil, fmt.Errorf("dispatch failure block %q/%q is incomplete or mismatched", beadID, failureClass)
+			}
 		}
 	}
 	for beadID, assignment := range loaded.Assignments {
@@ -1337,25 +1369,31 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 			return
 		}
 		if s.DispatchFailureBlocks == nil {
-			s.DispatchFailureBlocks = make(map[string]DispatchFailureBlock)
+			s.DispatchFailureBlocks = make(map[string]map[string]DispatchFailureBlock)
 		}
 		if s.DispatchFailureClearGeneration == nil {
-			s.DispatchFailureClearGeneration = make(map[string]uint64)
+			s.DispatchFailureClearGeneration = make(map[string]map[string]uint64)
 		}
 		block := *dispatchBlock
 		block.BeadID = observed.BeadID
 		block.FailureClass = strings.TrimSpace(block.FailureClass)
+		if s.DispatchFailureBlocks[observed.BeadID] == nil {
+			s.DispatchFailureBlocks[observed.BeadID] = make(map[string]DispatchFailureBlock)
+		}
+		if s.DispatchFailureClearGeneration[observed.BeadID] == nil {
+			s.DispatchFailureClearGeneration[observed.BeadID] = make(map[string]uint64)
+		}
 		if block.BlockedAt.IsZero() {
 			block.BlockedAt = time.Now().UTC()
 		} else {
 			block.BlockedAt = block.BlockedAt.UTC()
 		}
-		generation := s.DispatchFailureClearGeneration[observed.BeadID] + 1
-		if existing := s.DispatchFailureBlocks[observed.BeadID]; existing.Generation >= generation {
+		generation := s.DispatchFailureClearGeneration[observed.BeadID][block.FailureClass] + 1
+		if existing := s.DispatchFailureBlocks[observed.BeadID][block.FailureClass]; existing.Generation >= generation {
 			generation = existing.Generation
 		}
 		block.Generation = generation
-		s.DispatchFailureBlocks[observed.BeadID] = block
+		s.DispatchFailureBlocks[observed.BeadID][block.FailureClass] = block
 	}
 	ensureCompletionEvent := func() (bool, error) {
 		if !createCompletionEvent || strings.TrimSpace(current.PendingCompletionEventID) != "" {
@@ -1412,7 +1450,13 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 
 	startedAt := time.Now().UTC()
 	previous := cloneAssignment(current)
-	previousBlock, hadPreviousBlock := s.DispatchFailureBlocks[observed.BeadID]
+	dispatchFailureClass := ""
+	previousBlock := DispatchFailureBlock{}
+	hadPreviousBlock := false
+	if dispatchBlock != nil {
+		dispatchFailureClass = strings.TrimSpace(dispatchBlock.FailureClass)
+		previousBlock, hadPreviousBlock = s.DispatchFailureBlocks[observed.BeadID][dispatchFailureClass]
+	}
 	installDispatchBlock()
 	current.ClearState = ClearStateReservationReleasing
 	current.ClearStartedAt = &startedAt
@@ -1438,10 +1482,15 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 			return nil, false, nil
 		}
 		s.Assignments[observed.BeadID] = previous
-		if hadPreviousBlock {
-			s.DispatchFailureBlocks[observed.BeadID] = previousBlock
-		} else {
-			delete(s.DispatchFailureBlocks, observed.BeadID)
+		if dispatchBlock != nil {
+			if hadPreviousBlock {
+				s.DispatchFailureBlocks[observed.BeadID][dispatchFailureClass] = previousBlock
+			} else {
+				delete(s.DispatchFailureBlocks[observed.BeadID], dispatchFailureClass)
+				if len(s.DispatchFailureBlocks[observed.BeadID]) == 0 {
+					delete(s.DispatchFailureBlocks, observed.BeadID)
+				}
+			}
 		}
 		delete(s.replace, observed.BeadID)
 		return nil, false, err
@@ -1449,13 +1498,37 @@ func (s *AssignmentStore) beginTerminalReconciliationIfCurrent(ctx context.Conte
 	return cloneAssignment(current), true, nil
 }
 
-// ActiveDispatchFailureBlock returns the bead-scoped dispatch circuit breaker
-// when it has not been explicitly cleared by an operator.
+// ActiveDispatchFailureBlock returns one active bead/failure-class circuit
+// breaker. A bead is blocked while any failure class remains active.
 func (s *AssignmentStore) ActiveDispatchFailureBlock(beadID string) (DispatchFailureBlock, bool) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	block, ok := s.DispatchFailureBlocks[strings.TrimSpace(beadID)]
-	if !ok || block.Generation <= s.DispatchFailureClearGeneration[strings.TrimSpace(beadID)] {
+	beadID = strings.TrimSpace(beadID)
+	var selected DispatchFailureBlock
+	found := false
+	for failureClass, block := range s.DispatchFailureBlocks[beadID] {
+		if block.Generation <= s.DispatchFailureClearGeneration[beadID][failureClass] {
+			continue
+		}
+		if !found || block.BlockedAt.After(selected.BlockedAt) ||
+			(block.BlockedAt.Equal(selected.BlockedAt) && block.FailureClass < selected.FailureClass) {
+			selected = block
+			found = true
+		}
+	}
+	return selected, found
+}
+
+// ActiveDispatchFailureBlockForClass checks the exact durable breaker
+// identity. The attempt ceiling is scoped to this tuple, never to an
+// assignment row or to the bead alone.
+func (s *AssignmentStore) ActiveDispatchFailureBlockForClass(beadID, failureClass string) (DispatchFailureBlock, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	beadID = strings.TrimSpace(beadID)
+	failureClass = strings.TrimSpace(failureClass)
+	block, ok := s.DispatchFailureBlocks[beadID][failureClass]
+	if !ok || block.Generation <= s.DispatchFailureClearGeneration[beadID][failureClass] {
 		return DispatchFailureBlock{}, false
 	}
 	return block, true
@@ -1482,14 +1555,23 @@ func (s *AssignmentStore) ClearDispatchFailureBlock(ctx context.Context, beadID 
 	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	block, ok := s.DispatchFailureBlocks[beadID]
-	if !ok || block.Generation <= s.DispatchFailureClearGeneration[beadID] {
+	if s.DispatchFailureClearGeneration == nil {
+		s.DispatchFailureClearGeneration = make(map[string]map[string]uint64)
+	}
+	if s.DispatchFailureClearGeneration[beadID] == nil {
+		s.DispatchFailureClearGeneration[beadID] = make(map[string]uint64)
+	}
+	cleared := false
+	for failureClass, block := range s.DispatchFailureBlocks[beadID] {
+		if block.Generation <= s.DispatchFailureClearGeneration[beadID][failureClass] {
+			continue
+		}
+		s.DispatchFailureClearGeneration[beadID][failureClass] = block.Generation
+		cleared = true
+	}
+	if !cleared {
 		return false, nil
 	}
-	if s.DispatchFailureClearGeneration == nil {
-		s.DispatchFailureClearGeneration = make(map[string]uint64)
-	}
-	s.DispatchFailureClearGeneration[beadID] = block.Generation
 	if err := s.saveLocked(); err != nil {
 		return false, err
 	}

--- a/internal/assignment/store_test.go
+++ b/internal/assignment/store_test.go
@@ -1731,6 +1731,60 @@ func TestRecordAtomicIntentCannotReplaceTerminalLeaseHandles(t *testing.T) {
 	}
 }
 
+func TestDispatchFailureBlocksPersistByBeadAndFailureClass(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const (
+		session = "dispatch-failure-class-identity"
+		beadID  = "ntm-permanent-failure"
+	)
+	now := time.Now().UTC()
+	store := NewStore(session)
+	store.DispatchFailureBlocks[beadID] = map[string]DispatchFailureBlock{
+		"SENDER_TOKEN_MISMATCH": {
+			BeadID: beadID, FailureClass: "SENDER_TOKEN_MISMATCH", Reason: "sender registration is stale",
+			Generation: 1, BlockedAt: now,
+		},
+		"ACCOUNT_DISABLED": {
+			BeadID: beadID, FailureClass: "ACCOUNT_DISABLED", Reason: "account is disabled",
+			Generation: 1, BlockedAt: now.Add(time.Second),
+		},
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("save class-scoped dispatch blocks: %v", err)
+	}
+
+	reloaded, err := LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict reload class-scoped dispatch blocks: %v", err)
+	}
+	for _, failureClass := range []string{"SENDER_TOKEN_MISMATCH", "ACCOUNT_DISABLED"} {
+		block, active := reloaded.ActiveDispatchFailureBlockForClass(beadID, failureClass)
+		if !active || block.BeadID != beadID || block.FailureClass != failureClass {
+			t.Fatalf("block for %s=%+v active=%v", failureClass, block, active)
+		}
+	}
+	if _, active := reloaded.ActiveDispatchFailureBlockForClass(beadID, "RATE_LIMITED"); active {
+		t.Fatal("class-scoped breaker matched an unrelated failure class")
+	}
+	if block, active := reloaded.ActiveDispatchFailureBlock(beadID); !active || block.FailureClass != "ACCOUNT_DISABLED" {
+		t.Fatalf("bead-level admission view=%+v active=%v, want newest active class", block, active)
+	}
+
+	cleared, err := reloaded.ClearDispatchFailureBlock(t.Context(), beadID)
+	if err != nil || !cleared {
+		t.Fatalf("clear all bead failure classes: cleared=%v error=%v", cleared, err)
+	}
+	final, err := LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict reload after class-scoped clear: %v", err)
+	}
+	for _, failureClass := range []string{"SENDER_TOKEN_MISMATCH", "ACCOUNT_DISABLED"} {
+		if _, active := final.ActiveDispatchFailureBlockForClass(beadID, failureClass); active {
+			t.Fatalf("explicit bead override left class %s active", failureClass)
+		}
+	}
+}
+
 func TestAssignmentClearBarrierRetainsLeaseAndBlocksNewWork(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	const session = "assignment-clear-barrier"

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -65,9 +65,10 @@ var (
 	assignPrompt     string // Custom prompt for direct assignment
 
 	// Clear assignment flags
-	assignClear       string // Clear specific bead assignments (comma-separated)
-	assignClearPane   string // Clear all assignments for one canonical pane selector
-	assignClearFailed bool   // Clear all failed assignments
+	assignClear                 string // Clear specific bead assignments (comma-separated)
+	assignClearPane             string // Clear all assignments for one canonical pane selector
+	assignClearFailed           bool   // Clear all failed assignments
+	assignOverrideDispatchBlock bool   // Explicitly clear a durable permanent-dispatch circuit breaker
 
 	// Watch mode flags for continuous auto-assignment
 	assignWatch         bool          // Enable watch mode for continuous auto-assignment on completion
@@ -408,6 +409,7 @@ Examples:
 	cmd.Flags().StringVar(&assignClear, "clear", "", "Clear specific bead assignments (comma-separated bead IDs)")
 	cmd.Flags().StringVar(&assignClearPane, "clear-pane", "", "Clear all assignments for one pane (N, W.P, or %N; use when agent crashed)")
 	cmd.Flags().BoolVar(&assignClearFailed, "clear-failed", false, "Clear all failed assignments")
+	cmd.Flags().BoolVar(&assignOverrideDispatchBlock, "override-dispatch-block", false, "With --clear and --force, explicitly clear the bead's permanent-dispatch circuit breaker")
 
 	// Watch mode flags
 	cmd.Flags().BoolVar(&assignWatch, "watch", false, "Enable watch mode for continuous auto-assignment on completion")
@@ -512,7 +514,7 @@ func isAutomatedAssignmentSafetyError(err error) bool {
 // every non-clear CLI assignment mode. Clear is intentionally independent of
 // config validity because it only removes durable assignment state.
 func prepareResolvedAssignCommand(cmd *cobra.Command, session, projectDir string) (handled bool, policyProject string, closeWebhook func() error, err error) {
-	if assignClear != "" || strings.TrimSpace(assignClearPane) != "" || assignClearFailed {
+	if assignClear != "" || strings.TrimSpace(assignClearPane) != "" || assignClearFailed || assignOverrideDispatchBlock {
 		return true, "", nil, runClearAssignmentsForCommand(cmd, session)
 	}
 
@@ -3244,6 +3246,7 @@ type ClearAssignmentResult struct {
 	PreviousStatus           string   `json:"previous_status,omitempty"`
 	AssignmentFound          bool     `json:"assignment_found"`
 	FileReservationsReleased bool     `json:"file_reservations_released"`
+	DispatchBlockCleared     bool     `json:"dispatch_block_cleared,omitempty"`
 	FilesReleased            []string `json:"files_released,omitempty"`
 	Success                  bool     `json:"success"`
 	Error                    string   `json:"error,omitempty"`
@@ -3867,6 +3870,13 @@ func runClearAssignments(cmd *cobra.Command, session string) error {
 		}
 		return err
 	}
+	if assignOverrideDispatchBlock && (strings.TrimSpace(assignClear) == "" || !assignForce) {
+		err := fmt.Errorf("--override-dispatch-block requires --clear and --force")
+		if IsJSONOutput() {
+			return emitJSONFailureEnvelope(makeClearErrorEnvelope("INVALID_ARGS", err.Error()))
+		}
+		return err
+	}
 
 	if assignClear != "" {
 		return runClearSpecificBeads(cmd, session, assignClear)
@@ -4073,8 +4083,21 @@ func runClearSelectedAssignmentsFromStore(cmd *cobra.Command, store *assignment.
 		}
 
 		if foundAssignment == nil {
-			result.Success = false
-			result.Error = "assignment not found or already completed"
+			if assignOverrideDispatchBlock {
+				cleared, clearErr := store.ClearDispatchFailureBlock(ctx, beadID)
+				if clearErr != nil {
+					result.Error = clearErr.Error()
+				} else if cleared {
+					result.DispatchBlockCleared = true
+					result.Success = true
+					successCount++
+				} else {
+					result.Error = "assignment and active dispatch failure block not found"
+				}
+			} else {
+				result.Success = false
+				result.Error = "assignment not found or already completed"
+			}
 		} else {
 			result.PreviousPane = foundAssignment.Pane
 			result.PreviousAgent = foundAssignment.AgentName
@@ -4111,6 +4134,18 @@ func runClearSelectedAssignmentsFromStore(cmd *cobra.Command, store *assignment.
 					}
 				}
 			} else {
+				if assignOverrideDispatchBlock {
+					result.DispatchBlockCleared, clearErr = store.ClearDispatchFailureBlock(ctx, beadID)
+					if clearErr != nil {
+						result.Success = false
+						result.Error = clearErr.Error()
+						if firstFailureErr == nil {
+							firstFailureErr = clearErr
+						}
+						results = append(results, result)
+						continue
+					}
+				}
 				result.FilesReleased = releasedFiles
 				result.FileReservationsReleased = len(releasedFiles) > 0
 				result.Success = true

--- a/internal/cli/assign_clear_test.go
+++ b/internal/cli/assign_clear_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -1194,5 +1196,24 @@ func TestRunClearForceReleasesUnknownDispatchOutcome(t *testing.T) {
 	}
 	if releaseCalls != 1 || store.Get(beadID) != nil {
 		t.Fatalf("force clear release calls=%d remaining=%+v", releaseCalls, store.Get(beadID))
+	}
+	reloaded, err := assignment.LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict load after force clear: %v", err)
+	}
+	if reloaded.Get(beadID) != nil {
+		t.Fatalf("force-cleared assignment remained after strict load: %+v", reloaded.Get(beadID))
+	}
+	ledgerPath := filepath.Join(assignment.StorageDir(), session, "assignments.json")
+	primary, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read force-clear primary: %v", err)
+	}
+	backup, err := os.ReadFile(ledgerPath + ".bak")
+	if err != nil {
+		t.Fatalf("read force-clear backup: %v", err)
+	}
+	if string(primary) != string(backup) {
+		t.Fatal("force clear left equal-generation primary and backup divergent")
 	}
 }

--- a/internal/cli/assign_clear_test.go
+++ b/internal/cli/assign_clear_test.go
@@ -62,12 +62,17 @@ func TestClearDispatchFailureBlockRequiresExplicitForcedOverride(t *testing.T) {
 		beadID  = "ntm-permanent-failure"
 	)
 	store := assignment.NewStore(session)
-	store.DispatchFailureBlocks[beadID] = assignment.DispatchFailureBlock{
-		BeadID: beadID, FailureClass: "SENDER_TOKEN_MISMATCH", Reason: "permanent rejection",
-		Generation: 1, BlockedAt: time.Now().UTC(),
+	store.DispatchFailureBlocks[beadID] = map[string]assignment.DispatchFailureBlock{
+		"SENDER_TOKEN_MISMATCH": {
+			BeadID: beadID, FailureClass: "SENDER_TOKEN_MISMATCH", Reason: "permanent rejection",
+			Generation: 1, BlockedAt: time.Now().UTC(),
+		},
 	}
 	if err := store.Save(); err != nil {
 		t.Fatalf("seed dispatch failure block: %v", err)
+	}
+	if _, blocked := store.ActiveDispatchFailureBlockForClass(beadID, "SENDER_TOKEN_MISMATCH"); !blocked {
+		t.Fatal("seeded bead/failure-class block is not active")
 	}
 
 	previousClear := assignClear
@@ -98,7 +103,7 @@ func TestClearDispatchFailureBlockRequiresExplicitForcedOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("strict load after dispatch block override: %v", err)
 	}
-	if _, blocked := reloaded.ActiveDispatchFailureBlock(beadID); blocked {
+	if _, blocked := reloaded.ActiveDispatchFailureBlockForClass(beadID, "SENDER_TOKEN_MISMATCH"); blocked {
 		t.Fatal("explicit forced override left dispatch failure block active")
 	}
 }

--- a/internal/cli/assign_clear_test.go
+++ b/internal/cli/assign_clear_test.go
@@ -55,6 +55,54 @@ func TestClearAssignmentResultStructure(t *testing.T) {
 	}
 }
 
+func TestClearDispatchFailureBlockRequiresExplicitForcedOverride(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const (
+		session = "clear-dispatch-block"
+		beadID  = "ntm-permanent-failure"
+	)
+	store := assignment.NewStore(session)
+	store.DispatchFailureBlocks[beadID] = assignment.DispatchFailureBlock{
+		BeadID: beadID, FailureClass: "SENDER_TOKEN_MISMATCH", Reason: "permanent rejection",
+		Generation: 1, BlockedAt: time.Now().UTC(),
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("seed dispatch failure block: %v", err)
+	}
+
+	previousClear := assignClear
+	previousClearPane := assignClearPane
+	previousClearFailed := assignClearFailed
+	previousForce := assignForce
+	previousOverride := assignOverrideDispatchBlock
+	t.Cleanup(func() {
+		assignClear = previousClear
+		assignClearPane = previousClearPane
+		assignClearFailed = previousClearFailed
+		assignForce = previousForce
+		assignOverrideDispatchBlock = previousOverride
+	})
+	assignClear = beadID
+	assignClearPane = ""
+	assignClearFailed = false
+	assignOverrideDispatchBlock = true
+	assignForce = false
+	if err := runClearAssignments(&cobra.Command{}, session); err == nil {
+		t.Fatal("dispatch block override without --force succeeded")
+	}
+	assignForce = true
+	if _, err := captureStdout(t, func() error { return runClearAssignments(&cobra.Command{}, session) }); err != nil {
+		t.Fatalf("explicit forced dispatch block override: %v", err)
+	}
+	reloaded, err := assignment.LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict load after dispatch block override: %v", err)
+	}
+	if _, blocked := reloaded.ActiveDispatchFailureBlock(beadID); blocked {
+		t.Fatal("explicit forced override left dispatch failure block active")
+	}
+}
+
 // TestClearAssignmentResultNotFound tests result when assignment not found
 func TestClearAssignmentResultNotFound(t *testing.T) {
 	result := ClearAssignmentResult{

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -152,6 +153,21 @@ func (c *SessionCoordinator) AssignWork(ctx context.Context) ([]AssignmentResult
 		return results, err
 	}
 	recommendations = filtered
+	blockedRecommendations := make([]bv.TriageRecommendation, 0, len(recommendations))
+	for _, recommendation := range recommendations {
+		block, blocked := store.ActiveDispatchFailureBlock(recommendation.ID)
+		if !blocked {
+			blockedRecommendations = append(blockedRecommendations, recommendation)
+			continue
+		}
+		results = append(results, AssignmentResult{
+			Assignment: &WorkAssignment{BeadID: recommendation.ID},
+			Error: fmt.Sprintf(
+				"assignment for bead %q is blocked after permanent dispatch failure class %s; correct the failure condition, then clear the circuit breaker with ntm assign %s --clear %s --force --override-dispatch-block",
+				recommendation.ID, block.FailureClass, c.session, recommendation.ID),
+		})
+	}
+	recommendations = blockedRecommendations
 	if len(recommendations) == 0 {
 		return results, nil
 	}
@@ -345,7 +361,7 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 		if target != "" && paneSnapshotUsable {
 			if _, present := physicalTargets[target]; !present {
 				reason := fmt.Sprintf("assignment dispatch target %q is absent from the current tmux pane snapshot", target)
-				results = append(results, failCoordinatorAssignment(ctx, store, recorded, work, reason))
+				results = append(results, c.failCoordinatorAssignment(ctx, store, recorded, work, reason, nil))
 				continue
 			}
 		}
@@ -361,7 +377,16 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 		}
 		if recorded.DispatchAttempts >= coordinatorDispatchAttemptLimit {
 			reason := fmt.Sprintf("assignment dispatch attempt limit reached for target %q (%d attempts)", target, recorded.DispatchAttempts)
-			results = append(results, failCoordinatorAssignment(ctx, store, recorded, work, reason))
+			var block *assignmentstore.DispatchFailureBlock
+			if failureClass, permanent := serverDeclaredPermanentDispatchFailure(recorded.LastDispatchError); permanent {
+				reason = fmt.Sprintf("%s after server-declared permanent failure class %s", reason, failureClass)
+				block = &assignmentstore.DispatchFailureBlock{
+					FailureClass: failureClass,
+					Reason:       reason,
+					Target:       target,
+				}
+			}
+			results = append(results, c.failCoordinatorAssignment(ctx, store, recorded, work, reason, block))
 			continue
 		}
 		candidate, eligible := eligibleTargets[target]
@@ -399,20 +424,51 @@ func (c *SessionCoordinator) physicalAssignmentTargets() (map[string]struct{}, b
 	return targets, c.assignmentPaneSnapshotUsable
 }
 
-func failCoordinatorAssignment(ctx context.Context, store *assignmentstore.AssignmentStore, recorded *assignmentstore.Assignment, work *WorkAssignment, reason string) AssignmentResult {
+func (c *SessionCoordinator) failCoordinatorAssignment(ctx context.Context, store *assignmentstore.AssignmentStore, recorded *assignmentstore.Assignment, work *WorkAssignment, reason string, block *assignmentstore.DispatchFailureBlock) AssignmentResult {
 	result := AssignmentResult{
 		Assignment: safeCoordinatorWorkProjection(work), ClaimActor: recorded.ClaimActor,
 		IdempotencyKey: recorded.IdempotencyKey, Error: reason,
 	}
-	applied, err := store.MarkFailedIfCurrent(ctx, recorded, reason)
+	// A missing physical pane resolves an otherwise ambiguous `sending`
+	// boundary: there is no surviving target on which work can still begin.
+	// Move it back to the durable pending side before claim reconciliation.
+	if recorded.DispatchState == assignmentstore.DispatchSending {
+		if err := store.RecordAtomicDispatchFailed(recorded.BeadID, recorded.IdempotencyKey, errors.New(reason)); err != nil {
+			result.Error = fmt.Sprintf("%s: resolve dead-target dispatch boundary: %v", reason, err)
+			return result
+		}
+		recorded = store.Get(recorded.BeadID)
+	}
+	completed, err := c.reconcileTerminalAssignmentWithDispatchBlock(ctx, store, recorded, assignmentstore.StatusFailed, reason, block)
 	if err != nil {
-		result.Error = fmt.Sprintf("%s: persist terminal assignment: %v", reason, err)
+		result.Error = fmt.Sprintf("%s: reconcile terminal assignment: %v", reason, err)
 		return result
 	}
-	if !applied {
+	if !completed {
 		result.Error = fmt.Sprintf("%s: assignment changed before terminalization", reason)
 	}
 	return result
+}
+
+func serverDeclaredPermanentDispatchFailure(raw string) (string, bool) {
+	start := strings.Index(raw, "{")
+	if start < 0 {
+		return "", false
+	}
+	var payload struct {
+		Error struct {
+			Type        string `json:"type"`
+			Recoverable *bool  `json:"recoverable"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(raw[start:]), &payload); err != nil || payload.Error.Recoverable == nil || *payload.Error.Recoverable {
+		return "", false
+	}
+	failureClass := strings.TrimSpace(payload.Error.Type)
+	if failureClass == "" {
+		failureClass = "SERVER_DECLARED_PERMANENT"
+	}
+	return failureClass, true
 }
 
 func pendingRecoveryIdentityError(recorded *assignmentstore.Assignment, candidate *AgentState) error {
@@ -545,6 +601,10 @@ func (c *SessionCoordinator) reconcileTerminalAssignments(ctx context.Context, s
 }
 
 func (c *SessionCoordinator) reconcileTerminalAssignment(ctx context.Context, store *assignmentstore.AssignmentStore, observed *assignmentstore.Assignment, terminalStatus assignmentstore.AssignmentStatus, terminalReason string) (bool, error) {
+	return c.reconcileTerminalAssignmentWithDispatchBlock(ctx, store, observed, terminalStatus, terminalReason, nil)
+}
+
+func (c *SessionCoordinator) reconcileTerminalAssignmentWithDispatchBlock(ctx context.Context, store *assignmentstore.AssignmentStore, observed *assignmentstore.Assignment, terminalStatus assignmentstore.AssignmentStatus, terminalReason string, dispatchBlock *assignmentstore.DispatchFailureBlock) (bool, error) {
 	cleanupUnlock, err := store.AcquireExternalCleanupLock(ctx, observed.BeadID)
 	if err != nil {
 		return false, fmt.Errorf("lock terminal assignment %s external cleanup: %w", observed.BeadID, err)
@@ -565,7 +625,13 @@ func (c *SessionCoordinator) reconcileTerminalAssignment(ctx context.Context, st
 		terminalReason = current.PendingTerminalReason
 	}
 
-	barrier, applied, err := store.BeginTerminalReconciliationIfCurrent(ctx, current, terminalStatus, terminalReason)
+	var barrier *assignmentstore.Assignment
+	var applied bool
+	if dispatchBlock != nil {
+		barrier, applied, err = store.BeginDispatchBlockedTerminalReconciliationIfCurrent(ctx, current, terminalReason, *dispatchBlock)
+	} else {
+		barrier, applied, err = store.BeginTerminalReconciliationIfCurrent(ctx, current, terminalStatus, terminalReason)
+	}
 	if err != nil {
 		return false, fmt.Errorf("begin terminal reconciliation for %s: %w", observed.BeadID, err)
 	}

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -86,6 +86,11 @@ type AssignmentResult struct {
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 }
 
+// coordinatorDispatchAttemptLimit bounds retries that are proven to have
+// stopped before transport actuation. Outcome-unknown sends are never retried;
+// they remain behind the ambiguity barrier unless their physical pane dies.
+const coordinatorDispatchAttemptLimit = 3
+
 // AssignWork assigns verified actionable work to idle agents.
 func (c *SessionCoordinator) AssignWork(ctx context.Context) ([]AssignmentResult, error) {
 	if !c.config.AutoAssign {
@@ -315,6 +320,7 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 			eligibleTargets[strings.TrimSpace(candidate.PaneID)] = candidate
 		}
 	}
+	liveTargets := c.liveAssignmentTargets()
 	active := store.ListActive()
 	sort.Slice(active, func(i, j int) bool {
 		if active[i] == nil {
@@ -332,6 +338,17 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 			continue
 		}
 		work := coordinatorWorkAssignmentFromRecord(recorded)
+		target := strings.TrimSpace(recorded.OccupancyKey)
+		if target == "" {
+			target = strings.TrimSpace(recorded.DispatchTarget)
+		}
+		if target != "" {
+			if _, live := liveTargets[target]; !live {
+				reason := fmt.Sprintf("assignment dispatch target %q no longer exists", target)
+				results = append(results, failCoordinatorAssignment(ctx, store, recorded, work, reason))
+				continue
+			}
+		}
 		if recorded.DispatchState == assignmentstore.DispatchSending {
 			results = append(results, AssignmentResult{
 				Assignment: work, ClaimActor: recorded.ClaimActor, IdempotencyKey: recorded.IdempotencyKey,
@@ -342,9 +359,10 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 		if !coordinatorAssignmentIsRecoverable(recorded) {
 			continue
 		}
-		target := strings.TrimSpace(recorded.OccupancyKey)
-		if target == "" {
-			target = strings.TrimSpace(recorded.DispatchTarget)
+		if recorded.DispatchAttempts >= coordinatorDispatchAttemptLimit {
+			reason := fmt.Sprintf("assignment dispatch attempt limit reached for target %q (%d attempts)", target, recorded.DispatchAttempts)
+			results = append(results, failCoordinatorAssignment(ctx, store, recorded, work, reason))
+			continue
 		}
 		candidate, eligible := eligibleTargets[target]
 		if !eligible {
@@ -364,6 +382,39 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 		results = append(results, c.recoverPendingAssignment(ctx, store, recorded, work))
 	}
 	return results
+}
+
+// liveAssignmentTargets snapshots every currently observed agent pane, not
+// only idle/eligible candidates. RunCycle refreshes this map from tmux before
+// assignment, so absence proves that a persisted physical pane no longer
+// exists while presence still distinguishes a busy pane from a dead one.
+func (c *SessionCoordinator) liveAssignmentTargets() map[string]struct{} {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	targets := make(map[string]struct{}, len(c.agents))
+	for paneID := range c.agents {
+		if target := strings.TrimSpace(paneID); target != "" {
+			targets[target] = struct{}{}
+		}
+	}
+	return targets
+}
+
+func failCoordinatorAssignment(ctx context.Context, store *assignmentstore.AssignmentStore, recorded *assignmentstore.Assignment, work *WorkAssignment, reason string) AssignmentResult {
+	result := AssignmentResult{
+		Assignment: safeCoordinatorWorkProjection(work), ClaimActor: recorded.ClaimActor,
+		IdempotencyKey: recorded.IdempotencyKey, Error: reason,
+	}
+	applied, err := store.MarkFailedIfCurrent(ctx, recorded, reason)
+	if err != nil {
+		result.Error = fmt.Sprintf("%s: persist terminal assignment: %v", reason, err)
+		return result
+	}
+	if !applied {
+		result.Error = fmt.Sprintf("%s: assignment changed before terminalization", reason)
+	}
+	return result
 }
 
 func pendingRecoveryIdentityError(recorded *assignmentstore.Assignment, candidate *AgentState) error {

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -320,7 +320,7 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 			eligibleTargets[strings.TrimSpace(candidate.PaneID)] = candidate
 		}
 	}
-	liveTargets := c.liveAssignmentTargets()
+	physicalTargets, paneSnapshotUsable := c.physicalAssignmentTargets()
 	active := store.ListActive()
 	sort.Slice(active, func(i, j int) bool {
 		if active[i] == nil {
@@ -342,9 +342,9 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 		if target == "" {
 			target = strings.TrimSpace(recorded.DispatchTarget)
 		}
-		if target != "" {
-			if _, live := liveTargets[target]; !live {
-				reason := fmt.Sprintf("assignment dispatch target %q no longer exists", target)
+		if target != "" && paneSnapshotUsable {
+			if _, present := physicalTargets[target]; !present {
+				reason := fmt.Sprintf("assignment dispatch target %q is absent from the current tmux pane snapshot", target)
 				results = append(results, failCoordinatorAssignment(ctx, store, recorded, work, reason))
 				continue
 			}
@@ -384,21 +384,19 @@ func (c *SessionCoordinator) recoverPendingAssignments(ctx context.Context, stor
 	return results
 }
 
-// liveAssignmentTargets snapshots every currently observed agent pane, not
-// only idle/eligible candidates. RunCycle refreshes this map from tmux before
-// assignment, so absence proves that a persisted physical pane no longer
-// exists while presence still distinguishes a busy pane from a dead one.
-func (c *SessionCoordinator) liveAssignmentTargets() map[string]struct{} {
+// physicalAssignmentTargets returns the complete pane topology observed by
+// the monitor, including user and unclassified panes omitted from c.agents.
+// The boolean is false when topology enumeration failed or no successful
+// observation has occurred; an unavailable snapshot can never prove death.
+func (c *SessionCoordinator) physicalAssignmentTargets() (map[string]struct{}, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	targets := make(map[string]struct{}, len(c.agents))
-	for paneID := range c.agents {
-		if target := strings.TrimSpace(paneID); target != "" {
-			targets[target] = struct{}{}
-		}
+	targets := make(map[string]struct{}, len(c.assignmentPaneIDs))
+	for paneID := range c.assignmentPaneIDs {
+		targets[paneID] = struct{}{}
 	}
-	return targets
+	return targets, c.assignmentPaneSnapshotUsable
 }
 
 func failCoordinatorAssignment(ctx context.Context, store *assignmentstore.AssignmentStore, recorded *assignmentstore.Assignment, work *WorkAssignment, reason string) AssignmentResult {

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -960,6 +960,8 @@ func addEligibleCoordinatorAgent(c *SessionCoordinator, paneID, agentName string
 		Status: robot.StateWaiting, Healthy: true, SafeToDispatch: true,
 		LastActivity: now.Add(-time.Minute), ObservedAt: now, ObservationFreshness: status.FreshnessFresh,
 	}
+	c.assignmentPaneIDs[paneID] = struct{}{}
+	c.assignmentPaneSnapshotUsable = true
 	c.workItemStatusFn = func(context.Context, string) (string, error) { return "in_progress", nil }
 	c.actionableRecommendationsFn = func(context.Context, string, int) ([]bv.TriageRecommendation, error) { return nil, nil }
 }
@@ -1262,6 +1264,85 @@ func TestAssignWorkKeepsUnknownDispatchFailClosed(t *testing.T) {
 	}
 }
 
+func TestAssignWorkKeepsUnknownDispatchFailClosedForLiveUnclassifiedPane(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const session = "coordinator-live-unclassified"
+	request := assignmentstore.AtomicRequest{
+		BeadID: "ntm-live-unclassified", BeadTitle: "Live unclassified", Target: "%92", OccupancyKey: "%92", Pane: 2,
+		AgentType: "cod", AgentName: "BlueLake", Actor: "BlueLake", Prompt: "ambiguous delivery",
+		IdempotencyKey: "coordinator-live-unclassified-key",
+	}
+	store := assignmentstore.NewStore(session)
+	actor := assignmentstore.StableClaimActor(request.Actor, request.IdempotencyKey)
+	if _, err := store.RecordAtomicIntent(request, actor, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicIntent: %v", err)
+	}
+	if _, err := store.RecordAtomicClaim(request, assignmentstore.ClaimReceipt{BeadID: request.BeadID, Actor: actor, Status: "in_progress", ClaimedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("RecordAtomicClaim: %v", err)
+	}
+	if err := store.RecordAtomicDispatchStarted(request.BeadID, request.IdempotencyKey, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicDispatchStarted: %v", err)
+	}
+
+	c := New(session, t.TempDir(), &agentmail.Client{}, "CoordinatorAgent")
+	addEligibleCoordinatorAgent(c, "%1001", "DifferentAgent")
+	// %92 exists in the physical tmux topology but is deliberately absent
+	// from c.agents, matching a live pane whose agent is momentarily unknown.
+	c.assignmentPaneIDs[request.Target] = struct{}{}
+	c.atomicCoordinatorFactory = func(*assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
+		t.Fatal("outcome-unknown dispatch must remain behind the ambiguity barrier")
+		return nil
+	}
+	results, err := c.AssignWork(t.Context())
+	if err != nil {
+		t.Fatalf("AssignWork: %v", err)
+	}
+	if len(results) != 1 || results[0].Success || !strings.Contains(results[0].Error, assignmentstore.ErrDispatchOutcomeUnknown.Error()) {
+		t.Fatalf("live unclassified results = %+v", results)
+	}
+	row := store.Get(request.BeadID)
+	if row == nil || row.Status == assignmentstore.StatusFailed || row.DispatchState != assignmentstore.DispatchSending {
+		t.Fatalf("live unclassified row was terminalized = %+v", row)
+	}
+}
+
+func TestAssignWorkDoesNotInferDeathFromUnavailablePaneSnapshot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const session = "coordinator-pane-snapshot-unavailable"
+	request := assignmentstore.AtomicRequest{
+		BeadID: "ntm-unavailable-topology", BeadTitle: "Unavailable topology", Target: "%93", OccupancyKey: "%93", Pane: 3,
+		AgentType: "cod", AgentName: "BlueLake", Actor: "BlueLake", Prompt: "ambiguous delivery",
+		IdempotencyKey: "coordinator-unavailable-topology-key",
+	}
+	store := assignmentstore.NewStore(session)
+	actor := assignmentstore.StableClaimActor(request.Actor, request.IdempotencyKey)
+	if _, err := store.RecordAtomicIntent(request, actor, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicIntent: %v", err)
+	}
+	if _, err := store.RecordAtomicClaim(request, assignmentstore.ClaimReceipt{BeadID: request.BeadID, Actor: actor, Status: "in_progress", ClaimedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("RecordAtomicClaim: %v", err)
+	}
+	if err := store.RecordAtomicDispatchStarted(request.BeadID, request.IdempotencyKey, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicDispatchStarted: %v", err)
+	}
+
+	c := New(session, t.TempDir(), &agentmail.Client{}, "CoordinatorAgent")
+	addEligibleCoordinatorAgent(c, "%1001", "DifferentAgent")
+	c.assignmentPaneIDs = map[string]struct{}{}
+	c.assignmentPaneSnapshotUsable = false
+	results, err := c.AssignWork(t.Context())
+	if err != nil {
+		t.Fatalf("AssignWork: %v", err)
+	}
+	if len(results) != 1 || !strings.Contains(results[0].Error, assignmentstore.ErrDispatchOutcomeUnknown.Error()) {
+		t.Fatalf("unavailable topology results = %+v", results)
+	}
+	row := store.Get(request.BeadID)
+	if row == nil || row.Status == assignmentstore.StatusFailed || row.DispatchState != assignmentstore.DispatchSending {
+		t.Fatalf("unavailable topology row was terminalized = %+v", row)
+	}
+}
+
 func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1297,7 +1378,7 @@ func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
 		}
 	}
 	stranded := byBead["agent-factory-6ndm"]
-	if stranded.Success || !strings.Contains(stranded.Error, `%993`) || !strings.Contains(stranded.Error, "no longer exists") {
+	if stranded.Success || !strings.Contains(stranded.Error, `%993`) || !strings.Contains(stranded.Error, "absent from the current tmux pane snapshot") {
 		t.Fatalf("stranded result=%+v", stranded)
 	}
 	ready := byBead["agent-factory-ready-b"]

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -1523,6 +1523,13 @@ func TestAssignWorkPermanentFailureBlockSurvivesRowClearAndStopsRedispatch(t *te
 	if !blocked || block.FailureClass != "SENDER_TOKEN_MISMATCH" {
 		t.Fatalf("durable dispatch block=%+v active=%v", block, blocked)
 	}
+	classBlock, classBlocked := loaded.ActiveDispatchFailureBlockForClass("agent-factory-9d6s", "SENDER_TOKEN_MISMATCH")
+	if !classBlocked || classBlock.BeadID != "agent-factory-9d6s" || classBlock.FailureClass != "SENDER_TOKEN_MISMATCH" {
+		t.Fatalf("durable bead/failure-class block=%+v active=%v", classBlock, classBlocked)
+	}
+	if _, wrongClassBlocked := loaded.ActiveDispatchFailureBlockForClass("agent-factory-9d6s", "RATE_LIMITED"); wrongClassBlocked {
+		t.Fatal("permanent failure block leaked across failure classes")
+	}
 	placed := loaded.Get("agent-factory-ready-b")
 	if placed == nil || placed.Status != assignmentstore.StatusAssigned || placed.DispatchReceiptID != "mail-ready-after-nonretryable" {
 		t.Fatalf("ready assignment=%+v", placed)
@@ -1544,7 +1551,7 @@ func TestAssignWorkPermanentFailureBlockSurvivesRowClearAndStopsRedispatch(t *te
 	if loaded.Get("agent-factory-9d6s") != nil {
 		t.Fatal("failed assignment row survived explicit clear")
 	}
-	if _, stillBlocked := loaded.ActiveDispatchFailureBlock("agent-factory-9d6s"); !stillBlocked {
+	if _, stillBlocked := loaded.ActiveDispatchFailureBlockForClass("agent-factory-9d6s", "SENDER_TOKEN_MISMATCH"); !stillBlocked {
 		t.Fatal("row clear erased permanent dispatch circuit breaker")
 	}
 
@@ -1569,7 +1576,7 @@ func TestAssignWorkPermanentFailureBlockSurvivesRowClearAndStopsRedispatch(t *te
 	if err != nil {
 		t.Fatalf("strict reload after row clear: %v", err)
 	}
-	if _, stillBlocked := reloaded.ActiveDispatchFailureBlock("agent-factory-9d6s"); !stillBlocked {
+	if _, stillBlocked := reloaded.ActiveDispatchFailureBlockForClass("agent-factory-9d6s", "SENDER_TOKEN_MISMATCH"); !stillBlocked {
 		t.Fatal("strict reload lost permanent dispatch circuit breaker")
 	}
 	ledgerPath := filepath.Join(home, ".ntm", "sessions", session, "assignments.json")
@@ -1592,7 +1599,7 @@ func TestAssignWorkPermanentFailureBlockSurvivesRowClearAndStopsRedispatch(t *te
 	if err != nil {
 		t.Fatalf("strict reload after circuit-breaker override: %v", err)
 	}
-	if _, blocked := final.ActiveDispatchFailureBlock("agent-factory-9d6s"); blocked {
+	if _, blocked := final.ActiveDispatchFailureBlockForClass("agent-factory-9d6s", "SENDER_TOKEN_MISMATCH"); blocked {
 		t.Fatal("explicit circuit-breaker override did not survive strict reload")
 	}
 }

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -1412,6 +1412,99 @@ func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
 	}
 }
 
+func TestAssignWorkNonRetryableLivePaneDoesNotBlockReadyBead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const session = "agent-factory"
+	writeNonRetryableLivePaneIncidentFixture(t, home, session)
+
+	c := New(session, t.TempDir(), &agentmail.Client{}, "CoordinatorAgent")
+	addEligibleCoordinatorAgent(c, "%893", "WildIvy")
+	addEligibleCoordinatorAgent(c, "%1001", "ReadyAgent")
+	c.actionableRecommendationsFn = func(context.Context, string, int) ([]bv.TriageRecommendation, error) {
+		return []bv.TriageRecommendation{{
+			ID: "agent-factory-ready-b", Title: "Ready bead B", Type: "bug", Status: "open", Priority: 1, Score: 1,
+		}}, nil
+	}
+	c.workItemStatusFn = func(_ context.Context, beadID string) (string, error) {
+		if beadID == "agent-factory-ready-b" {
+			return "open", nil
+		}
+		return "in_progress", nil
+	}
+	failedDispatches := 0
+	c.atomicCoordinatorFactory = func(store *assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
+		claim := assignmentstore.ClaimFunc(func(_ context.Context, beadID, actor string) (assignmentstore.ClaimReceipt, error) {
+			return assignmentstore.ClaimReceipt{BeadID: beadID, Actor: actor, Status: "in_progress", ClaimedAt: time.Now().UTC()}, nil
+		})
+		dispatch := assignmentstore.DispatchFunc(func(_ context.Context, request assignmentstore.DispatchRequest) (assignmentstore.DispatchReceipt, error) {
+			if request.BeadID == "agent-factory-9d6s" {
+				failedDispatches++
+				rejection := &agentmail.ToolRejectionError{Err: errors.New(`tool error: {"error":{"type":"SENDER_TOKEN_MISMATCH","message":"sender_token does not match the registered token for agent 'WhiteHorse'","recoverable":false}}`)}
+				return assignmentstore.DispatchReceipt{}, coordinatorMailDispatchError(rejection)
+			}
+			return assignmentstore.DispatchReceipt{DeliveryID: "mail-ready-after-nonretryable"}, nil
+		})
+		preflight := assignmentstore.PromptPreflightFunc(func(_ context.Context, request assignmentstore.DispatchRequest) (assignmentstore.PromptPreflightResult, error) {
+			return assignmentstore.PromptPreflightResult{DispatchPrompt: request.Prompt, DurablePrompt: request.Prompt}, nil
+		})
+		return assignmentstore.NewAtomicCoordinator(store, claim, nil, dispatch, preflight)
+	}
+
+	results, err := c.AssignWork(t.Context())
+	if err != nil {
+		t.Fatalf("AssignWork: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("assignment results=%+v, want failed A attempt plus placed B", results)
+	}
+	byBead := make(map[string]AssignmentResult, len(results))
+	for _, result := range results {
+		if result.Assignment != nil {
+			byBead[result.Assignment.BeadID] = result
+		}
+	}
+	stranded := byBead["agent-factory-9d6s"]
+	if stranded.Success || !strings.Contains(stranded.Error, "SENDER_TOKEN_MISMATCH") || strings.Contains(stranded.Error, "absent from") {
+		t.Fatalf("non-retryable live-pane result=%+v", stranded)
+	}
+	ready := byBead["agent-factory-ready-b"]
+	if !ready.Success || !ready.MessageSent {
+		t.Fatalf("ready bead B was not placed: %+v", ready)
+	}
+	if failedDispatches != 1 {
+		t.Fatalf("non-retryable dispatch attempts=%d, want 1", failedDispatches)
+	}
+
+	// The first cycle consumes the final known-no-actuation attempt while still
+	// placing B. The next cycle terminalizes A before a fourth dispatch.
+	results, err = c.AssignWork(t.Context())
+	if err != nil {
+		t.Fatalf("AssignWork after reaching ceiling: %v", err)
+	}
+	if len(results) != 1 || results[0].Assignment == nil || results[0].Assignment.BeadID != "agent-factory-9d6s" ||
+		!strings.Contains(results[0].Error, "attempt limit reached") {
+		t.Fatalf("post-ceiling results=%+v", results)
+	}
+	if failedDispatches != 1 {
+		t.Fatalf("non-retryable row dispatched past ceiling: attempts=%d", failedDispatches)
+	}
+
+	loaded, err := assignmentstore.LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict load after recovery: %v", err)
+	}
+	failed := loaded.Get("agent-factory-9d6s")
+	if failed == nil || failed.Status != assignmentstore.StatusFailed || failed.DispatchAttempts != coordinatorDispatchAttemptLimit ||
+		!strings.Contains(failed.FailReason, "attempt limit reached") {
+		t.Fatalf("non-retryable live-pane assignment=%+v", failed)
+	}
+	placed := loaded.Get("agent-factory-ready-b")
+	if placed == nil || placed.Status != assignmentstore.StatusAssigned || placed.DispatchReceiptID != "mail-ready-after-nonretryable" {
+		t.Fatalf("ready assignment=%+v", placed)
+	}
+}
+
 func TestAssignWorkBoundsKnownSafeDispatchRetries(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	const session = "coordinator-dispatch-attempt-limit"
@@ -1517,6 +1610,76 @@ func writeStrandedAssignmentIncidentFixture(t *testing.T, home, session string) 
 	for _, path := range []string{filepath.Join(dir, "assignments.json"), filepath.Join(dir, "assignments.json.bak")} {
 		if err := os.WriteFile(path, data, 0o600); err != nil {
 			t.Fatalf("write incident fixture %s: %v", path, err)
+		}
+	}
+}
+
+func writeNonRetryableLivePaneIncidentFixture(t *testing.T, home, session string) {
+	t.Helper()
+	// This is the second live incident recorded on agent-factory-m0ip. The
+	// attempt count starts one below the coordinator ceiling so the fixture
+	// proves that this permanent tool rejection belongs to the bounded,
+	// known-no-actuation failure class.
+	const strandedRow = `{
+  "bead_id": "agent-factory-9d6s",
+  "bead_title": "planrun preflight: host map declares an orx.exe exploratory holder on workshop-pc, but host-install-sources has no orx entry, so the holder can never be installed and preflight refuses the seat",
+  "pane": 2,
+  "agent_type": "cod",
+  "agent_name": "WildIvy",
+  "status": "claimed",
+  "assigned_at": "2026-09-03T02:48:01Z",
+  "idempotency_key": "e1f181f3d71942813a59c006ddbce8f214100992bd1f8c24cbed09eac72959d4",
+  "claim_actor": "WildIvy/ntm-e1f181f3d719",
+  "claim_state": "claimed",
+  "claim_status": "in_progress",
+  "claim_attempts": 1,
+  "claim_started_at": "2026-09-03T02:48:01Z",
+  "claimed_at": "2026-09-03T02:48:01Z",
+  "claim_requires_non_terminal": true,
+  "reservation_state": "reserved",
+  "reservation_attempts": 1,
+  "reservation_completed": true,
+  "reservation_agent": "WildIvy",
+  "reservation_target": "%893",
+  "dispatch_state": "pending",
+  "dispatch_target": "%893",
+  "occupancy_key": "%893",
+  "prompt_sha256": "09f7ae947be557a67aae68dfd84f4c7b40c80cd24945de9564a36d6fcc8acf98",
+  "intent_sha256": "09f7ae947be557a67aae68dfd84f4c7b40c80cd24945de9564a36d6fcc8acf98",
+  "pending_prompt": "# Work Assignment\n\n**Bead:** agent-factory-9d6s\n**Title:** planrun preflight: host map declares an orx.exe exploratory holder on workshop-pc, but host-install-sources has no orx entry, so the holder can never be installed and preflight refuses the seat\n**Priority:** P1\n**Score:** 0.13\n\n## Why This Task\n\n- 🔓 Unblocks 1 item(s): agent-factory-clmx\n- ✅ Currently unclaimed - available for work\n- 🚨 High priority (P1) - prioritize this work\n\n## Impact\n\nCompleting this will unblock 1 other tasks:\n- agent-factory-clmx\n\n## Instructions\n\n1. Review the bead with ` + "`" + `br show agent-factory-9d6s` + "`" + `\n2. NTM already claimed this bead atomically as ` + "`" + `WildIvy/ntm-e1f181f3d719` + "`" + `; do not claim it again\n3. Verify the listed file reservations before editing\n4. Implement and test\n5. Close with ` + "`" + `br close agent-factory-9d6s` + "`" + `\n6. Commit with ` + "`" + `.beads/` + "`" + ` changes\n\nPlease acknowledge this message when you begin work.\n",
+  "dispatch_attempts": 2,
+  "dispatch_started_at": "2026-09-03T03:38:00Z",
+  "last_dispatch_error": "agentmail: send_message failed: tool error: {\"error\":{\"type\":\"SENDER_TOKEN_MISMATCH\",\"message\":\"sender_token does not match the registered token for agent 'WhiteHorse'. Only the agent's owner (the session that called register_agent) can send messages as this agent. Use the registration_token returned by register_agent.\",\"recoverable\":false,\"data\":{\"sender_name\":\"WhiteHorse\",\"hint\":\"Use the registration_token returned by register_agent as sender_token\"}}}"
+}`
+	var assignment assignmentstore.Assignment
+	if err := json.Unmarshal([]byte(strandedRow), &assignment); err != nil {
+		t.Fatalf("decode non-retryable incident row: %v", err)
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, "2026-09-03T03:38:00Z")
+	if err != nil {
+		t.Fatalf("parse non-retryable incident ledger timestamp: %v", err)
+	}
+	snapshot := struct {
+		SessionName           string                                 `json:"session_name"`
+		Assignments           map[string]*assignmentstore.Assignment `json:"assignments"`
+		PersistenceGeneration uint64                                 `json:"persistence_generation"`
+		UpdatedAt             time.Time                              `json:"updated_at"`
+		Version               int                                    `json:"version"`
+	}{
+		SessionName: session, Assignments: map[string]*assignmentstore.Assignment{assignment.BeadID: &assignment},
+		PersistenceGeneration: 4890, UpdatedAt: updatedAt, Version: 9,
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		t.Fatalf("encode non-retryable incident ledger fixture: %v", err)
+	}
+	dir := filepath.Join(home, ".ntm", "sessions", session)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("create non-retryable fixture directory: %v", err)
+	}
+	for _, path := range []string{filepath.Join(dir, "assignments.json"), filepath.Join(dir, "assignments.json.bak")} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write non-retryable fixture %s: %v", path, err)
 		}
 	}
 }

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -2,8 +2,11 @@ package coordinator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -1256,6 +1259,184 @@ func TestAssignWorkKeepsUnknownDispatchFailClosed(t *testing.T) {
 	stored := store.Get(request.BeadID)
 	if stored == nil || stored.DispatchState != assignmentstore.DispatchSending || stored.DispatchAttempts != 1 {
 		t.Fatalf("unknown dispatch ledger changed = %+v", stored)
+	}
+}
+
+func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const session = "agent-factory"
+	writeStrandedAssignmentIncidentFixture(t, home, session)
+
+	c := New(session, t.TempDir(), &agentmail.Client{}, "CoordinatorAgent")
+	addEligibleCoordinatorAgent(c, "%1001", "ReadyAgent")
+	c.actionableRecommendationsFn = func(context.Context, string, int) ([]bv.TriageRecommendation, error) {
+		return []bv.TriageRecommendation{{
+			ID: "agent-factory-ready-b", Title: "Ready bead B", Type: "bug", Status: "open", Priority: 1, Score: 1,
+		}}, nil
+	}
+	c.workItemStatusFn = func(_ context.Context, beadID string) (string, error) {
+		if beadID == "agent-factory-ready-b" {
+			return "open", nil
+		}
+		return "in_progress", nil
+	}
+	c.atomicCoordinatorFactory = successfulCoordinatorAtomicFactory("mail-ready-b")
+
+	results, err := c.AssignWork(t.Context())
+	if err != nil {
+		t.Fatalf("AssignWork: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("assignment results=%+v, want dead A plus placed B", results)
+	}
+	byBead := make(map[string]AssignmentResult, len(results))
+	for _, result := range results {
+		if result.Assignment != nil {
+			byBead[result.Assignment.BeadID] = result
+		}
+	}
+	stranded := byBead["agent-factory-6ndm"]
+	if stranded.Success || !strings.Contains(stranded.Error, `%993`) || !strings.Contains(stranded.Error, "no longer exists") {
+		t.Fatalf("stranded result=%+v", stranded)
+	}
+	ready := byBead["agent-factory-ready-b"]
+	if !ready.Success || !ready.MessageSent {
+		t.Fatalf("ready bead B was not placed: %+v", ready)
+	}
+
+	loaded, err := assignmentstore.LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict load after recovery: %v", err)
+	}
+	failed := loaded.Get("agent-factory-6ndm")
+	if failed == nil || failed.Status != assignmentstore.StatusFailed || !strings.Contains(failed.FailReason, `%993`) || failed.DispatchAttempts != 1 {
+		t.Fatalf("stranded assignment=%+v, want terminal failed state naming dead target", failed)
+	}
+	placed := loaded.Get("agent-factory-ready-b")
+	if placed == nil || placed.Status != assignmentstore.StatusAssigned || placed.DispatchReceiptID != "mail-ready-b" {
+		t.Fatalf("ready assignment=%+v", placed)
+	}
+	ledgerPath := filepath.Join(home, ".ntm", "sessions", session, "assignments.json")
+	primary, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read primary ledger: %v", err)
+	}
+	backup, err := os.ReadFile(ledgerPath + ".bak")
+	if err != nil {
+		t.Fatalf("read backup ledger: %v", err)
+	}
+	if string(primary) != string(backup) || loaded.PersistenceGeneration <= 4775 {
+		t.Fatalf("recovery persistence generation=%d primary/backup equal=%v", loaded.PersistenceGeneration, string(primary) == string(backup))
+	}
+}
+
+func TestAssignWorkBoundsKnownSafeDispatchRetries(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const session = "coordinator-dispatch-attempt-limit"
+	request := assignmentstore.AtomicRequest{
+		BeadID: "ntm-retry-limit", BeadTitle: "Bounded retry", Target: "%94", OccupancyKey: "%94", Pane: 1,
+		AgentType: "cod", AgentName: "BlueLake", Actor: "BlueLake", Prompt: "bounded delivery",
+		IdempotencyKey: "coordinator-retry-limit-key",
+	}
+	store := assignmentstore.NewStore(session)
+	actor := assignmentstore.StableClaimActor(request.Actor, request.IdempotencyKey)
+	if _, err := store.RecordAtomicIntent(request, actor, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordAtomicIntent: %v", err)
+	}
+	if _, err := store.RecordAtomicClaim(request, assignmentstore.ClaimReceipt{BeadID: request.BeadID, Actor: actor, Status: "in_progress", ClaimedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("RecordAtomicClaim: %v", err)
+	}
+	for attempt := 0; attempt < coordinatorDispatchAttemptLimit; attempt++ {
+		if err := store.RecordAtomicDispatchStarted(request.BeadID, request.IdempotencyKey, time.Now().UTC()); err != nil {
+			t.Fatalf("RecordAtomicDispatchStarted attempt %d: %v", attempt+1, err)
+		}
+		if err := store.RecordAtomicDispatchFailed(request.BeadID, request.IdempotencyKey, errors.New("known pre-send failure")); err != nil {
+			t.Fatalf("RecordAtomicDispatchFailed attempt %d: %v", attempt+1, err)
+		}
+	}
+
+	c := New(session, t.TempDir(), &agentmail.Client{}, "CoordinatorAgent")
+	addEligibleCoordinatorAgent(c, request.Target, request.AgentName)
+	c.atomicCoordinatorFactory = func(*assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
+		t.Fatal("attempt ceiling must stop before another dispatch")
+		return nil
+	}
+	results, err := c.AssignWork(t.Context())
+	if err != nil {
+		t.Fatalf("AssignWork: %v", err)
+	}
+	if len(results) != 1 || results[0].Success || !strings.Contains(results[0].Error, "attempt limit reached") {
+		t.Fatalf("attempt-limit results=%+v", results)
+	}
+	failed, err := assignmentstore.LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict load: %v", err)
+	}
+	row := failed.Get(request.BeadID)
+	if row == nil || row.Status != assignmentstore.StatusFailed || row.DispatchAttempts != coordinatorDispatchAttemptLimit || !strings.Contains(row.FailReason, "attempt limit reached") {
+		t.Fatalf("attempt-limit row=%+v", row)
+	}
+}
+
+func writeStrandedAssignmentIncidentFixture(t *testing.T, home, session string) {
+	t.Helper()
+	const strandedRow = `{
+  "bead_id": "agent-factory-6ndm",
+  "bead_title": "Hiring has no front door: factory hire exists and runs pipeline.md section 7, but nothing owns the trigger phrases or checks the roster first (repurpose ex-hire per George)",
+  "pane": 8,
+  "agent_type": "codex",
+  "agent_name": "ChartreuseThrush",
+  "status": "claimed",
+  "assigned_at": "2026-09-02T19:26:37.747913399Z",
+  "idempotency_key": "229bbb021f11b4ed872090599e6cc674287b66f381da0674e758236633a9cff8",
+  "claim_actor": "ChartreuseThrush/ntm-30a83b47454b",
+  "claim_state": "claimed",
+  "claim_status": "in_progress",
+  "claim_attempts": 1,
+  "claim_started_at": "2026-09-02T19:26:37.792893902Z",
+  "claimed_at": "2026-09-02T19:26:37.874312506Z",
+  "claim_requires_non_terminal": true,
+  "reservation_state": "pending",
+  "dispatch_state": "sending",
+  "dispatch_target": "%993",
+  "occupancy_key": "%993",
+  "prompt_sha256": "6e85de7a11d48ef72c7be7d5b9d08bd298dec3acb342dc9591914ea5280d2380",
+  "intent_sha256": "6e85de7a11d48ef72c7be7d5b9d08bd298dec3acb342dc9591914ea5280d2380",
+  "pending_prompt": "Work on bead agent-factory-6ndm: Hiring has no front door: factory hire exists and runs pipeline.md section 7, but nothing owns the trigger phrases or checks the roster first (repurpose ex-hire per George). Check dependencies first with ` + "`" + `br dep tree agent-factory-6ndm` + "`" + `.",
+  "dispatch_attempts": 1,
+  "dispatch_started_at": "2026-09-02T19:26:39.301798264Z"
+}`
+	var assignment assignmentstore.Assignment
+	if err := json.Unmarshal([]byte(strandedRow), &assignment); err != nil {
+		t.Fatalf("decode preserved incident row: %v", err)
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, "2026-09-02T23:00:59.530647074Z")
+	if err != nil {
+		t.Fatalf("parse incident ledger timestamp: %v", err)
+	}
+	snapshot := struct {
+		SessionName           string                                 `json:"session_name"`
+		Assignments           map[string]*assignmentstore.Assignment `json:"assignments"`
+		PersistenceGeneration uint64                                 `json:"persistence_generation"`
+		UpdatedAt             time.Time                              `json:"updated_at"`
+		Version               int                                    `json:"version"`
+	}{
+		SessionName: session, Assignments: map[string]*assignmentstore.Assignment{assignment.BeadID: &assignment},
+		PersistenceGeneration: 4775, UpdatedAt: updatedAt, Version: 9,
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		t.Fatalf("encode incident ledger fixture: %v", err)
+	}
+	dir := filepath.Join(home, ".ntm", "sessions", session)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("create incident fixture directory: %v", err)
+	}
+	for _, path := range []string{filepath.Join(dir, "assignments.json"), filepath.Join(dir, "assignments.json.bak")} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write incident fixture %s: %v", path, err)
+		}
 	}
 }
 

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1343,7 +1344,7 @@ func TestAssignWorkDoesNotInferDeathFromUnavailablePaneSnapshot(t *testing.T) {
 	}
 }
 
-func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
+func TestAssignWorkDeadPaneReapsIncidentRowAndPlacesIndependentWork(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	const session = "agent-factory"
@@ -1362,6 +1363,7 @@ func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
 		}
 		return "in_progress", nil
 	}
+	c.releaseWorkItemClaimFn = func(context.Context, string, string, string) (bool, error) { return true, nil }
 	c.atomicCoordinatorFactory = successfulCoordinatorAtomicFactory("mail-ready-b")
 
 	results, err := c.AssignWork(t.Context())
@@ -1382,6 +1384,9 @@ func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
 		t.Fatalf("stranded result=%+v", stranded)
 	}
 	ready := byBead["agent-factory-ready-b"]
+	// B is an independent-work control, not evidence that the old row caused
+	// starvation: AssignWork has always continued from recovery into scoring
+	// whenever another verified candidate and recommendation exist.
 	if !ready.Success || !ready.MessageSent {
 		t.Fatalf("ready bead B was not placed: %+v", ready)
 	}
@@ -1412,7 +1417,7 @@ func TestAssignWorkDeadPaneDoesNotBlockReadyBead(t *testing.T) {
 	}
 }
 
-func TestAssignWorkNonRetryableLivePaneDoesNotBlockReadyBead(t *testing.T) {
+func TestAssignWorkPermanentFailureBlockSurvivesRowClearAndStopsRedispatch(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	const session = "agent-factory"
@@ -1426,11 +1431,24 @@ func TestAssignWorkNonRetryableLivePaneDoesNotBlockReadyBead(t *testing.T) {
 			ID: "agent-factory-ready-b", Title: "Ready bead B", Type: "bug", Status: "open", Priority: 1, Score: 1,
 		}}, nil
 	}
+	trackerStatus := map[string]string{
+		"agent-factory-9d6s":    "in_progress",
+		"agent-factory-ready-b": "open",
+	}
 	c.workItemStatusFn = func(_ context.Context, beadID string) (string, error) {
 		if beadID == "agent-factory-ready-b" {
 			return "open", nil
 		}
-		return "in_progress", nil
+		return trackerStatus[beadID], nil
+	}
+	claimReleases := 0
+	c.releaseWorkItemClaimFn = func(_ context.Context, _ string, beadID, actor string) (bool, error) {
+		if beadID != "agent-factory-9d6s" || actor != "WildIvy/ntm-e1f181f3d719" {
+			t.Fatalf("release claim bead=%q actor=%q", beadID, actor)
+		}
+		claimReleases++
+		trackerStatus[beadID] = "open"
+		return true, nil
 	}
 	failedDispatches := 0
 	c.atomicCoordinatorFactory = func(store *assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
@@ -1475,7 +1493,6 @@ func TestAssignWorkNonRetryableLivePaneDoesNotBlockReadyBead(t *testing.T) {
 	if failedDispatches != 1 {
 		t.Fatalf("non-retryable dispatch attempts=%d, want 1", failedDispatches)
 	}
-
 	// The first cycle consumes the final known-no-actuation attempt while still
 	// placing B. The next cycle terminalizes A before a fourth dispatch.
 	results, err = c.AssignWork(t.Context())
@@ -1489,6 +1506,9 @@ func TestAssignWorkNonRetryableLivePaneDoesNotBlockReadyBead(t *testing.T) {
 	if failedDispatches != 1 {
 		t.Fatalf("non-retryable row dispatched past ceiling: attempts=%d", failedDispatches)
 	}
+	if claimReleases != 1 || trackerStatus["agent-factory-9d6s"] != "open" {
+		t.Fatalf("post-reap claim releases=%d tracker status=%q, want one release and open", claimReleases, trackerStatus["agent-factory-9d6s"])
+	}
 
 	loaded, err := assignmentstore.LoadStoreStrict(session)
 	if err != nil {
@@ -1499,9 +1519,103 @@ func TestAssignWorkNonRetryableLivePaneDoesNotBlockReadyBead(t *testing.T) {
 		!strings.Contains(failed.FailReason, "attempt limit reached") {
 		t.Fatalf("non-retryable live-pane assignment=%+v", failed)
 	}
+	block, blocked := loaded.ActiveDispatchFailureBlock("agent-factory-9d6s")
+	if !blocked || block.FailureClass != "SENDER_TOKEN_MISMATCH" {
+		t.Fatalf("durable dispatch block=%+v active=%v", block, blocked)
+	}
 	placed := loaded.Get("agent-factory-ready-b")
 	if placed == nil || placed.Status != assignmentstore.StatusAssigned || placed.DispatchReceiptID != "mail-ready-after-nonretryable" {
 		t.Fatalf("ready assignment=%+v", placed)
+	}
+
+	// Reproduce the live second cycle: an operator clears the failed row after
+	// its stale claim is released, which returns the bead to the ready queue.
+	// The circuit breaker is outside that row, so the same permanent failure
+	// class cannot start a fresh attempt counter and dispatch again.
+	if _, err := loaded.BeginClearForce(t.Context(), "agent-factory-9d6s", time.Now().UTC()); err != nil {
+		t.Fatalf("BeginClearForce failed row: %v", err)
+	}
+	if _, err := loaded.RecordClearLeasesReleased(t.Context(), "agent-factory-9d6s"); err != nil {
+		t.Fatalf("RecordClearLeasesReleased failed row: %v", err)
+	}
+	if err := loaded.CompleteClear(t.Context(), "agent-factory-9d6s"); err != nil {
+		t.Fatalf("CompleteClear failed row: %v", err)
+	}
+	if loaded.Get("agent-factory-9d6s") != nil {
+		t.Fatal("failed assignment row survived explicit clear")
+	}
+	if _, stillBlocked := loaded.ActiveDispatchFailureBlock("agent-factory-9d6s"); !stillBlocked {
+		t.Fatal("row clear erased permanent dispatch circuit breaker")
+	}
+
+	c.actionableRecommendationsFn = func(context.Context, string, int) ([]bv.TriageRecommendation, error) {
+		return []bv.TriageRecommendation{{
+			ID: "agent-factory-9d6s", Title: "Ready again after claim release", Type: "bug", Status: "open", Priority: 1, Score: 1,
+		}}, nil
+	}
+	results, err = c.AssignWork(t.Context())
+	if err != nil {
+		t.Fatalf("AssignWork after row clear: %v", err)
+	}
+	if len(results) != 1 || results[0].Assignment == nil || results[0].Assignment.BeadID != "agent-factory-9d6s" ||
+		!strings.Contains(results[0].Error, "SENDER_TOKEN_MISMATCH") || !strings.Contains(results[0].Error, "--override-dispatch-block") {
+		t.Fatalf("post-clear circuit-breaker results=%+v", results)
+	}
+	if failedDispatches != 1 {
+		t.Fatalf("same bead was re-dispatched after row clear: total dispatches=%d, want 1", failedDispatches)
+	}
+
+	reloaded, err := assignmentstore.LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict reload after row clear: %v", err)
+	}
+	if _, stillBlocked := reloaded.ActiveDispatchFailureBlock("agent-factory-9d6s"); !stillBlocked {
+		t.Fatal("strict reload lost permanent dispatch circuit breaker")
+	}
+	ledgerPath := filepath.Join(home, ".ntm", "sessions", session, "assignments.json")
+	primary, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read primary ledger: %v", err)
+	}
+	backup, err := os.ReadFile(ledgerPath + ".bak")
+	if err != nil {
+		t.Fatalf("read backup ledger: %v", err)
+	}
+	if !bytes.Equal(primary, backup) {
+		t.Fatal("primary and backup ledgers differ after durable dispatch block")
+	}
+	cleared, err := reloaded.ClearDispatchFailureBlock(t.Context(), "agent-factory-9d6s")
+	if err != nil || !cleared {
+		t.Fatalf("explicit circuit-breaker override cleared=%v error=%v", cleared, err)
+	}
+	final, err := assignmentstore.LoadStoreStrict(session)
+	if err != nil {
+		t.Fatalf("strict reload after circuit-breaker override: %v", err)
+	}
+	if _, blocked := final.ActiveDispatchFailureBlock("agent-factory-9d6s"); blocked {
+		t.Fatal("explicit circuit-breaker override did not survive strict reload")
+	}
+}
+
+func TestServerDeclaredPermanentDispatchFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantClass string
+		want      bool
+	}{
+		{name: "permanent", raw: `tool error: {"error":{"type":"SENDER_TOKEN_MISMATCH","recoverable":false}}`, wantClass: "SENDER_TOKEN_MISMATCH", want: true},
+		{name: "recoverable", raw: `tool error: {"error":{"type":"RATE_LIMITED","recoverable":true}}`},
+		{name: "missing declaration", raw: `tool error: {"error":{"type":"UNKNOWN"}}`},
+		{name: "malformed", raw: `tool error: {nope`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotClass, got := serverDeclaredPermanentDispatchFailure(test.raw)
+			if got != test.want || gotClass != test.wantClass {
+				t.Fatalf("serverDeclaredPermanentDispatchFailure()=(%q,%v), want (%q,%v)", gotClass, got, test.wantClass, test.want)
+			}
+		})
 	}
 }
 
@@ -1532,6 +1646,7 @@ func TestAssignWorkBoundsKnownSafeDispatchRetries(t *testing.T) {
 
 	c := New(session, t.TempDir(), &agentmail.Client{}, "CoordinatorAgent")
 	addEligibleCoordinatorAgent(c, request.Target, request.AgentName)
+	c.releaseWorkItemClaimFn = func(context.Context, string, string, string) (bool, error) { return true, nil }
 	c.atomicCoordinatorFactory = func(*assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
 		t.Fatal("attempt ceiling must stop before another dispatch")
 		return nil

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -51,8 +52,10 @@ type SessionCoordinator struct {
 	operatorGatedLabels         []string
 
 	// Agent tracking
-	agents     map[string]*AgentState
-	lastUpdate time.Time
+	agents                       map[string]*AgentState
+	assignmentPaneIDs            map[string]struct{}
+	assignmentPaneSnapshotUsable bool
+	lastUpdate                   time.Time
 
 	// Monitors
 	monitor *AgentMonitor
@@ -233,6 +236,7 @@ func New(session, projectKey string, mailClient *agentmail.Client, agentName str
 		reservationClient:   mailClient,
 		operatorGatedLabels: append([]string(nil), bv.OperatorGatedLabelsForProject(projectKey)...),
 		agents:              make(map[string]*AgentState),
+		assignmentPaneIDs:   make(map[string]struct{}),
 		config:              DefaultCoordinatorConfig(),
 		events:              make(chan CoordinatorEvent, 100),
 		stopCh:              make(chan struct{}),
@@ -564,6 +568,12 @@ func (c *SessionCoordinator) updateAgentStatesContext(ctx context.Context) error
 		c.markAgentObservationsUnavailable(observation.ObservedAt, err)
 		return err
 	}
+	assignmentPaneIDs := make(map[string]struct{}, len(observation.Panes))
+	for _, pane := range observation.Panes {
+		if paneID := strings.TrimSpace(pane.Pane.ID); paneID != "" {
+			assignmentPaneIDs[paneID] = struct{}{}
+		}
+	}
 
 	type agentUpdate struct {
 		paneID    string
@@ -600,6 +610,8 @@ func (c *SessionCoordinator) updateAgentStatesContext(ctx context.Context) error
 	}
 
 	c.mu.Lock()
+	c.assignmentPaneIDs = assignmentPaneIDs
+	c.assignmentPaneSnapshotUsable = true
 
 	// Track which panes we've seen
 	seenPanes := make(map[string]bool, len(updates))
@@ -695,6 +707,9 @@ func (c *SessionCoordinator) markAgentObservationsUnavailable(observedAt time.Ti
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// A failed topology observation is not an empty pane set. Keep the last
+	// snapshot for diagnostics, but make it unusable as evidence of pane death.
+	c.assignmentPaneSnapshotUsable = false
 	for _, agent := range c.agents {
 		if agent.ObservationFreshness == status.FreshnessFresh && agent.Status != robot.StateUnknown {
 			agent.LastKnownStatus = agent.Status

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -318,9 +318,48 @@ func TestUpdateAgentStates_TopologyFailureInvalidatesCurrentWithoutRefreshingLas
 	}
 	c.mu.RLock()
 	lastUpdate := c.lastUpdate
+	paneSnapshotUsable := c.assignmentPaneSnapshotUsable
 	c.mu.RUnlock()
 	if lastUpdate != priorUpdate {
 		t.Fatalf("lastUpdate refreshed on failed topology: got %v want %v", lastUpdate, priorUpdate)
+	}
+	if paneSnapshotUsable {
+		t.Fatal("failed topology remained usable as pane-death evidence")
+	}
+}
+
+func TestUpdateAgentStatesTracksPhysicalUnclassifiedPanes(t *testing.T) {
+	origGetPanesWithActivity := getPanesWithActivity
+	origCaptureForHealthCheckWithCtx := captureForHealthCheckWithCtx
+	t.Cleanup(func() {
+		getPanesWithActivity = origGetPanesWithActivity
+		captureForHealthCheckWithCtx = origCaptureForHealthCheckWithCtx
+	})
+
+	getPanesWithActivity = func(string) ([]tmux.PaneActivity, error) {
+		return []tmux.PaneActivity{
+			{Pane: tmux.Pane{ID: "%1", Index: 1, Type: tmux.AgentCodex}},
+			{Pane: tmux.Pane{ID: "%2", Index: 2, Type: tmux.AgentUnknown}},
+		}, nil
+	}
+	captureForHealthCheckWithCtx = func(context.Context, string) (string, error) {
+		return "completed\n────────────\n› \n────────────", nil
+	}
+
+	c := New("test-session", t.TempDir(), nil, "TestAgent")
+	c.monitor = NewAgentMonitor(c.session, nil, c.projectKey)
+	if err := c.updateAgentStatesContext(t.Context()); err != nil {
+		t.Fatalf("updateAgentStatesContext: %v", err)
+	}
+	if _, classified := c.GetAgents()["%2"]; classified {
+		t.Fatal("unknown pane unexpectedly entered the agent map")
+	}
+	physical, usable := c.physicalAssignmentTargets()
+	if !usable {
+		t.Fatal("successful topology observation was not usable")
+	}
+	if _, present := physical["%2"]; !present {
+		t.Fatalf("unclassified pane absent from physical topology: %v", physical)
 	}
 }
 


### PR DESCRIPTION
Summary

- Terminalize a non-sent assignment when its physical tmux pane is absent from the coordinator fresh-session snapshot; the persisted fail_reason names the missing target.
- Bound known pre-actuation dispatch retries at three while preserving the fail-closed ambiguity barrier for a live target whose send outcome is unknown.
- Continue the assignment pass after terminalizing a stranded row, so ready bead B can be placed in the same cycle.
- Exercise the existing operator escape hatch and prove force-clear keeps equal-generation primary and backup snapshots byte-identical.

Regression evidence

The coordinator regression is built from the preserved agent-factory incident row for agent-factory-6ndm, including dispatch_state sending, dispatch_target and occupancy_key %993, dispatch_attempts 1, generation 4775, and the original timestamps and hashes.

Tests

- PASS: focused coordinator regressions, including dead A does not block ready B and bounded known-safe retries.
- PASS: focused force-clear strict-reload and primary/backup identity test.
- PASS: full internal/coordinator package.
- PASS: go build ./cmd/ntm.
- FULL SUITE RUN: nice -n 15 make test-all returned exit 2. The five observed failures all reproduce on an untouched e4718530 upstream-main worktree:
  - internal/checkpoint TestCapturer_captureSessionState_UsesSessionSelectedPaneAcrossWindows
  - internal/cli TestRunReassignment_ToPane_Success
  - internal/cli TestRunRetryAssignments_PreservesPreviousFailReasonAndMetadata
  - internal/cli TestSessionTemplateSpawn_Builtin
  - internal/cli TestSessionTemplateSpawn_CustomUserTemplate
  The four CLI cases are live-spawn failures where fake agent panes exit to bare shells or are not prompt-ready; the checkpoint assertion is identical on the base commit.

Carrier: agent-factory-m0ip.