### PR TITLE
fix(activity): persist pane state age across invocations

### DIFF
--- a/internal/cli/activity.go
+++ b/internal/cli/activity.go
@@ -105,9 +105,17 @@ type activityOptions struct {
 	filterPane        string
 	watchMode         bool
 	interval          time.Duration
+	watermarkStore    robot.WatermarkStore
 }
 
 func runActivity(session string, opts activityOptions) error {
+	// PersistentPreRun opens the runtime store for the real command path.
+	// Carry it explicitly into collection so direct unit-test/library calls do
+	// not depend on mutable package-global store lifecycle.
+	if opts.watermarkStore == nil {
+		opts.watermarkStore = robotStateStore
+	}
+
 	// bd-ixy2t: emit a JSON envelope on early-fail when --json is set so
 	// automation pipelines (`ntm activity --json | jq ...`) always see a
 	// parseable failure on stdout instead of a stderr "Error:" line.
@@ -263,7 +271,7 @@ func collectActivityData(session string, opts activityOptions) (*activityResult,
 
 	result := &activityResult{
 		Session:    session,
-		CapturedAt: time.Now(),
+		CapturedAt: time.Now().UTC(),
 		Agents:     make([]agentInfo, 0),
 		Summary:    make(map[string]int),
 	}
@@ -283,7 +291,9 @@ func collectActivityData(session string, opts activityOptions) (*activityResult,
 
 		// Create classifier and get state
 		classifier := robot.NewStateClassifier(pane.ID, &robot.ClassifierConfig{
-			AgentType: agentType,
+			AgentType:  agentType,
+			PaneWidth:  pane.Width,
+			PaneHeight: pane.Height,
 		})
 
 		activity, err := classifier.Classify()
@@ -300,10 +310,26 @@ func collectActivityData(session string, opts activityOptions) (*activityResult,
 			continue
 		}
 
-		// Calculate duration
+		// A one-shot activity invocation creates a fresh classifier, so its
+		// in-memory StateSince is necessarily "now". Reconcile the observed
+		// state through the runtime store to preserve state age across both
+		// watch ticks and separate CLI processes.
+		stateSince := activity.StateSince
+		if durableSince, persistErr := robot.ObserveActivityState(
+			opts.watermarkStore,
+			activityStateScope(session, pane),
+			activity.State,
+			result.CapturedAt,
+		); persistErr == nil {
+			stateSince = durableSince
+		}
+
+		// Calculate duration against the snapshot timestamp so every row in a
+		// frame has a coherent clock and a future/corrupt watermark cannot emit
+		// a negative duration.
 		var duration time.Duration
-		if !activity.StateSince.IsZero() {
-			duration = time.Since(activity.StateSince)
+		if !stateSince.IsZero() && !stateSince.After(result.CapturedAt) {
+			duration = result.CapturedAt.Sub(stateSince)
 		}
 
 		info := agentInfo{
@@ -315,7 +341,7 @@ func collectActivityData(session string, opts activityOptions) (*activityResult,
 			Confidence:  activity.Confidence,
 			Velocity:    activity.Velocity,
 			Duration:    duration,
-			StateSince:  activity.StateSince,
+			StateSince:  stateSince,
 		}
 
 		result.Agents = append(result.Agents, info)
@@ -323,6 +349,10 @@ func collectActivityData(session string, opts activityOptions) (*activityResult,
 	}
 
 	return result, nil
+}
+
+func activityStateScope(session string, pane tmux.Pane) string {
+	return fmt.Sprintf("%s|%s|%d", session, pane.ID, pane.PID)
 }
 
 func detectAgentTypeFromPane(pane tmux.Pane) string {

--- a/internal/cli/activity_test.go
+++ b/internal/cli/activity_test.go
@@ -71,6 +71,15 @@ func TestFormatActivityDuration(t *testing.T) {
 	}
 }
 
+func TestActivityStateScopeSeparatesPaneLifetimes(t *testing.T) {
+	first := activityStateScope("agent-factory", tmux.Pane{ID: "%9", PID: 4242})
+	samePaneNewProcess := activityStateScope("agent-factory", tmux.Pane{ID: "%9", PID: 5252})
+	otherSession := activityStateScope("workshop", tmux.Pane{ID: "%9", PID: 4242})
+	if first == samePaneNewProcess || first == otherSession {
+		t.Fatalf("activity state scope aliases pane lifetimes: %q, %q, %q", first, samePaneNewProcess, otherSession)
+	}
+}
+
 func TestPassesFilter(t *testing.T) {
 
 	tests := []struct {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -585,6 +585,17 @@ func TestShouldInitializeRobotPersistenceSkipsStatelessOverlay(t *testing.T) {
 	}
 }
 
+func TestShouldInitializeRobotPersistenceForActivity(t *testing.T) {
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+	os.Args = []string{"ntm", "activity", "agent-factory", "--json"}
+
+	cmd := &cobra.Command{Use: "activity"}
+	if !shouldInitializeRobotPersistence(cmd) {
+		t.Fatal("activity command must initialize persistence for durable state_since")
+	}
+}
+
 func isolateSessionAgentStorage(t *testing.T) {
 	t.Helper()
 	home := t.TempDir()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -824,7 +824,7 @@ Shell Integration:
 		}
 
 		if shouldInitializeRobotPersistence(cmd) {
-			if err := initializeRobotPersistence(cmd.Context()); err != nil {
+			if err := initializeRobotPersistence(cmd.Context(), cmd.Name() != "activity"); err != nil {
 				return err
 			}
 		}
@@ -3380,6 +3380,9 @@ func shouldInitializeRobotPersistence(cmd *cobra.Command) bool {
 	if cmd != nil && cmd.Name() == "serve" {
 		return false
 	}
+	if cmd != nil && cmd.Name() == "activity" {
+		return true
+	}
 
 	for _, arg := range os.Args[1:] {
 		if arg == "--schema" {
@@ -3411,7 +3414,7 @@ func robotFlagSkipsPersistence(arg string) bool {
 	}
 }
 
-func initializeRobotPersistence(ctx context.Context) error {
+func initializeRobotPersistence(ctx context.Context, refreshProjection bool) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -3437,6 +3440,9 @@ func initializeRobotPersistence(ctx context.Context) error {
 	))
 	robot.SetProjectionStore(store)
 	robotStateStore = store
+	if !refreshProjection {
+		return nil
+	}
 
 	// Assignment commands perform their own strict policy validation before
 	// consulting bv/br. Keep the persistence store available to the command, but

--- a/internal/robot/activity.go
+++ b/internal/robot/activity.go
@@ -39,6 +39,55 @@ type WatermarkStore interface {
 // WatermarkTypeVelocity is the watermark type used for velocity tracker baselines.
 const WatermarkTypeVelocity = "velocity"
 
+// WatermarkTypeActivityState is the watermark type used to preserve the time
+// at which a pane entered its currently observed activity state. Unlike a
+// StateClassifier instance, this watermark survives one-shot CLI processes.
+const WatermarkTypeActivityState = "activity_state"
+
+// ObserveActivityState reconciles one classified pane state with its durable
+// watermark and returns the time at which that state was first observed. A
+// scope must identify one pane lifetime (callers should include the session,
+// tmux pane ID, and pane PID) so a recycled tmux ID cannot inherit old state.
+//
+// A nil store degrades to the current observation time. Store failures are
+// returned so callers can keep their non-durable classifier result rather than
+// failing an otherwise healthy activity query.
+func ObserveActivityState(store WatermarkStore, scope string, activityState AgentState, observedAt time.Time) (time.Time, error) {
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	if store == nil {
+		return observedAt, nil
+	}
+
+	wm, err := store.GetWatermark(WatermarkTypeActivityState, scope)
+	if err != nil {
+		return observedAt, err
+	}
+	if wm != nil && wm.Consumer == string(activityState) && wm.LastTs != nil && !wm.LastTs.After(observedAt) {
+		return wm.LastTs.UTC(), nil
+	}
+
+	createdAt := observedAt
+	if wm != nil && !wm.CreatedAt.IsZero() {
+		createdAt = wm.CreatedAt
+	}
+	stateSince := observedAt
+	if err := store.SetWatermark(&state.OutputWatermark{
+		WatermarkType: WatermarkTypeActivityState,
+		Scope:         scope,
+		LastTs:        &stateSince,
+		Consumer:      string(activityState),
+		CreatedAt:     createdAt,
+		UpdatedAt:     observedAt,
+	}); err != nil {
+		return observedAt, err
+	}
+	return stateSince, nil
+}
+
 // VelocitySample represents a single velocity measurement at a point in time.
 type VelocitySample struct {
 	Timestamp  time.Time `json:"timestamp"`
@@ -703,6 +752,7 @@ type StateClassifier struct {
 	patternLibrary     *PatternLibrary
 	agentType          string
 	paneWidth          int
+	paneHeight         int
 	stallThreshold     time.Duration
 	hysteresisDuration time.Duration
 
@@ -725,7 +775,11 @@ type ClassifierConfig struct {
 	AgentType string
 	// PaneWidth is the real tmux pane width; used to widen the live tail
 	// window on narrow panes (bd-eeifh). Zero keeps the calibrated budget.
-	PaneWidth          int
+	PaneWidth int
+	// PaneHeight is the real tmux pane height. When set, transient state
+	// markers are classified only from the visible screen, excluding the
+	// additional scrollback rows returned by capture-pane -S.
+	PaneHeight         int
 	StallThreshold     time.Duration
 	HysteresisDuration time.Duration
 	PatternLibrary     *PatternLibrary
@@ -764,6 +818,7 @@ func NewStateClassifier(paneID string, cfg *ClassifierConfig) *StateClassifier {
 		patternLibrary:     patternLib,
 		agentType:          cfg.AgentType,
 		paneWidth:          cfg.PaneWidth,
+		paneHeight:         cfg.PaneHeight,
 		stallThreshold:     stallThreshold,
 		hysteresisDuration: hysteresis,
 		currentState:       StateUnknown,
@@ -830,7 +885,11 @@ func (sc *StateClassifier) classifyInternal(sample *VelocitySample) (*AgentActiv
 	// stale "failed" or "api error" text high in scrollback must not pin a
 	// pane to ERROR after its TUI has visibly moved on. Fresh errors inside
 	// the live tail still classify as ERROR.
-	liveContent := lastNLines(content, util.WidthAdaptiveTailLines(sc.paneWidth, liveThinkingWindowLines))
+	visibleContent := content
+	if sc.paneHeight > 0 {
+		visibleContent = util.GetLastNLines(content, sc.paneHeight)
+	}
+	liveContent := lastNLines(visibleContent, util.WidthAdaptiveTailLines(sc.paneWidth, liveThinkingWindowLines))
 	liveMatches := sc.patternLibrary.Match(liveContent, sc.agentType)
 	effectiveMatches := filterThinkingToLive(matches, liveMatches)
 	effectiveMatches = filterErrorToLiveWithCurrentSignal(effectiveMatches, liveMatches)

--- a/internal/robot/activity_test.go
+++ b/internal/robot/activity_test.go
@@ -2339,6 +2339,82 @@ func (m *mockWatermarkStore) SetWatermark(wm *state.OutputWatermark) error {
 	return nil
 }
 
+func TestObserveActivityStateSurvivesOneShotProcesses(t *testing.T) {
+	store := newMockWatermarkStore()
+	started := time.Date(2026, 9, 3, 11, 30, 0, 0, time.UTC)
+	scope := "agent-factory|%9|4242"
+
+	first, err := ObserveActivityState(store, scope, StateWaiting, started)
+	if err != nil {
+		t.Fatalf("first observation: %v", err)
+	}
+	second, err := ObserveActivityState(store, scope, StateWaiting, started.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("second observation: %v", err)
+	}
+	if !first.Equal(started) || !second.Equal(started) {
+		t.Fatalf("stable WAITING state_since = %v then %v, want %v", first, second, started)
+	}
+
+	changedAt := started.Add(31 * time.Second)
+	changed, err := ObserveActivityState(store, scope, StateThinking, changedAt)
+	if err != nil {
+		t.Fatalf("changed observation: %v", err)
+	}
+	if !changed.Equal(changedAt) {
+		t.Fatalf("changed THINKING state_since = %v, want %v", changed, changedAt)
+	}
+
+	stableAgain, err := ObserveActivityState(store, scope, StateThinking, changedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("stable changed observation: %v", err)
+	}
+	if !stableAgain.Equal(changedAt) {
+		t.Fatalf("stable THINKING state_since = %v, want %v", stableAgain, changedAt)
+	}
+}
+
+func TestStateClassifierLimitsCodexThinkingToVisiblePane(t *testing.T) {
+	const idleComposerWithOffscreenSpinner = "• Working (12s • Esc to interrupt)\n" +
+		"historical output\n" +
+		"more historical output\n" +
+		"\n" +
+		"▌ Ask Codex to do something\n" +
+		"›\n" +
+		"  ⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit\n"
+
+	idle := NewStateClassifier("%9", &ClassifierConfig{
+		AgentType:  "codex",
+		PaneWidth:  80,
+		PaneHeight: 4,
+	})
+	activity, err := idle.ClassifyWithOutput(idleComposerWithOffscreenSpinner)
+	if err != nil {
+		t.Fatalf("idle classification: %v", err)
+	}
+	if activity.State != StateWaiting {
+		t.Fatalf("Codex composer with off-screen spinner = %s, want %s", activity.State, StateWaiting)
+	}
+
+	const workingViewport = "historical output\n" +
+		"• Working (12s • Esc to interrupt)\n" +
+		"▌ Ask Codex to do something\n" +
+		"›\n" +
+		"  ⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit\n"
+	working := NewStateClassifier("%10", &ClassifierConfig{
+		AgentType:  "codex",
+		PaneWidth:  80,
+		PaneHeight: 4,
+	})
+	activity, err = working.ClassifyWithOutput(workingViewport)
+	if err != nil {
+		t.Fatalf("working classification: %v", err)
+	}
+	if activity.State != StateThinking {
+		t.Fatalf("Codex viewport with live spinner = %s, want %s", activity.State, StateThinking)
+	}
+}
+
 func TestVelocityTracker_RestartSafeBaseline_UnchangedContent(t *testing.T) {
 
 	store := newMockWatermarkStore()

--- a/internal/status/unified.go
+++ b/internal/status/unified.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Dicklesworthstone/ntm/internal/agent"
 	"github.com/Dicklesworthstone/ntm/internal/tmux"
+	"github.com/Dicklesworthstone/ntm/internal/util"
 )
 
 // UnifiedDetector implements the Detector interface by combining
@@ -809,8 +810,18 @@ func (o *SessionObserver) buildPaneObservation(cache *sessionObservationCache, p
 		lastActivity = contentChangedAt
 	}
 
-	status := o.detector.AnalyzeAt(pane.Pane.ID, pane.Pane.Title, normalizedAgentType, output, lastActivity, observedAt)
-	confidence := observationConfidence(status, output)
+	// CapturePaneOutput(-N) returns N scrollback rows plus the whole visible
+	// screen. Transient TUI markers (Codex's "Working" spinner in particular)
+	// are authoritative only while visible; using a fixed tail lets an
+	// off-screen marker survive indefinitely on short panes. Keep the full
+	// capture for content-change history and diagnostics, but classify only the
+	// pane's current viewport when tmux supplied its height.
+	classificationOutput := output
+	if pane.Pane.Height > 0 {
+		classificationOutput = util.GetLastNLines(output, pane.Pane.Height)
+	}
+	status := o.detector.AnalyzeAt(pane.Pane.ID, pane.Pane.Title, normalizedAgentType, classificationOutput, lastActivity, observedAt)
+	confidence := observationConfidence(status, classificationOutput)
 	observation.Current = StateObservation{
 		Status:     status,
 		ObservedAt: observedAt,

--- a/internal/status/unified_test.go
+++ b/internal/status/unified_test.go
@@ -943,6 +943,85 @@ func TestDetermineStateCodexIdleBeatsWindowVelocity(t *testing.T) {
 	}
 }
 
+// TestSessionObserverClassifiesOnlyVisibleCodexViewport covers short tmux
+// panes where capture-pane -S includes more scrollback than screen rows. A
+// completed turn's spinner may remain inside the 15-line detector tail while
+// already being off-screen; assignment must use the visible composer state.
+func TestSessionObserverClassifiesOnlyVisibleCodexViewport(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 9, 3, 11, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		capture      string
+		wantState    AgentState
+		wantDispatch bool
+	}{
+		{
+			name: "off-screen spinner above idle composer",
+			capture: "• Working (12s • Esc to interrupt)\n" +
+				"historical output\n" +
+				"more historical output\n" +
+				"\n" +
+				"▌ Ask Codex to do something\n" +
+				"›\n" +
+				"  ⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit\n",
+			wantState:    StateIdle,
+			wantDispatch: true,
+		},
+		{
+			name: "spinner inside working viewport",
+			capture: "historical output\n" +
+				"• Working (12s • Esc to interrupt)\n" +
+				"▌ Ask Codex to do something\n" +
+				"›\n" +
+				"  ⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit\n",
+			wantState:    StateWorking,
+			wantDispatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer := NewSessionObserverWithDependencies(NewDetector(), DefaultSessionObserverConfig(DefaultConfig()), SessionObserverDependencies{
+				ListPanes: func(context.Context, string) ([]tmux.PaneActivity, error) {
+					return []tmux.PaneActivity{{
+						Pane: tmux.Pane{
+							ID:          "%9",
+							WindowIndex: 0,
+							Index:       1,
+							Title:       "agent-factory__cod_1",
+							Type:        tmux.AgentCodex,
+							Width:       80,
+							Height:      4,
+						},
+						LastActivity: observedAt,
+					}}, nil
+				},
+				CapturePane: func(context.Context, string, int) (string, error) {
+					return tt.capture, nil
+				},
+				Now: func() time.Time { return observedAt },
+			})
+
+			observation, err := observer.Observe(context.Background(), "agent-factory")
+			if err != nil {
+				t.Fatalf("Observe() error = %v", err)
+			}
+			pane, ok := observation.PaneByID("%9")
+			if !ok {
+				t.Fatal("observation missing pane %9")
+			}
+			if pane.Current.Status.State != tt.wantState {
+				t.Fatalf("state = %s, want %s", pane.Current.Status.State, tt.wantState)
+			}
+			if pane.SafeToDispatch() != tt.wantDispatch {
+				t.Fatalf("SafeToDispatch() = %v, want %v", pane.SafeToDispatch(), tt.wantDispatch)
+			}
+		})
+	}
+}
+
 // TestSessionObserverAppliesPaneLocalActivityBound covers the second half of
 // #234: the pane-content fingerprint bound from ntm#213 lived only in
 // UnifiedDetector.Detect, not in SessionObserver.buildPaneObservation — and the


### PR DESCRIPTION
## Summary

- persist `ntm activity` state transitions in the runtime watermark store so `state_since` remains stable and `duration` grows across one-shot invocations
- classify transient pane state from the actual visible viewport instead of extra `capture-pane -S` scrollback, preventing stale Codex spinners from masking an idle composer
- carry pane width/height into the activity classifier and isolate state scopes by session, pane ID, and pane PID

## Verification

- `go test -short ./...`
- `go test ./internal/robot -run "TestObserveActivityStateSurvivesOneShotProcesses|TestStateClassifierLimitsCodexThinkingToVisiblePane" -count=1`
- `go test ./internal/status -run "TestSessionObserverClassifiesOnlyVisibleCodexViewport|TestDetermineStateCodexIdleBeatsWindowVelocity" -count=1`
- `go test ./internal/cli -run "TestShouldInitializeRobotPersistenceForActivity|TestActivityStateScopeSeparatesPaneLifetimes|TestActivity_TwoWindowPaneIndexCollision" -count=1`
- `golangci-lint run --new-from-rev=origin/main --timeout=5m` (0 issues)
- controlled 6-row tmux pane: two `ntm activity --json` calls 37s apart stayed WAITING, kept the same `state_since`, and advanced duration to 37s
- controlled `ntm assign --watch --dry-run`: initial pass and subsequent scans each found the idle pane and produced a recommendation

## Existing upstream lint debt

Full `golangci-lint run --timeout=5m` reports 25 findings, all outside the files changed by this PR. The changed-lines run is clean.