### PR TITLE
fix(coordinator): unblock daemon placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ ntm coordinator conflicts payments
 ntm coordinator enable auto-assign
 ntm coordinator enable digest --interval=30m
 ntm coordinator disable conflict-negotiate
+ntm coordinator run payments --reserve-files=false
+ntm assign payments --clear-pane=3 --force --retain-claim
 ```
 
 `ntm locks force-release` is approval-gated by default (`automation.force_release:
@@ -323,6 +325,12 @@ action honor the same policy setting.
 `coordinator enable` and `disable` persist the selected `--config` file, or the
 global config by default, without replacing unrelated settings or comments.
 Restart an already running `ntm coordinator run` daemon to apply a toggle.
+Pass `--reserve-files=false` to that daemon when Agent Mail reservations are
+unavailable. To remove a terminal assignment row that still owns a pane without
+reopening its Bead, clear it with `--retain-claim`; this flag rejects nonterminal
+rows. The clear still releases reservations first, using the durable reservation
+ID, bead reason, agent, and path binding even if the stored reservation has a
+malformed project ID.
 The selected file may use a `[coordinator]` table or root dotted assignments
 such as `coordinator.auto_assign = false`. A whole-section inline assignment
 such as `coordinator = { auto_assign = false }` is rejected without changing

--- a/internal/assign/reservation.go
+++ b/internal/assign/reservation.go
@@ -607,9 +607,10 @@ func selectExactReleaseReservations(
 		path := strings.TrimSpace(reservation.PathPattern)
 		_, requestedByID := wantedIDs[reservation.ID]
 		_, requestedByPath := wantedPaths[path]
-		exactBinding := reservation.ID > 0 && reservation.ProjectID == expectedProjectID &&
-			strings.TrimSpace(reservation.AgentName) == agentName && strings.TrimSpace(reservation.Reason) == reason
-		if requestedByID && !exactBinding {
+		identityBinding := reservation.ID > 0 && strings.TrimSpace(reservation.AgentName) == agentName &&
+			strings.TrimSpace(reservation.Reason) == reason
+		exactBinding := identityBinding && reservation.ProjectID == expectedProjectID
+		if requestedByID && !identityBinding {
 			return nil, nil, fmt.Errorf("reservation %d is not authoritatively bound to bead %s", reservation.ID, beadID)
 		}
 		if requestedByID && len(wantedPaths) > 0 && !requestedByPath {
@@ -619,14 +620,18 @@ func selectExactReleaseReservations(
 			strings.TrimSpace(reservation.AgentName) == agentName && strings.TrimSpace(reservation.Reason) == reason && reservation.ID <= 0 {
 			return nil, nil, fmt.Errorf("active reservation for path %q has no durable ID", path)
 		}
-		if exactBinding && requestedByPath {
+		if exactBinding && requestedByPath && !requestedByID {
 			matchesByPath[path] = append(matchesByPath[path], reservation.ID)
 		}
-		if requestedByID && exactBinding && len(wantedPaths) == 0 {
+		// A durable reservation ID plus the exact bead, agent, and path binding
+		// remains safe to release when the server reports a malformed project
+		// ID. Requiring the malformed field to agree made such rows permanent.
+		if requestedByID && identityBinding {
 			selectedIDs[reservation.ID] = struct{}{}
 			if path != "" {
 				selectedPaths[path] = struct{}{}
 			}
+			continue
 		}
 	}
 	for path := range wantedPaths {

--- a/internal/assign/reservation_test.go
+++ b/internal/assign/reservation_test.go
@@ -657,6 +657,36 @@ func TestReleaseExactForBeadRequiresDurableBarrier(t *testing.T) {
 	}
 }
 
+func TestReleaseExactForBeadReleasesDurablyBoundProjectMismatch(t *testing.T) {
+	releaseCalls := 0
+	server := newAssignMCPServer(t, map[string]assignToolHandler{
+		"list_file_reservations": func(map[string]interface{}) (interface{}, *agentmail.JSONRPCError) {
+			if releaseCalls > 0 {
+				return []agentmail.FileReservation{}, nil
+			}
+			reservation := reconcileReservation(142, "AgentOne", "internal/shared.go", "bead assignment: bd-release")
+			reservation.ProjectID = 0
+			return []agentmail.FileReservation{reservation}, nil
+		},
+		"release_file_reservations": func(args map[string]interface{}) (interface{}, *agentmail.JSONRPCError) {
+			releaseCalls++
+			ids, _ := args["file_reservation_ids"].([]interface{})
+			if len(ids) != 1 || int(ids[0].(float64)) != 142 {
+				t.Fatalf("release reservation IDs=%v, want [142]", ids)
+			}
+			return agentmail.ReleaseReservationsResult{Released: 1}, nil
+		},
+	})
+	defer server.Close()
+	manager := NewFileReservationManager(agentmail.NewClient(agentmail.WithBaseURL(server.URL+"/")), "/test/project")
+	released, err := manager.ReleaseExactForBead(
+		t.Context(), exactReleaseBarrier("bd-release", "AgentOne"), []int{142}, []string{"internal/shared.go"},
+	)
+	if err != nil || !reflect.DeepEqual(released, []string{"internal/shared.go"}) || releaseCalls != 1 {
+		t.Fatalf("project-mismatch release paths=%v calls=%d error=%v", released, releaseCalls, err)
+	}
+}
+
 func TestReconcileForBeadReturnsOnlyExactActiveLeases(t *testing.T) {
 	releasedAt := agentmail.FlexTime{Time: time.Now().UTC()}
 	manager := newReservationReconcileManager(t, []agentmail.FileReservation{

--- a/internal/assignment/atomic.go
+++ b/internal/assignment/atomic.go
@@ -719,7 +719,7 @@ func (c *AtomicCoordinator) Execute(ctx context.Context, req AtomicRequest) (Ato
 	}
 	if occupied != nil {
 		result.Assignment = occupied
-		return result, fmt.Errorf("%w: %s is owned by bead %s", ErrTargetOccupied, req.Target, occupied.BeadID)
+		return result, targetOccupiedError(req.Target, occupied, c.now())
 	}
 
 	prior := c.store.Get(req.BeadID)
@@ -974,6 +974,24 @@ func (c *AtomicCoordinator) Execute(ctx context.Context, req AtomicRequest) (Ato
 	result.Assignment = c.store.Get(req.BeadID)
 	result.Sent = true
 	return result, nil
+}
+
+func targetOccupiedError(target string, occupied *Assignment, now time.Time) error {
+	if occupied == nil {
+		return fmt.Errorf("%w: %s has an unknown owner", ErrTargetOccupied, target)
+	}
+	age := "unknown"
+	assignedAt := "unknown"
+	if !occupied.AssignedAt.IsZero() {
+		assignedAt = occupied.AssignedAt.UTC().Format(time.RFC3339)
+		elapsed := now.Sub(occupied.AssignedAt)
+		if elapsed < 0 {
+			elapsed = 0
+		}
+		age = elapsed.Truncate(time.Second).String()
+	}
+	return fmt.Errorf("%w: %s is owned by bead %s (status=%s, age=%s, assigned_at=%s)",
+		ErrTargetOccupied, target, occupied.BeadID, occupied.Status, age, assignedAt)
 }
 
 func assignmentEligibilityAuthorizationRequest(prior *Assignment, req AtomicRequest, actor string, replacementStart bool) AssignmentEligibilityAuthorizationRequest {
@@ -1391,7 +1409,6 @@ func (c *AtomicCoordinator) ensureReservation(ctx context.Context, req AtomicReq
 			return lease, recorded, fmt.Errorf("reconcile reservation for %s: invalid state %q", req.BeadID, reconciliation.State)
 		}
 	}
-
 	if c.reserver == nil {
 		if req.RequireReservation {
 			return lease, recorded, ErrReservationRequired

--- a/internal/assignment/atomic_test.go
+++ b/internal/assignment/atomic_test.go
@@ -1218,6 +1218,21 @@ func TestAtomicAssignmentCanonicalOccupancyRejectsSelectorAliases(t *testing.T) 
 	}
 }
 
+func TestTargetOccupiedErrorNamesStatusAndAge(t *testing.T) {
+	assignedAt := time.Date(2026, 9, 3, 10, 0, 0, 0, time.UTC)
+	err := targetOccupiedError("%42", &Assignment{
+		BeadID: "ntm-stale", Status: StatusCompleted, AssignedAt: assignedAt,
+	}, assignedAt.Add(90*time.Minute))
+	if !errors.Is(err, ErrTargetOccupied) {
+		t.Fatalf("targetOccupiedError()=%v, want ErrTargetOccupied", err)
+	}
+	for _, want := range []string{"owned by bead ntm-stale", "status=completed", "age=1h30m0s", "assigned_at=2026-09-03T10:00:00Z"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("targetOccupiedError()=%q, missing %q", err, want)
+		}
+	}
+}
+
 func TestAtomicAssignmentDispatchOnlyCanonicalIdentityOccupiesTarget(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	store := NewStore("atomic-dispatch-only-occupancy")

--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -68,6 +68,7 @@ var (
 	assignClear       string // Clear specific bead assignments (comma-separated)
 	assignClearPane   string // Clear all assignments for one canonical pane selector
 	assignClearFailed bool   // Clear all failed assignments
+	assignRetainClaim bool   // Retain the Beads claim while retiring terminal ledger rows
 
 	// Watch mode flags for continuous auto-assignment
 	assignWatch         bool          // Enable watch mode for continuous auto-assignment on completion
@@ -367,6 +368,7 @@ Examples:
   ntm assign myproject --clear-pane=3          # Clear all assignments for pane 3
   ntm assign myproject --clear-failed          # Clear all failed assignments
   ntm assign myproject --clear bd-123 --force  # Clear completed assignment
+  ntm assign myproject --clear-pane=3 --force --retain-claim # Retire terminal pane residue without reopening its bead
   ntm assign myproject --reassign bd-123 --to-pane=4   # Reassign to pane 4
   ntm assign myproject --reassign bd-123 --to-type=codex  # Reassign to idle codex
   ntm assign myproject --retry bd-123          # Retry failed bead bd-123
@@ -408,6 +410,7 @@ Examples:
 	cmd.Flags().StringVar(&assignClear, "clear", "", "Clear specific bead assignments (comma-separated bead IDs)")
 	cmd.Flags().StringVar(&assignClearPane, "clear-pane", "", "Clear all assignments for one pane (N, W.P, or %N; use when agent crashed)")
 	cmd.Flags().BoolVar(&assignClearFailed, "clear-failed", false, "Clear all failed assignments")
+	cmd.Flags().BoolVar(&assignRetainClaim, "retain-claim", false, "Keep the Beads claim when clearing terminal assignment rows")
 
 	// Watch mode flags
 	cmd.Flags().BoolVar(&assignWatch, "watch", false, "Enable watch mode for continuous auto-assignment on completion")
@@ -514,6 +517,9 @@ func isAutomatedAssignmentSafetyError(err error) bool {
 func prepareResolvedAssignCommand(cmd *cobra.Command, session, projectDir string) (handled bool, policyProject string, closeWebhook func() error, err error) {
 	if assignClear != "" || strings.TrimSpace(assignClearPane) != "" || assignClearFailed {
 		return true, "", nil, runClearAssignmentsForCommand(cmd, session)
+	}
+	if assignRetainClaim {
+		return false, "", nil, fmt.Errorf("%w: --retain-claim requires --clear, --clear-pane, or --clear-failed", errCLIInvalidInput)
 	}
 
 	if err := ensureAuthoritativeAssignmentPolicy(projectDir, &policyProject); err != nil {
@@ -3245,6 +3251,7 @@ type ClearAssignmentResult struct {
 	AssignmentFound          bool     `json:"assignment_found"`
 	FileReservationsReleased bool     `json:"file_reservations_released"`
 	FilesReleased            []string `json:"files_released,omitempty"`
+	ClaimRetained            bool     `json:"claim_retained,omitempty"`
 	Success                  bool     `json:"success"`
 	Error                    string   `json:"error,omitempty"`
 	ErrorCode                string   `json:"error_code,omitempty"`
@@ -3920,6 +3927,9 @@ func clearStoredAssignmentIfStatus(ctx context.Context, store *assignment.Assign
 		return nil, fmt.Errorf("assignment %s reached terminal status %s while waiting to clear", current.BeadID, refreshed.Status)
 	}
 	current = refreshed
+	if assignRetainClaim && !assignmentStatusIsTerminalForCleanup(current.Status) {
+		return nil, fmt.Errorf("--retain-claim requires a terminal assignment row; %s is %s", current.BeadID, current.Status)
+	}
 	if assignForce && current.DispatchState == assignment.DispatchSending && !IsJSONOutput() {
 		output.PrintWarningf(
 			"Force-clearing %s while its dispatch outcome is unknown: the original message may already have been delivered, so re-assigning can duplicate work. Verify pane %d before re-dispatching.",
@@ -3960,7 +3970,7 @@ func clearStoredAssignmentIfStatus(ctx context.Context, store *assignment.Assign
 			return released, fmt.Errorf("persist completed reservation release: %w", err)
 		}
 	}
-	if strings.TrimSpace(clearing.ClaimActor) != "" {
+	if strings.TrimSpace(clearing.ClaimActor) != "" && !assignRetainClaim {
 		projectDir, projectErr := resolveAssignProjectDir(ctx, session)
 		if projectErr != nil {
 			claimErr := fmt.Errorf("resolve project for Beads claim release: %w", projectErr)
@@ -4113,6 +4123,7 @@ func runClearSelectedAssignmentsFromStore(cmd *cobra.Command, store *assignment.
 			} else {
 				result.FilesReleased = releasedFiles
 				result.FileReservationsReleased = len(releasedFiles) > 0
+				result.ClaimRetained = assignRetainClaim && strings.TrimSpace(foundAssignment.ClaimActor) != ""
 				result.Success = true
 				successCount++
 			}
@@ -4176,7 +4187,11 @@ func runClearSelectedAssignmentsFromStore(cmd *cobra.Command, store *assignment.
 		fmt.Printf("Cleared %d of %d bead assignments:\n\n", successCount, len(beadIDs))
 		for _, result := range results {
 			if result.Success {
-				fmt.Printf("  ✓ %s (pane %d, %s)\n", result.BeadID, result.PreviousPane, result.PreviousAgentType)
+				claimNote := ""
+				if result.ClaimRetained {
+					claimNote = ", claim retained"
+				}
+				fmt.Printf("  ✓ %s (pane %d, %s%s)\n", result.BeadID, result.PreviousPane, result.PreviousAgentType, claimNote)
 				if len(result.FilesReleased) > 0 {
 					fmt.Printf("    Released files: %v\n", result.FilesReleased)
 				}
@@ -4334,6 +4349,7 @@ func runClearPaneAssignments(cmd *cobra.Command, session, selector string) error
 		} else {
 			beadResult.FilesReleased = releasedFiles
 			beadResult.FileReservationsReleased = len(releasedFiles) > 0
+			beadResult.ClaimRetained = assignRetainClaim && strings.TrimSpace(a.ClaimActor) != ""
 			beadResult.Success = true
 		}
 
@@ -4409,7 +4425,11 @@ func runClearPaneAssignments(cmd *cobra.Command, session, selector string) error
 			fmt.Printf("Cleared all assignments for pane %s (%s):\n\n", assignmentPaneTarget(targetPane), agentType)
 			for _, beadResult := range result.ClearedBeads {
 				if beadResult.Success {
-					fmt.Printf("  ✓ %s\n", beadResult.BeadID)
+					claimNote := ""
+					if beadResult.ClaimRetained {
+						claimNote = " (claim retained)"
+					}
+					fmt.Printf("  ✓ %s%s\n", beadResult.BeadID, claimNote)
 					if len(beadResult.FilesReleased) > 0 {
 						fmt.Printf("    Released files: %v\n", beadResult.FilesReleased)
 					}

--- a/internal/cli/assign_clear_test.go
+++ b/internal/cli/assign_clear_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -550,6 +551,85 @@ func TestRunClearFailedAssignmentsClearsOnlyFailedRows(t *testing.T) {
 	}
 }
 
+func TestClearTerminalAssignmentCanRetainBeadClaim(t *testing.T) {
+	isolateSessionAgentStorage(t)
+	const (
+		session = "clear-terminal-retain-claim"
+		beadID  = "ntm-terminal-retain-claim"
+	)
+	store := assignment.NewStore(session)
+	stored, err := store.Assign(beadID, "Terminal residue", 1, "codex", "BlueLake", "work")
+	if err != nil {
+		t.Fatalf("assign terminal row: %v", err)
+	}
+	stored.Status = assignment.StatusFailed
+	stored.ClaimActor = "BlueLake/ntm-retained"
+	store.Assignments[beadID] = stored
+	if err := store.Save(); err != nil {
+		t.Fatalf("save terminal row: %v", err)
+	}
+
+	previousRetain := assignRetainClaim
+	previousRelease := releaseAssignmentLeases
+	previousClaimRelease := releaseBeadClaimForAssignment
+	t.Cleanup(func() {
+		assignRetainClaim = previousRetain
+		releaseAssignmentLeases = previousRelease
+		releaseBeadClaimForAssignment = previousClaimRelease
+	})
+	assignRetainClaim = true
+	releaseAssignmentLeases = func(context.Context, string, *assignment.Assignment) ([]string, error) { return nil, nil }
+	releaseBeadClaimForAssignment = func(context.Context, string, string, string) (bool, error) {
+		t.Fatal("retain-claim clear released the Beads claim")
+		return false, nil
+	}
+
+	if _, err := clearStoredAssignment(t.Context(), store, session, store.Get(beadID)); err != nil {
+		t.Fatalf("clear terminal row while retaining claim: %v", err)
+	}
+	if got := store.Get(beadID); got != nil {
+		t.Fatalf("terminal residue still owns pane: %+v", got)
+	}
+}
+
+func TestRetainClaimRejectsNonterminalAssignment(t *testing.T) {
+	isolateSessionAgentStorage(t)
+	const (
+		session = "clear-working-retain-claim"
+		beadID  = "ntm-working-retain-claim"
+	)
+	store := assignment.NewStore(session)
+	stored, err := store.Assign(beadID, "Working assignment", 1, "codex", "BlueLake", "work")
+	if err != nil {
+		t.Fatalf("assign working row: %v", err)
+	}
+	stored.ClaimActor = "BlueLake/ntm-working"
+	store.Assignments[beadID] = stored
+	if err := store.Save(); err != nil {
+		t.Fatalf("save working row: %v", err)
+	}
+
+	previousRetain := assignRetainClaim
+	previousRelease := releaseAssignmentLeases
+	t.Cleanup(func() {
+		assignRetainClaim = previousRetain
+		releaseAssignmentLeases = previousRelease
+	})
+	assignRetainClaim = true
+	releaseAssignmentLeases = func(context.Context, string, *assignment.Assignment) ([]string, error) {
+		t.Fatal("nonterminal retain-claim crossed the release boundary")
+		return nil, nil
+	}
+
+	_, err = clearStoredAssignment(t.Context(), store, session, store.Get(beadID))
+	if err == nil || !strings.Contains(err.Error(), "requires a terminal assignment row") {
+		t.Fatalf("nonterminal retain-claim error=%v", err)
+	}
+	if got := store.Get(beadID); got == nil || got.ClearState != assignment.ClearStateNone {
+		t.Fatalf("nonterminal retain-claim mutated row: %+v", got)
+	}
+}
+
 func TestRunClearSelectedAssignmentsCanceledJSONIsTimeoutWithoutMutation(t *testing.T) {
 	isolateSessionAgentStorage(t)
 	const (
@@ -802,6 +882,14 @@ func TestAssignCommandHasClearFailedFlag(t *testing.T) {
 	flag := cmd.Flags().Lookup("clear-failed")
 	if flag == nil {
 		t.Fatal("Expected 'clear-failed' flag to exist")
+	}
+}
+
+func TestAssignCommandHasRetainClaimFlag(t *testing.T) {
+	cmd := newAssignCmd()
+	flag := cmd.Flags().Lookup("retain-claim")
+	if flag == nil || flag.DefValue != "false" {
+		t.Fatalf("--retain-claim flag = %+v", flag)
 	}
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -386,18 +386,22 @@ func runCoordinatorDigest(cmd *cobra.Command, args []string, sendMail bool) erro
 }
 
 type coordinatorRunOutput struct {
-	Success     bool                           `json:"success"`
-	Session     string                         `json:"session"`
-	Timestamp   string                         `json:"timestamp"`
-	Once        bool                           `json:"once"`
-	AutoAssign  bool                           `json:"auto_assign"`
-	Assignments []coordinator.AssignmentResult `json:"assignments"`
-	ErrorCode   string                         `json:"error_code,omitempty"`
-	Error       string                         `json:"error,omitempty"`
+	Success      bool                           `json:"success"`
+	Session      string                         `json:"session"`
+	Timestamp    string                         `json:"timestamp"`
+	Once         bool                           `json:"once"`
+	AutoAssign   bool                           `json:"auto_assign"`
+	ReserveFiles bool                           `json:"reserve_files"`
+	Assignments  []coordinator.AssignmentResult `json:"assignments"`
+	ErrorCode    string                         `json:"error_code,omitempty"`
+	Error        string                         `json:"error,omitempty"`
 }
 
 func newCoordinatorRunCmd() *cobra.Command {
-	var once bool
+	var (
+		once         bool
+		reserveFiles bool
+	)
 	cmd := &cobra.Command{
 		Use:   "run [session]",
 		Short: "Run the session coordinator until interrupted",
@@ -407,14 +411,15 @@ opt-in automatic assignment. The command exits cleanly on SIGINT or SIGTERM.
 Use --once to execute exactly one fresh observation and assignment cycle.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCoordinatorRun(cmd, args, once)
+			return runCoordinatorRun(cmd, args, once, reserveFiles)
 		},
 	}
 	cmd.Flags().BoolVar(&once, "once", false, "Run exactly one fresh coordinator cycle")
+	cmd.Flags().BoolVar(&reserveFiles, "reserve-files", true, "Reserve repository paths via Agent Mail before daemon assignment")
 	return cmd
 }
 
-func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
+func runCoordinatorRun(cmd *cobra.Command, args []string, once, reserveFiles bool) error {
 	var session string
 	if len(args) > 0 {
 		session = args[0]
@@ -443,6 +448,7 @@ func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
 	}
 
 	runtimeConfig, ntmConfig := loadCoordinatorRuntimeConfigWithNTM()
+	runtimeConfig.ReserveFiles = reserveFiles
 	mailClient := newAgentMailClient(projectKey)
 	coordName := resolveCoordinatorIdentity(cmd.Context(), mailClient, session, projectKey)
 	coord := coordinator.New(session, projectKey, mailClient, coordName).
@@ -453,7 +459,7 @@ func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
 		runErr := coordinatorRunFailure(assignments, cycleErr)
 		output := coordinatorRunOutput{
 			Success: runErr == nil, Session: session, Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
-			Once: true, AutoAssign: runtimeConfig.AutoAssign, Assignments: assignments,
+			Once: true, AutoAssign: runtimeConfig.AutoAssign, ReserveFiles: runtimeConfig.ReserveFiles, Assignments: assignments,
 		}
 		if runErr != nil {
 			output.ErrorCode = "ASSIGNMENT_FAILED"
@@ -488,13 +494,13 @@ func runCoordinatorRun(cmd *cobra.Command, args []string, once bool) error {
 	if jsonOutput {
 		output := coordinatorRunOutput{
 			Success: true, Session: session, Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
-			Once: false, AutoAssign: runtimeConfig.AutoAssign, Assignments: []coordinator.AssignmentResult{},
+			Once: false, AutoAssign: runtimeConfig.AutoAssign, ReserveFiles: runtimeConfig.ReserveFiles, Assignments: []coordinator.AssignmentResult{},
 		}
 		if err := json.NewEncoder(cmd.OutOrStdout()).Encode(output); err != nil {
 			return err
 		}
 	} else {
-		fmt.Fprintf(cmd.OutOrStdout(), "Coordinator running for %s (auto-assign=%t); press Ctrl-C to stop\n", session, runtimeConfig.AutoAssign)
+		fmt.Fprintf(cmd.OutOrStdout(), "Coordinator running for %s (auto-assign=%t, reserve-files=%t); press Ctrl-C to stop\n", session, runtimeConfig.AutoAssign, runtimeConfig.ReserveFiles)
 	}
 	<-cmd.Context().Done()
 	return nil
@@ -1063,6 +1069,7 @@ func coordinatorConfigFromTOML(toml config.CoordinatorConfig, fallback coordinat
 		AutoAssign:        toml.AutoAssign,
 		IdleThreshold:     toml.IdleThreshold,
 		AssignOnlyIdle:    toml.AssignOnlyIdle,
+		ReserveFiles:      fallback.ReserveFiles,
 		ConflictNotify:    toml.ConflictNotify,
 		ConflictNegotiate: toml.ConflictNegotiate,
 		SendDigests:       toml.SendDigests,

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -148,6 +148,9 @@ func TestCoordinatorRunCommandExposesDeterministicOnceMode(t *testing.T) {
 	if flag := cmd.Flags().Lookup("once"); flag == nil || flag.DefValue != "false" {
 		t.Fatalf("--once flag = %+v", flag)
 	}
+	if flag := cmd.Flags().Lookup("reserve-files"); flag == nil || flag.DefValue != "true" {
+		t.Fatalf("--reserve-files flag = %+v", flag)
+	}
 }
 
 func stubCoordinatorLiveTopology(t *testing.T, panes []tmux.Pane, paths map[string]string) {

--- a/internal/coordinator/assign.go
+++ b/internal/coordinator/assign.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -687,6 +688,10 @@ func (c *SessionCoordinator) attemptAssignment(ctx context.Context, assignment *
 	}
 	claimActor := assignmentstore.StableClaimActor(assignment.AgentMailName, idempotencyKey)
 	body := c.formatAssignmentMessage(assignment, rec, claimActor)
+	requestedPaths := repositoryReservationPaths(c.projectKey, assignment.FilesToReserve)
+	if !c.config.ReserveFiles {
+		requestedPaths = nil
+	}
 
 	store, err := assignmentstore.LoadStoreStrict(c.session)
 	if err != nil {
@@ -703,11 +708,47 @@ func (c *SessionCoordinator) attemptAssignment(ctx context.Context, assignment *
 		Actor:              assignment.AgentMailName,
 		Prompt:             body,
 		IdempotencyKey:     idempotencyKey,
-		RequireReservation: len(assignment.FilesToReserve) > 0,
-		RequestedPaths:     append([]string(nil), assignment.FilesToReserve...),
+		RequireReservation: len(requestedPaths) > 0,
+		RequestedPaths:     requestedPaths,
 		ReservationTTL:     time.Hour,
 	}
 	return c.executeAtomicAssignment(ctx, store, assignment, request)
+}
+
+// repositoryReservationPaths removes path-like prose before it reaches Agent
+// Mail. Concrete paths must exist under the repository; glob patterns must
+// have an existing literal repository prefix. This keeps rate expressions,
+// dates, ratios, and other slash-bearing title fragments out of reservations.
+func repositoryReservationPaths(projectKey string, candidates []string) []string {
+	root := filepath.Clean(strings.TrimSpace(projectKey))
+	if root == "" || root == "." {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(candidates))
+	paths := make([]string, 0, len(candidates))
+	for _, raw := range candidates {
+		candidate := filepath.Clean(strings.TrimSpace(raw))
+		if candidate == "" || candidate == "." || filepath.IsAbs(candidate) || candidate == ".." || strings.HasPrefix(candidate, ".."+string(filepath.Separator)) {
+			continue
+		}
+		prefix := candidate
+		if wildcard := strings.IndexAny(prefix, "*?["); wildcard >= 0 {
+			prefix = strings.TrimRight(prefix[:wildcard], string(filepath.Separator))
+			if prefix == "" {
+				prefix = "."
+			}
+		}
+		if _, err := os.Stat(filepath.Join(root, prefix)); err != nil {
+			continue
+		}
+		candidate = filepath.ToSlash(candidate)
+		if _, duplicate := seen[candidate]; duplicate {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		paths = append(paths, candidate)
+	}
+	return paths
 }
 
 func (c *SessionCoordinator) executeAtomicAssignment(ctx context.Context, store *assignmentstore.AssignmentStore, work *WorkAssignment, request assignmentstore.AtomicRequest) AssignmentResult {
@@ -1008,7 +1049,7 @@ func (c *SessionCoordinator) newAtomicAssignmentCoordinator(store *assignmentsto
 			BeadID: claim.ID, Actor: claim.Actor, Status: claim.Status, ClaimedAt: claim.ClaimedAt,
 		}, nil
 	})
-	reservationPort := &coordinatorAgentMailReservationPort{client: c.reservationClient, projectKey: agentmail.CanonicalProjectKey(c.projectKey)}
+	reservationPort := c.newCoordinatorReservationPort()
 	dispatchPort := assignmentstore.DispatchFunc(func(ctx context.Context, req assignmentstore.DispatchRequest) (assignmentstore.DispatchReceipt, error) {
 		started := time.Now()
 		project, err := c.mailClient.EnsureProject(ctx, c.projectKey)
@@ -1144,6 +1185,13 @@ func (c *SessionCoordinator) newAtomicAssignmentCoordinator(store *assignmentsto
 			},
 		)).
 		WithWorkingReplacementAuthorizationPort(replacementAuthorization)
+}
+
+func (c *SessionCoordinator) newCoordinatorReservationPort() assignmentstore.ReservationPort {
+	if !c.config.ReserveFiles {
+		return nil
+	}
+	return &coordinatorAgentMailReservationPort{client: c.reservationClient, projectKey: agentmail.CanonicalProjectKey(c.projectKey)}
 }
 
 // coordinatorMailDispatchError classifies an Agent Mail send failure for the
@@ -1611,6 +1659,12 @@ func ExtractMentionedFiles(title, description string) []string {
 // isFilePath checks if a string looks like a file path.
 func isFilePath(s string) bool {
 	if len(s) < 3 {
+		return false
+	}
+	// Slash-bearing quantities such as "13714/2m" and dates such as
+	// "2026/09/03" are prose, not repository paths. Extracted paths are also
+	// checked against the repository before any reservation request.
+	if s[0] >= '0' && s[0] <= '9' {
 		return false
 	}
 

--- a/internal/coordinator/assign_test.go
+++ b/internal/coordinator/assign_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -253,6 +255,12 @@ func TestAttemptAssignmentRequiresAgentMailIdentity(t *testing.T) {
 func TestAttemptAssignmentAtomicSuccessPersistsReceipt(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, "internal", "coordinator"), 0o755); err != nil {
+		t.Fatalf("create repository path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "internal", "coordinator", "assign.go"), []byte("package coordinator\n"), 0o600); err != nil {
+		t.Fatalf("write repository path: %v", err)
+	}
 	c := New("coordinator-atomic-success", projectDir, &agentmail.Client{}, "CoordinatorAgent")
 	var order []string
 	c.atomicCoordinatorFactory = func(store *assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
@@ -302,6 +310,49 @@ func TestAttemptAssignmentAtomicSuccessPersistsReceipt(t *testing.T) {
 	if stored == nil || stored.DispatchState != assignmentstore.DispatchSent || stored.DispatchReceiptID != "mail-91" ||
 		stored.ClaimActor != result.ClaimActor || stored.IdempotencyKey != result.IdempotencyKey || stored.OccupancyKey != "%9" {
 		t.Fatalf("durable coordinator assignment = %+v", stored)
+	}
+}
+
+func TestAttemptAssignmentCanDisableUnavailableReservations(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, "internal"), 0o755); err != nil {
+		t.Fatalf("create repository path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "internal", "daemon.go"), []byte("package internal\n"), 0o600); err != nil {
+		t.Fatalf("write repository path: %v", err)
+	}
+	c := New("coordinator-reservations-disabled", projectDir, &agentmail.Client{}, "CoordinatorAgent")
+	c.config.AutoAssign = true
+	c.config.ReserveFiles = false
+	c.reservationClient = &fakeCoordinatorReservationClient{ensureErr: errors.New("reservation service unavailable")}
+	var order []string
+	c.atomicCoordinatorFactory = func(store *assignmentstore.AssignmentStore) *assignmentstore.AtomicCoordinator {
+		claim := assignmentstore.ClaimFunc(func(_ context.Context, beadID, actor string) (assignmentstore.ClaimReceipt, error) {
+			order = append(order, "claim")
+			return assignmentstore.ClaimReceipt{BeadID: beadID, Actor: actor, Status: "in_progress", ClaimedAt: time.Now().UTC()}, nil
+		})
+		dispatch := assignmentstore.DispatchFunc(func(context.Context, assignmentstore.DispatchRequest) (assignmentstore.DispatchReceipt, error) {
+			order = append(order, "dispatch")
+			return assignmentstore.DispatchReceipt{DeliveryID: "mail-disabled-reservation"}, nil
+		})
+		return assignmentstore.NewAtomicCoordinator(store, claim, c.newCoordinatorReservationPort(), dispatch)
+	}
+	work := &WorkAssignment{
+		BeadID: "ntm-reservations-disabled", BeadTitle: "Daemon internal/daemon.go", AgentPaneID: "%19", AgentPaneIndex: 2,
+		AgentMailName: "BlueFox", AgentType: "cod", FilesToReserve: []string{"internal/daemon.go"},
+	}
+	result := c.attemptAssignment(t.Context(), work, &bv.TriageRecommendation{ID: work.BeadID, Title: work.BeadTitle})
+	if !result.Success || strings.Join(order, ",") != "claim,dispatch" || len(result.Reservations) != 0 {
+		t.Fatalf("reservations-disabled result=%+v order=%v", result, order)
+	}
+	record := assignmentstore.NewStore(c.session)
+	if err := record.LoadStrict(); err != nil {
+		t.Fatalf("load reservations-disabled ledger: %v", err)
+	}
+	stored := record.Get(work.BeadID)
+	if stored == nil || stored.ReservationRequired || len(stored.ReservationInputPaths) != 0 || stored.DispatchState != assignmentstore.DispatchSent {
+		t.Fatalf("reservations-disabled ledger=%+v", stored)
 	}
 }
 
@@ -2560,6 +2611,24 @@ func TestExtractMentionedFiles(t *testing.T) {
 	}
 }
 
+func TestRepositoryReservationPathsRequireRealRepositoryTargets(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {
+		t.Fatalf("create repository directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "internal", "real.go"), []byte("package internal\n"), 0o600); err != nil {
+		t.Fatalf("write repository file: %v", err)
+	}
+	candidates := ExtractMentionedFiles(
+		"iris pressure CRIT: allocstall 13714/2m for 2 samples; fix internal/real.go and missing/path.go",
+		"",
+	)
+	got := repositoryReservationPaths(root, candidates)
+	if !reflect.DeepEqual(got, []string{"internal/real.go"}) {
+		t.Fatalf("repository reservation paths=%v, want only the real repository file", got)
+	}
+}
+
 func TestIsFilePath(t *testing.T) {
 	tests := []struct {
 		input string
@@ -2570,6 +2639,7 @@ func TestIsFilePath(t *testing.T) {
 		{"pkg/**/*.ts", true},
 		{"README.md", true},
 		{".gitignore", true},
+		{"13714/2m", false},
 		{"hello", false},
 		{"the", false},
 		{"Fix", false},

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -135,6 +135,7 @@ type CoordinatorConfig struct {
 	AutoAssign     bool    `toml:"auto_assign"`      // Automatically assign work to idle agents
 	IdleThreshold  float64 `toml:"idle_threshold"`   // Seconds of inactivity before considering idle
 	AssignOnlyIdle bool    `toml:"assign_only_idle"` // Only assign to truly idle agents
+	ReserveFiles   bool    `toml:"-"`                // Reserve repository paths before daemon assignment
 
 	// Conflict handling
 	ConflictNotify    bool `toml:"conflict_notify"`    // Notify when conflicts detected
@@ -177,6 +178,7 @@ func DefaultCoordinatorConfig() CoordinatorConfig {
 		AutoAssign:        false, // Disabled by default - opt-in
 		IdleThreshold:     30.0,
 		AssignOnlyIdle:    true,
+		ReserveFiles:      true,
 		ConflictNotify:    true,
 		ConflictNegotiate: false, // Manual resolution by default
 		SendDigests:       false, // Disabled by default


### PR DESCRIPTION
## Summary

- add `ntm coordinator run --reserve-files=false` and bypass the reservation port when disabled
- filter coordinator reservation candidates to real repository paths, excluding slash-bearing prose such as `13714/2m`
- make occupied-pane diagnostics report the owning bead, status, age, and assignment time
- add terminal assignment cleanup with `ntm assign --retain-claim`, plus exact malformed-project reservation release by durable identity

## Verification

- `go test -short ./...`
- `go build ./cmd/ntm`
- `go vet ./...`
- `gofmt` and `git diff --check`

Agent Factory bead: agent-factory-yqu9