### PR TITLE
test(e2e): reap tmux fixtures leaked by a mid-run-killed test binary

### DIFF
--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -35,6 +35,17 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// Self-heal against leaks from a prior run that was killed mid-test. A
+	// SIGKILL (interrupted suite, OOM, host reboot) runs neither t.Cleanup nor
+	// the isolation cleanup above, so that run's detached tmux server and its
+	// "ntm-tmux-test-*" socket dir survive and accumulate. Reaping past a
+	// conservative age here bounds that accumulation; the age guard keeps a
+	// concurrent in-flight run — and the socket root this process just isolated
+	// for itself — untouched.
+	if reaped := testutil.ReapStaleTmuxTestServers(staleTmuxReapAge()); reaped > 0 {
+		fmt.Fprintf(os.Stderr, "E2E: reaped %d leaked tmux test server dir(s) from an earlier interrupted run\n", reaped)
+	}
+
 	bin, err := ensureE2ENTMBin()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "E2E: failed to resolve/build ntm: %v\n", err)
@@ -62,6 +73,21 @@ func TestMain(m *testing.M) {
 		code = 1
 	}
 	os.Exit(code)
+}
+
+// staleTmuxReapAge is the minimum age a leaked tmux test socket dir must reach
+// before the startup reaper removes it. The default is deliberately generous so
+// a slow but live e2e run is never mistaken for a leak; override with
+// NTM_E2E_TMUX_REAP_MIN (minutes) on a host that needs a tighter or looser floor.
+func staleTmuxReapAge() time.Duration {
+	const defaultMinutes = 30
+	minutes := defaultMinutes
+	if v := strings.TrimSpace(os.Getenv("NTM_E2E_TMUX_REAP_MIN")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			minutes = n
+		}
+	}
+	return time.Duration(minutes) * time.Minute
 }
 
 func ensureE2ENTMBin() (string, error) {

--- a/e2e/tmux_teardown_e2e_test.go
+++ b/e2e/tmux_teardown_e2e_test.go
@@ -1,0 +1,41 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/Dicklesworthstone/ntm/tests/testutil"
+)
+
+// TestNoOrphanTmuxSessionSurvivesCompletedRun pins AC2 for the normal
+// completion path: the harness registers a kill-session cleanup and Close runs
+// it on both the pass and the fail path, so no ntm-e2e-* tmux session may
+// outlive a completed e2e run. The mid-run-kill case (a SIGKILLed binary that
+// runs no cleanup) is covered separately by the TestMain startup reaper and its
+// unit test testutil.TestReapStaleTmuxTestServersRemovesLeakedServerButSparesFresh.
+func TestNoOrphanTmuxSessionSurvivesCompletedRun(t *testing.T) {
+	testutil.RequireTmuxThrottled(t)
+
+	h, err := NewScenarioHarness(t, HarnessOptions{Scenario: "tmux-teardown", Retain: RetainNever})
+	if err != nil {
+		t.Fatalf("new scenario harness: %v", err)
+	}
+	if err := h.SetupTmuxSession(TmuxSessionOptions{}); err != nil {
+		t.Fatalf("setup tmux session: %v", err)
+	}
+
+	session := h.SessionName()
+	if !testutil.SessionExists(session) {
+		t.Fatalf("precondition: session %q should exist after setup", session)
+	}
+
+	// Close is idempotent (guarded by closeOnce) and also runs via tb.Cleanup;
+	// calling it here lets the assertion observe the completed-run teardown.
+	h.Close()
+
+	if testutil.SessionExists(session) {
+		t.Errorf("ntm-e2e session %q survived a completed run", session)
+	}
+}

--- a/tests/testutil/reap_test.go
+++ b/tests/testutil/reap_test.go
@@ -1,0 +1,86 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func isolatedTmuxSessionExists(bin, socketDir, session string) bool {
+	cmd := exec.Command(bin, "has-session", "-t", session)
+	cmd.Env = isolatedTmuxEnvironment(socketDir)
+	return cmd.Run() == nil
+}
+
+func startIsolatedTmuxSession(t *testing.T, bin, socketDir, session string) {
+	t.Helper()
+	cmd := exec.Command(bin, "new-session", "-d", "-s", session, "-x", "80", "-y", "24")
+	cmd.Env = isolatedTmuxEnvironment(socketDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("start isolated tmux session %q: %v: %s", session, err, out)
+	}
+}
+
+// TestReapStaleTmuxTestServersRemovesLeakedServerButSparesFresh exercises the
+// startup reaper the e2e TestMain relies on: a socket dir older than the floor,
+// with a live ntm-e2e-* server on it, is killed and removed; a freshly created
+// one is left alone. This is the AC2 invariant for the mid-run-kill case — no
+// ntm-e2e-* session survives past the reap floor — and pins the age guard that
+// keeps a concurrent in-flight run safe.
+func TestReapStaleTmuxTestServersRemovesLeakedServerButSparesFresh(t *testing.T) {
+	RequireTmux(t)
+	bin := findSystemTmuxBinary()
+	if bin == "" {
+		t.Skip("no system tmux binary available")
+	}
+
+	// A leaked server: real ntm-e2e-* session whose socket dir has aged past the floor.
+	staleDir, err := createShortTmuxTempDir()
+	if err != nil {
+		t.Fatalf("create stale socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(staleDir) })
+	const staleSession = "ntm-e2e-reap-stale"
+	startIsolatedTmuxSession(t, bin, staleDir, staleSession)
+	if !isolatedTmuxSessionExists(bin, staleDir, staleSession) {
+		t.Fatalf("precondition: stale session should exist before reaping")
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(staleDir, old, old); err != nil {
+		t.Fatalf("age the stale socket dir: %v", err)
+	}
+
+	// A fresh server: created just now; the age guard must spare it.
+	freshDir, err := createShortTmuxTempDir()
+	if err != nil {
+		t.Fatalf("create fresh socket dir: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command(bin, "kill-server")
+		cmd.Env = isolatedTmuxEnvironment(freshDir)
+		_ = cmd.Run()
+		_ = os.RemoveAll(freshDir)
+	})
+	const freshSession = "ntm-e2e-reap-fresh"
+	startIsolatedTmuxSession(t, bin, freshDir, freshSession)
+
+	reaped := ReapStaleTmuxTestServers(time.Hour)
+	if reaped < 1 {
+		t.Fatalf("expected the reaper to remove at least the aged socket dir, got %d", reaped)
+	}
+
+	if isolatedTmuxSessionExists(bin, staleDir, staleSession) {
+		t.Errorf("stale ntm-e2e session %q survived the reaper", staleSession)
+	}
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Errorf("stale socket dir was not removed (stat err = %v)", err)
+	}
+
+	if _, err := os.Stat(freshDir); err != nil {
+		t.Errorf("fresh socket dir was removed despite the age guard: %v", err)
+	}
+	if !isolatedTmuxSessionExists(bin, freshDir, freshSession) {
+		t.Errorf("fresh ntm-e2e session %q was killed despite the age guard", freshSession)
+	}
+}

--- a/tests/testutil/throttle.go
+++ b/tests/testutil/throttle.go
@@ -274,6 +274,67 @@ func ShortTmuxTempDir(t *testing.T) string {
 	return dir
 }
 
+// ReapStaleTmuxTestServers kills isolated tmux test servers that leaked from a
+// test binary killed mid-run. On a normal pass or fail the per-test cleanup and
+// the TestMain cleanup stop each private server and remove its socket root, but
+// a SIGKILL — an interrupted suite, an OOM, a host reboot — runs neither, so the
+// detached tmux server and its "ntm-tmux-test-*" socket directory survive and
+// accumulate. On a small-core host each leaked server is a standing contribution
+// to process count and load, on exactly the metric that gates test parallelism,
+// and it grows with every run.
+//
+// Every isolated server keeps its socket under a "ntm-tmux-test-*" directory in
+// one of the short candidate bases: the process-wide server from
+// IsolateTmuxTestProcess and every per-fixture server from ShortTmuxTempDir
+// alike. This scans those same bases and, for each such directory whose mtime is
+// older than minAge, kills the server on that socket and removes the directory.
+// The age guard is load-bearing: a concurrent in-flight run's socket root is
+// recent, so it — and the socket root this process just created for itself — is
+// never touched. Call it from a package TestMain before m.Run() so leaks cannot
+// accumulate across runs. It is best-effort by design: it never fails a suite,
+// and returns the number of socket directories it removed.
+func ReapStaleTmuxTestServers(minAge time.Duration) int {
+	prefix := strings.TrimSuffix(tmuxTempDirPattern, "*")
+	bin := findSystemTmuxBinary()
+	now := time.Now()
+	reaped := 0
+	seen := make(map[string]struct{})
+	for _, candidate := range shortTmuxTempDirCandidates() {
+		entries, err := os.ReadDir(candidate.path)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+				continue
+			}
+			dir := filepath.Join(candidate.path, entry.Name())
+			if _, dup := seen[dir]; dup {
+				continue
+			}
+			seen[dir] = struct{}{}
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			if now.Sub(info.ModTime()) < minAge {
+				continue // recent — may belong to an in-flight run
+			}
+			if bin != "" {
+				ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+				cmd := exec.CommandContext(ctx, bin, "kill-server")
+				cmd.Env = isolatedTmuxEnvironment(dir)
+				_ = cmd.Run() // best-effort; a dead or empty socket yields "no server"
+				cancel()
+			}
+			if err := os.RemoveAll(dir); err == nil {
+				reaped++
+			}
+		}
+	}
+	return reaped
+}
+
 func createShortTmuxTempDir() (string, error) {
 	return createShortTmuxTempDirFromCandidates(shortTmuxTempDirCandidates())
 }


### PR DESCRIPTION
## Problem

ntm's e2e tests isolate every tmux server under a private `ntm-tmux-test-*` `TMUX_TMPDIR` — the process-wide one from `IsolateTmuxTestProcess` and each per-fixture one from `ShortTmuxTempDir`. On a normal pass or fail, the per-test cleanup and the `TestMain` cleanup stop the server and remove its socket dir.

But when the test binary is **killed mid-run** — an interrupted suite, an OOM, a host reboot — neither runs. A tmux server is a detached process with its own socket, so it survives, along with its `ntm-tmux-test-*` socket dir, and these **accumulate without bound** across runs. On a small-core CI/agent host each leaked server is a standing contribution to process count and load — the very metric that gates test parallelism — and it grows with every run. (Measured on one 4-core host: dozens of leaked `ntm-e2e-*` servers, oldest 9h.)

## Fix

A process cannot clean up after its own `SIGKILL`, so the next run self-heals. `testutil.ReapStaleTmuxTestServers(minAge)` scans the same short candidate bases for `ntm-tmux-test-*` dirs older than a floor, kills the server on each socket (via `kill-server` with that `TMUX_TMPDIR`), and removes the dir. The e2e `TestMain` calls it before `m.Run()` (default floor 30m, override `NTM_E2E_TMUX_REAP_MIN` minutes).

The **age guard is load-bearing**: a concurrent in-flight run's socket root is recent, so it — and the root this process just isolated for itself — is never touched.

## Tests

- `testutil.TestReapStaleTmuxTestServersRemovesLeakedServerButSparesFresh`: a stale `ntm-e2e-*` server (aged socket dir) is killed and its dir removed, while a freshly created one is spared — the mid-run-kill case and the age guard.
- e2e-tagged `TestNoOrphanTmuxSessionSurvivesCompletedRun`: pins the completed-run invariant that no `ntm-e2e-*` session outlives a harness `Close`.

`go test ./tests/testutil/` green; `go vet -tags e2e ./e2e/` clean.

Refs: agent-factory-0j46