### PR TITLE
feat(assign): report per-pane placeability instead of one opaque "no idle agents"

### DIFF
--- a/internal/cli/assign.go
+++ b/internal/cli/assign.go
@@ -1212,9 +1212,92 @@ type AssignOutputEnhanced struct {
 	Strategy    string                `json:"strategy"`
 	Assignments []AssignmentItem      `json:"assignments"`
 	Skipped     []SkippedItem         `json:"skipped"`
+	AgentPool   []AgentPoolEntry      `json:"agent_pool,omitempty"`
 	Summary     AssignSummaryEnhanced `json:"summary"`
 	Allocation  *AssignAllocationView `json:"allocation,omitempty"`
 	Errors      []string              `json:"-"`
+}
+
+// Placeability reasons. An empty Reason on a placeable entry is the only
+// combination that means "this pane can receive work right now".
+const (
+	AgentPoolReasonAgentTypeFiltered     = "agent_type_filtered"
+	AgentPoolReasonHoldsActiveAssignment = "holds_active_assignment"
+	AgentPoolReasonObservationStale      = "observation_stale"
+	AgentPoolReasonObservationError      = "observation_error"
+	AgentPoolReasonLowConfidence         = "low_confidence"
+	AgentPoolReasonStateNotIdle          = "state_not_idle"
+	AgentPoolReasonRoleIneligible        = "role_ineligible_for_template"
+)
+
+// AgentPoolEntry is one pane's placeability verdict, reported alongside its
+// activity state. `state` answers "what is this agent doing?"; `placeable`
+// answers "can I dispatch here?". Those are different questions, and a
+// consumer that infers the second from the first gets it wrong for every
+// state that is neither clearly working nor clearly idle. Reporting both
+// keeps the activity enum free to describe activity.
+type AgentPoolEntry struct {
+	PaneID     string  `json:"pane_id"`
+	PaneTarget string  `json:"pane_target,omitempty"`
+	AgentType  string  `json:"agent_type"`
+	State      string  `json:"state,omitempty"`
+	Confidence float64 `json:"confidence,omitempty"`
+	Freshness  string  `json:"freshness,omitempty"`
+	Placeable  bool    `json:"placeable"`
+	// Reason is empty when Placeable is true, and otherwise names the single
+	// gate that rejected this pane, in evaluation order.
+	Reason string `json:"reason,omitempty"`
+}
+
+// dispatchRejectionReason names the first SafeToDispatch condition a pane
+// fails. It mirrors status.PaneObservation.SafeToDispatch exactly; if that
+// predicate gains a clause, this must gain a matching case.
+func dispatchRejectionReason(p statuspkg.PaneObservation) string {
+	switch {
+	case p.Current.Freshness != statuspkg.FreshnessFresh:
+		return AgentPoolReasonObservationStale
+	case p.Current.Error != "":
+		return AgentPoolReasonObservationError
+	case !statuspkg.ObservationConfidenceIsActionable(p.Current.Confidence):
+		return AgentPoolReasonLowConfidence
+	case p.Current.Status.State != statuspkg.StateIdle:
+		return AgentPoolReasonStateNotIdle
+	case p.SafeToDispatch():
+		return ""
+	default:
+		// Every clause above passed and SafeToDispatch still refused, so it
+		// has grown a condition this function does not know about. Say that
+		// rather than reporting a pane as rejected for no reason; the
+		// agreement test fails on this value.
+		return "unknown"
+	}
+}
+
+// markRoleGatedPool records the panes that cleared dispatch but were then
+// dropped by persona role gating, which is otherwise invisible to an operator
+// reading a zero idle-agent count.
+func markRoleGatedPool(pool []AgentPoolEntry, before, after []assignAgentInfo, template string) []AgentPoolEntry {
+	if len(before) == len(after) {
+		return pool
+	}
+	survived := make(map[string]struct{}, len(after))
+	for _, agent := range after {
+		survived[agent.pane.ID] = struct{}{}
+	}
+	for i := range pool {
+		if !pool[i].Placeable {
+			continue
+		}
+		if _, ok := survived[pool[i].PaneID]; ok {
+			continue
+		}
+		pool[i].Placeable = false
+		pool[i].Reason = AgentPoolReasonRoleIneligible
+		if template != "" {
+			pool[i].Reason += " (" + template + ")"
+		}
+	}
+	return pool
 }
 
 // AssignmentItem represents a single assignment in JSON output.
@@ -1697,19 +1780,45 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 		return nil, err
 	}
 
+	// agentPool records one placeability verdict per pane so an operator can
+	// see WHY a pane was excluded. "Not placeable" is a conjunction of several
+	// independent gates; reporting only the count collapses them into a single
+	// opaque word and leaves "the seats are busy" as the natural (and often
+	// wrong) reading.
+	var agentPool []AgentPoolEntry
 	for _, pane := range panes {
 		at := agentTypeForPane(pane)
+		entry := AgentPoolEntry{
+			PaneID:     pane.ID,
+			PaneTarget: assignmentPaneTarget(pane),
+			AgentType:  at,
+		}
+
 		if at == "user" || at == "unknown" {
+			// Not an agent pane at all; not part of the pool.
 			continue
 		}
 
 		// Apply agent type filter
 		if opts.AgentTypeFilter != "" && at != opts.AgentTypeFilter {
+			entry.Reason = AgentPoolReasonAgentTypeFiltered
+			agentPool = append(agentPool, entry)
 			continue
 		}
 
-		// Skip panes that already hold an active assignment.
+		// Skip panes that already hold an active assignment. Report the
+		// observed state anyway, best-effort and without the error path that
+		// would abort the command: "idle AND fenced by an assignment" is the
+		// signature of a leaked claim on an otherwise free pane, and it is
+		// indistinguishable from "busy" without that state.
 		if assignmentPaneIsActive(activePanes, pane) {
+			entry.Reason = AgentPoolReasonHoldsActiveAssignment
+			if observed, ok := observation.PaneByID(pane.ID); ok {
+				entry.State = string(observed.Current.Status.State)
+				entry.Confidence = observed.Current.Confidence
+				entry.Freshness = string(observed.Current.Freshness)
+			}
+			agentPool = append(agentPool, entry)
 			continue
 		}
 
@@ -1719,8 +1828,13 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 		}
 		model := detectModelFromTitle(at, pane.Title)
 		state := string(paneObservation.Current.Status.State)
+		entry.State = state
+		entry.Confidence = paneObservation.Current.Confidence
+		entry.Freshness = string(paneObservation.Current.Freshness)
 
 		if paneObservation.SafeToDispatch() {
+			entry.Placeable = true
+			agentPool = append(agentPool, entry)
 			idleAgents = append(idleAgents, assignAgentInfo{
 				pane:       pane,
 				agentType:  at,
@@ -1728,7 +1842,10 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 				state:      state,
 				scrollback: paneObservation.RawOutput,
 			})
+			continue
 		}
+		entry.Reason = dispatchRejectionReason(paneObservation)
+		agentPool = append(agentPool, entry)
 	}
 
 	// Get beads from bv. Source candidates from the FULL dependency-aware
@@ -1834,15 +1951,18 @@ func getAssignOutputEnhanced(ctx context.Context, opts *AssignCommandOptions) (*
 
 	// Persona role gating: reviewer-only panes never receive impl work and
 	// implementer-only panes never receive review work.
-	idleAgents, err = assignRoleEligibleAgents(idleAgents, projectDir, opts.Template)
+	roleEligible, err := assignRoleEligibleAgents(idleAgents, projectDir, opts.Template)
 	if err != nil {
 		return nil, err
 	}
+	agentPool = markRoleGatedPool(agentPool, idleAgents, roleEligible, opts.Template)
+	idleAgents = roleEligible
 
 	result := &AssignOutputEnhanced{
 		Strategy:    opts.Strategy,
 		Assignments: make([]AssignmentItem, 0),
 		Skipped:     allSkipped, // Blocked + cyclic beads
+		AgentPool:   agentPool,
 		Summary: AssignSummaryEnhanced{
 			TotalBeadCount:  len(readyBeads) + len(blockedBeads) + cycleWarnings,
 			ActionableCount: len(readyBeads),
@@ -2514,13 +2634,25 @@ func displayAssignOutputEnhanced(out *AssignOutputEnhanced, verbose bool) {
 			}
 			fmt.Println()
 		}
+		if verbose {
+			printAgentPool(out.AgentPool, subtitleStyle)
+		}
 	} else {
 		fmt.Println()
 		fmt.Println(subtitleStyle.Render("No assignments to recommend."))
 		if out.Summary.IdleAgents == 0 {
-			fmt.Println(subtitleStyle.Render("  Reason: No idle agents available"))
+			fmt.Println(subtitleStyle.Render("  Reason: No placeable agents available"))
+			// Always show the per-pane breakdown here. "No idle agents" reads
+			// as "the seats are busy", and that is only one of the reasons a
+			// pane can be excluded. An operator looking at panes that visibly
+			// sit at an empty prompt needs the gate that actually rejected
+			// them, not a count.
+			printAgentPool(out.AgentPool, subtitleStyle)
 		} else if out.Summary.TotalBeadCount == 0 {
 			fmt.Println(subtitleStyle.Render("  Reason: No ready beads to assign"))
+			if verbose {
+				printAgentPool(out.AgentPool, subtitleStyle)
+			}
 		}
 	}
 
@@ -7045,3 +7177,34 @@ func dispatchPromptHash(prompt string) string {
 }
 
 // runWatchMode implements the --watch flag for continuous auto-assignment
+
+// printAgentPool renders one line per candidate pane with its placeability
+// verdict. Panes that are not agent panes at all are absent from the pool.
+func printAgentPool(pool []AgentPoolEntry, style lipgloss.Style) {
+	if len(pool) == 0 {
+		fmt.Println(style.Render("  Agent pool: no agent panes found in this session"))
+		return
+	}
+	fmt.Println(style.Render("  Agent pool:"))
+	for _, entry := range pool {
+		verdict := "NOT PLACEABLE"
+		detail := entry.Reason
+		if entry.Placeable {
+			verdict = "PLACEABLE"
+			detail = ""
+		}
+		line := fmt.Sprintf("    %-6s %-8s state=%-8s conf=%.2f %s",
+			entry.PaneID, entry.AgentType, valueOrDash(entry.State), entry.Confidence, verdict)
+		if detail != "" {
+			line += "  (" + detail + ")"
+		}
+		fmt.Println(style.Render(line))
+	}
+}
+
+func valueOrDash(v string) string {
+	if v == "" {
+		return "-"
+	}
+	return v
+}

--- a/internal/cli/assign_agent_pool_test.go
+++ b/internal/cli/assign_agent_pool_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	statuspkg "github.com/Dicklesworthstone/ntm/internal/status"
+	"github.com/Dicklesworthstone/ntm/internal/tmux"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func freshObservation(state statuspkg.AgentState, confidence float64) statuspkg.PaneObservation {
+	return statuspkg.PaneObservation{
+		Current: statuspkg.StateObservation{
+			Status:     statuspkg.AgentStatus{State: state},
+			ObservedAt: time.Now(),
+			Freshness:  statuspkg.FreshnessFresh,
+			Confidence: confidence,
+		},
+	}
+}
+
+// dispatchRejectionReason must agree with SafeToDispatch on every input: a pane
+// it calls placeable must have no reason, and a rejected pane must never be
+// reported as rejected for "unknown".
+func TestDispatchRejectionReasonAgreesWithSafeToDispatch(t *testing.T) {
+	cases := []struct {
+		name       string
+		observed   statuspkg.PaneObservation
+		wantReason string
+	}{
+		{"idle and confident is placeable", freshObservation(statuspkg.StateIdle, 0.95), ""},
+		{"working is not idle", freshObservation(statuspkg.StateWorking, 0.95), AgentPoolReasonStateNotIdle},
+		{"unknown is not idle", freshObservation(statuspkg.StateUnknown, 0.95), AgentPoolReasonStateNotIdle},
+		{"error state is not idle", freshObservation(statuspkg.StateError, 0.95), AgentPoolReasonStateNotIdle},
+		{"low confidence is rejected before state", freshObservation(statuspkg.StateIdle, 0.5), AgentPoolReasonLowConfidence},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dispatchRejectionReason(tc.observed)
+			safe := tc.observed.SafeToDispatch()
+			if safe && got != "" {
+				t.Fatalf("pane is SafeToDispatch but reported reason %q", got)
+			}
+			if !safe && got == "" {
+				t.Fatal("pane is not SafeToDispatch but reported no reason")
+			}
+			if got == "unknown" {
+				t.Fatal("dispatchRejectionReason fell through: it disagrees with SafeToDispatch")
+			}
+			if tc.wantReason != "" && got != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", got, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestDispatchRejectionReasonReportsStaleAndErrored(t *testing.T) {
+	stale := freshObservation(statuspkg.StateIdle, 0.95)
+	stale.Current.Freshness = statuspkg.FreshnessStale
+	if got := dispatchRejectionReason(stale); got != AgentPoolReasonObservationStale {
+		t.Fatalf("stale reason = %q, want %q", got, AgentPoolReasonObservationStale)
+	}
+
+	errored := freshObservation(statuspkg.StateIdle, 0.95)
+	errored.Current.Error = "capture failed"
+	if got := dispatchRejectionReason(errored); got != AgentPoolReasonObservationError {
+		t.Fatalf("errored reason = %q, want %q", got, AgentPoolReasonObservationError)
+	}
+}
+
+// A pane dropped by persona role gating must be reported as role-gated rather
+// than silently vanishing from a pool that still calls it placeable.
+func TestMarkRoleGatedPoolNamesTheDroppedPane(t *testing.T) {
+	pool := []AgentPoolEntry{
+		{PaneID: "%11", AgentType: "claude", State: "idle", Placeable: true},
+		{PaneID: "%12", AgentType: "codex", State: "idle", Placeable: true},
+	}
+	before := []assignAgentInfo{
+		{pane: tmux.Pane{ID: "%11"}},
+		{pane: tmux.Pane{ID: "%12"}},
+	}
+	after := []assignAgentInfo{{pane: tmux.Pane{ID: "%12"}}}
+
+	got := markRoleGatedPool(pool, before, after, "review")
+
+	if got[0].Placeable {
+		t.Fatal("%11 was dropped by role gating but is still reported placeable")
+	}
+	if !strings.HasPrefix(got[0].Reason, AgentPoolReasonRoleIneligible) {
+		t.Fatalf("%%11 reason = %q, want the role-ineligible reason", got[0].Reason)
+	}
+	if !strings.Contains(got[0].Reason, "review") {
+		t.Fatalf("%%11 reason = %q, want the template named", got[0].Reason)
+	}
+	if !got[1].Placeable || got[1].Reason != "" {
+		t.Fatalf("%%12 survived role gating but was marked %+v", got[1])
+	}
+}
+
+func TestMarkRoleGatedPoolLeavesPoolAloneWhenNothingWasDropped(t *testing.T) {
+	pool := []AgentPoolEntry{{PaneID: "%11", Placeable: true}}
+	agents := []assignAgentInfo{{pane: tmux.Pane{ID: "%11"}}}
+	got := markRoleGatedPool(pool, agents, agents, "impl")
+	if !got[0].Placeable || got[0].Reason != "" {
+		t.Fatalf("unchanged pool was mutated: %+v", got[0])
+	}
+}
+
+// A pane already excluded for another reason must keep that reason; role gating
+// only explains panes that cleared dispatch.
+func TestMarkRoleGatedPoolKeepsTheEarlierReason(t *testing.T) {
+	pool := []AgentPoolEntry{
+		{PaneID: "%11", Placeable: false, Reason: AgentPoolReasonStateNotIdle},
+		{PaneID: "%12", Placeable: true},
+	}
+	before := []assignAgentInfo{{pane: tmux.Pane{ID: "%12"}}}
+	after := []assignAgentInfo{}
+	got := markRoleGatedPool(pool, before, after, "")
+	if got[0].Reason != AgentPoolReasonStateNotIdle {
+		t.Fatalf("%%11 reason = %q, want it preserved", got[0].Reason)
+	}
+	if got[1].Reason != AgentPoolReasonRoleIneligible {
+		t.Fatalf("%%12 reason = %q, want %q", got[1].Reason, AgentPoolReasonRoleIneligible)
+	}
+}
+
+// The zero-placeable path must name the gate per pane. This is the whole point
+// of the change: "no idle agents" reads as "the seats are busy", which is only
+// one of the reasons a pane can be excluded.
+func TestDisplayNamesEveryExclusionGate(t *testing.T) {
+	out := &AssignOutputEnhanced{
+		Strategy: "balanced",
+		AgentPool: []AgentPoolEntry{
+			{PaneID: "%11", AgentType: "claude", Placeable: false, Reason: AgentPoolReasonHoldsActiveAssignment},
+			{PaneID: "%12", AgentType: "claude", State: "working", Confidence: 0.95, Placeable: false, Reason: AgentPoolReasonStateNotIdle},
+		},
+		Summary: AssignSummaryEnhanced{IdleAgents: 0, ActionableCount: 41},
+	}
+	fetch := captureStdoutForTest(t)
+	displayAssignOutputEnhanced(out, false)
+	rendered := fetch()
+
+	if strings.Contains(rendered, "No idle agents available") {
+		t.Fatal("output still says 'No idle agents available', which misreports non-busy exclusions")
+	}
+	for _, want := range []string{"%11", "%12", AgentPoolReasonHoldsActiveAssignment, AgentPoolReasonStateNotIdle} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("output is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestPrintAgentPoolReportsAnEmptyPool(t *testing.T) {
+	fetch := captureStdoutForTest(t)
+	printAgentPool(nil, lipgloss.NewStyle())
+	rendered := fetch()
+	if !strings.Contains(rendered, "no agent panes found") {
+		t.Fatalf("empty pool was not explained:\n%s", rendered)
+	}
+}


### PR DESCRIPTION
## The problem

When `ntm assign` finds nothing to place, it says one thing:

```
Idle Agents: 0 | Actionable Beads: 41

No assignments to recommend.
  Reason: No idle agents available
```

and stamps every skipped bead `no_idle_agents`.

But "not placeable" is a conjunction of six independent gates evaluated in
`getAssignOutputEnhanced`:

1. the pane is not an agent pane (`user` / `unknown`)
2. `--to` agent-type filter excluded it
3. it holds an active assignment (`assignmentPaneIsActive`)
4. `SafeToDispatch()` refused it — stale observation, observation error,
   confidence below `minimumDispatchConfidence`, or state != `StateIdle`
5. persona role gating dropped it (`assignRoleEligibleAgents`)

All six collapse into one word, and that word is the wrong one. "No idle
agents available" reads as *the seats are busy*. Only gate 4's state clause
means that. Gates 3 and 5 fire on panes that are sitting at an empty prompt
right now, and the operator has no way to tell which case they are in.

The failure mode this cost us: an operator watching two agent panes render a
settled, empty prompt, with `ntm activity` reporting them `WAITING` at
confidence 0.90, while `ntm assign --dry-run --verbose` reported
`Idle Agents: 0` and skipped 24 beads `no_idle_agents`. Three sources said
available; the assigner said zero; nothing in the output connected them. The
natural conclusion — "the assigner must exclude `WAITING` from its idle set" —
is wrong (see the naming note below), and chasing it cost hours. The panes were
fenced by assignment records, which no output mentioned.

## The change

Carry one placeability verdict per pane through the assignment path and report
it, in both human and JSON output. No behavior change: the same panes are
placed, for the same reasons.

New `AgentPoolEntry` on `AssignOutputEnhanced`:

```json
{
  "pane_id": "%11",
  "pane_target": "1.2",
  "agent_type": "claude",
  "state": "idle",
  "confidence": 0.95,
  "freshness": "fresh",
  "placeable": false,
  "reason": "holds_active_assignment"
}
```

`state` answers *what is this agent doing?*; `placeable` answers *can I
dispatch here?* Those are different questions, and a consumer that infers the
second from the first gets it wrong for every state that is neither clearly
working nor clearly idle. Reporting both keeps the activity enum free to
describe activity.

Human output prints the pool whenever zero agents are placeable (and under
`--verbose` otherwise):

```
No assignments to recommend.
  Reason: No placeable agents available
  Agent pool:
    %11    claude   state=idle     conf=0.95 NOT PLACEABLE  (holds_active_assignment)
    %12    claude   state=working  conf=0.95 NOT PLACEABLE  (holds_active_assignment)
    %13    claude   state=working  conf=0.95 NOT PLACEABLE  (state_not_idle)
    %14    codex    state=working  conf=0.95 NOT PLACEABLE  (state_not_idle)
```

That first line is the one that was unobtainable before: a pane observed
`idle` at 0.95 confidence, excluded because it holds an assignment. On stock
`v1.32.0` that same session prints only `Reason: No idle agents available`.

A pane rejected at gate 3 still reports its observed state, best-effort via
`observation.PaneByID` rather than `currentAssignPaneObservation`, so a stale
observation on a fenced pane cannot newly abort the command. "Idle **and**
fenced" is the signature of a leaked claim on an otherwise free pane, and it is
indistinguishable from "busy" without that state.

`dispatchRejectionReason` mirrors `PaneObservation.SafeToDispatch` clause for
clause. A test asserts the two agree on every input and fails loudly (on the
sentinel `"unknown"`) if `SafeToDispatch` grows a condition this function does
not know about, so the two cannot drift apart silently.

## A naming hazard this exposes, worth a separate look

`ntm activity` and `ntm assign` classify the same pane through different
packages with different vocabularies for the same condition:

- `internal/robot/activity.go:1227` — a pane at an empty prompt is
  `StateWaiting`, confidence 0.90, evidence `idle_prompt`. Rendered `WAITING`.
- `internal/status` — the same pane is `StateIdle`, and `SafeToDispatch()`
  requires exactly `StateIdle`.
- `internal/coordinator/monitor.go:104` confirms the correspondence:
  `status.StateIdle` → `robot.StateWaiting`.

So an operator reads `WAITING` from one command and `no idle agents` from
another, about the same pane, in the same second, and reasonably concludes the
assigner excludes `WAITING`. It does not — both classifiers agree the pane is
at an idle prompt; they just spell it differently. Reporting `placeable`
explicitly is what makes that unambiguous at the point of use, which is why
this PR adds it rather than renaming either enum.

## Tests

`internal/cli/assign_agent_pool_test.go`:

- `TestDispatchRejectionReasonAgreesWithSafeToDispatch` — the agreement
  property across idle/working/unknown/error/low-confidence.
- `TestDispatchRejectionReasonReportsStaleAndErrored` — the two evidence-quality
  gates.
- `TestMarkRoleGatedPoolNamesTheDroppedPane` / `...LeavesPoolAloneWhenNothingWasDropped`
  / `...KeepsTheEarlierReason` — role gating explains only panes that cleared
  dispatch, and never overwrites an earlier reason.
- `TestDisplayNamesEveryExclusionGate` — the zero-placeable path names each
  gate and no longer prints "No idle agents available".
- `TestPrintAgentPoolReportsAnEmptyPool` — a session with no agent panes says so.

Full `internal/cli` package, matched arms on an otherwise idle host:

- baseline `5426f120`: ok, 326.5s
- this branch:          ok, 340.1s

plus `internal/status` ok and `internal/assignment` ok. Zero new failures.

Verified live against a four-pane session on ntm `v1.32.0-5-g5426f120`.
