### PR TITLE
fix(assignment): reap atomic identity lock files

### DIFF
--- a/internal/assignment/atomic_test.go
+++ b/internal/assignment/atomic_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -2827,6 +2829,94 @@ func TestAtomicOperationLockWaitHonorsContext(t *testing.T) {
 	}
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("context cancellation took %s", elapsed)
+	}
+}
+
+func TestAtomicOperationLockReapsIdentityFileButPreservesStableLocks(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	storePath := NewStore("atomic-lock-reap").path
+	lockPath := atomicOperationLockPath(storePath, "bead", "agent-factory-uygc")
+	guardPath := storePath + ".atomic.lock"
+
+	unlock, err := acquireAtomicBeadOperationLock(context.Background(), storePath, "agent-factory-uygc")
+	if err != nil {
+		t.Fatalf("acquire atomic operation lock: %v", err)
+	}
+	lockToken, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("identity lock must exist while held: %v", err)
+	}
+	if len(lockToken) != 32 {
+		t.Fatalf("identity lock token length = %d, want 32", len(lockToken))
+	}
+	if _, err := os.Stat(guardPath); err != nil {
+		t.Fatalf("stable atomic guard must exist: %v", err)
+	}
+	unlock()
+
+	if _, err := os.Stat(lockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("identity lock survived release: %v", err)
+	}
+	if _, err := os.Stat(guardPath); err != nil {
+		t.Fatalf("stable atomic guard was removed: %v", err)
+	}
+
+	storeUnlock, err := acquireStoreFileLock(storePath)
+	if err != nil {
+		t.Fatalf("acquire whole-store lock: %v", err)
+	}
+	storeUnlock()
+	if _, err := os.Stat(storePath + ".lock"); err != nil {
+		t.Fatalf("whole-store lock was removed: %v", err)
+	}
+}
+
+func TestAtomicOperationLockFilesStayBoundedAcrossUniqueIdentities(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	storePath := NewStore("atomic-lock-bounded").path
+
+	for i := range 200 {
+		identity := fmt.Sprintf("never-repeated-%d", i)
+		unlock, err := acquireAtomicBeadOperationLock(context.Background(), storePath, identity)
+		if err != nil {
+			t.Fatalf("acquire identity %q: %v", identity, err)
+		}
+		unlock()
+	}
+
+	matches, err := filepath.Glob(storePath + ".atomic-*.lock")
+	if err != nil {
+		t.Fatalf("glob identity locks: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("unique identities left %d lock files: %v", len(matches), matches)
+	}
+	if _, err := os.Stat(storePath + ".atomic.lock"); err != nil {
+		t.Fatalf("stable atomic guard must remain for future operations: %v", err)
+	}
+}
+
+func TestRemoveLockFileWithTokenPreservesReplacement(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "assignments.json.atomic-bead-replaced.lock")
+	originalToken := []byte("original-token")
+	if err := os.WriteFile(lockPath, originalToken, 0600); err != nil {
+		t.Fatalf("write original lock: %v", err)
+	}
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove original lock: %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte("replacement"), 0600); err != nil {
+		t.Fatalf("write replacement lock: %v", err)
+	}
+
+	removeLockFileWithToken(lockPath, originalToken)
+
+	content, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("replacement lock was removed: %v", err)
+	}
+	if string(content) != "replacement" {
+		t.Fatalf("replacement lock content = %q", content)
 	}
 }
 

--- a/internal/assignment/store_lock.go
+++ b/internal/assignment/store_lock.go
@@ -1,10 +1,13 @@
 package assignment
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"os"
 	"strings"
 	"sync"
 )
@@ -50,9 +53,38 @@ func (s *AssignmentStore) AcquireExternalCleanupLock(ctx context.Context, beadID
 }
 
 func acquireAtomicOperationLock(ctx context.Context, storePath, namespace, identity string) (func(), error) {
+	lockPath := atomicOperationLockPath(storePath, namespace, identity)
+	return acquireReapableAssignmentFileLock(ctx, lockPath, storePath+".atomic.lock")
+}
+
+func atomicOperationLockPath(storePath, namespace, identity string) string {
 	digest := sha256.Sum256([]byte(namespace + "\x00" + identity))
-	lockPath := storePath + ".atomic-" + namespace + "-" + hex.EncodeToString(digest[:16]) + ".lock"
-	return acquireAssignmentFileLock(ctx, lockPath)
+	return storePath + ".atomic-" + namespace + "-" + hex.EncodeToString(digest[:16]) + ".lock"
+}
+
+// markLockFile gives this acquisition an identity that survives Close. An inode
+// comparison is insufficient here because a remove-and-create can immediately
+// reuse the same inode number.
+func markLockFile(lockFile *os.File) ([]byte, error) {
+	token := make([]byte, 32)
+	if _, err := rand.Read(token); err != nil {
+		return nil, err
+	}
+	if err := lockFile.Truncate(0); err != nil {
+		return nil, err
+	}
+	if _, err := lockFile.WriteAt(token, 0); err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+// removeLockFileWithToken refuses to remove a path replaced after acquisition.
+func removeLockFileWithToken(lockPath string, token []byte) {
+	currentToken, err := os.ReadFile(lockPath)
+	if err == nil && bytes.Equal(token, currentToken) {
+		_ = os.Remove(lockPath)
+	}
 }
 
 func lockAssignmentPathLocally(ctx context.Context, path string) (func(), error) {

--- a/internal/assignment/store_lock_unix.go
+++ b/internal/assignment/store_lock_unix.go
@@ -57,6 +57,76 @@ func acquireAssignmentFileLock(ctx context.Context, lockPath string) (func(), er
 	}, nil
 }
 
+// acquireReapableAssignmentFileLock holds a stable guard while opening or
+// removing an identity-scoped lock file. A contender that finds the identity
+// lock busy closes that descriptor before releasing the guard and retrying.
+// Therefore no conforming waiter can retain the inode that the holder removes
+// on release and later run concurrently with a new lock file at the same path.
+func acquireReapableAssignmentFileLock(ctx context.Context, lockPath, guardPath string) (func(), error) {
+	localUnlock, err := lockAssignmentPathLocally(ctx, lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockFile *os.File
+	var lockToken []byte
+	for {
+		guardUnlock, guardErr := acquireAssignmentFileLock(ctx, guardPath)
+		if guardErr != nil {
+			localUnlock()
+			return nil, guardErr
+		}
+		lockFile, err = os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			guardUnlock()
+			localUnlock()
+			return nil, err
+		}
+		err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			lockToken, err = markLockFile(lockFile)
+			if err != nil {
+				_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+				_ = lockFile.Close()
+				guardUnlock()
+				localUnlock()
+				return nil, err
+			}
+			guardUnlock()
+			break
+		}
+		_ = lockFile.Close()
+		guardUnlock()
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			localUnlock()
+			return nil, err
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			localUnlock()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return func() {
+		// A release cannot inherit the caller's canceled context: it must finish
+		// the lock lifecycle even when the operation itself was canceled.
+		guardUnlock, guardErr := acquireAssignmentFileLock(context.Background(), guardPath)
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		_ = lockFile.Close()
+		if guardErr == nil {
+			removeLockFileWithToken(lockPath, lockToken)
+			guardUnlock()
+		}
+		localUnlock()
+	}, nil
+}
+
 func syncAssignmentDirectory(path string) error {
 	dir, err := os.Open(path)
 	if err != nil {

--- a/internal/assignment/store_lock_windows.go
+++ b/internal/assignment/store_lock_windows.go
@@ -66,6 +66,82 @@ func acquireAssignmentFileLock(ctx context.Context, lockPath string) (func(), er
 	}, nil
 }
 
+// acquireReapableAssignmentFileLock is the Windows counterpart of the Unix
+// guarded lifecycle. LockFileEx contenders close a busy identity descriptor
+// before releasing the stable guard, and removal happens after UnlockFileEx
+// and Close because Windows does not permit deleting this open handle.
+func acquireReapableAssignmentFileLock(ctx context.Context, lockPath, guardPath string) (func(), error) {
+	localUnlock, err := lockAssignmentPathLocally(ctx, lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockFile *os.File
+	var overlapped *windows.Overlapped
+	var lockToken []byte
+	for {
+		guardUnlock, guardErr := acquireAssignmentFileLock(ctx, guardPath)
+		if guardErr != nil {
+			localUnlock()
+			return nil, guardErr
+		}
+		lockFile, err = os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			guardUnlock()
+			localUnlock()
+			return nil, err
+		}
+		overlapped = new(windows.Overlapped)
+		err = windows.LockFileEx(
+			windows.Handle(lockFile.Fd()),
+			windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			overlapped,
+		)
+		if err == nil {
+			lockToken, err = markLockFile(lockFile)
+			if err != nil {
+				_ = windows.UnlockFileEx(windows.Handle(lockFile.Fd()), 0, 1, 0, overlapped)
+				_ = lockFile.Close()
+				guardUnlock()
+				localUnlock()
+				return nil, err
+			}
+			guardUnlock()
+			break
+		}
+		_ = lockFile.Close()
+		guardUnlock()
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			localUnlock()
+			return nil, err
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			localUnlock()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return func() {
+		guardUnlock, guardErr := acquireAssignmentFileLock(context.Background(), guardPath)
+		_ = windows.UnlockFileEx(windows.Handle(lockFile.Fd()), 0, 1, 0, overlapped)
+		_ = lockFile.Close()
+		if guardErr == nil {
+			removeLockFileWithToken(lockPath, lockToken)
+			guardUnlock()
+		}
+		localUnlock()
+	}, nil
+}
+
 func syncAssignmentDirectory(string) error {
 	// Windows FlushFileBuffers does not support directory handles opened by
 	// os.Open. The temp files themselves are flushed before atomic replacement.


### PR DESCRIPTION
Fixes unbounded assignments.json.atomic-*.lock inode growth by taking approach (a): unlink identity-scoped locks on release.

A stable per-store assignments.json.atomic.lock guard serializes identity-file open/retry/reap boundaries. Busy contenders close the identity descriptor before releasing the guard, preventing a waiter from retaining an unlinked inode. Each acquisition writes a random token; release removes only a path that still carries that token, protecting a replacement even if the filesystem reuses the inode number. The Unix flock and Windows LockFileEx implementations use the same lifecycle. assignments.json.lock remains persistent and unchanged.

Verification:
- go test -race ./internal/assignment
- GOOS=windows GOARCH=amd64 go test -exec=/usr/bin/true ./internal/assignment
- go build ./cmd/ntm
- go vet ./...
- 20 repeated bounded/replacement focused test runs
- live ntm assign agent-factory --dry-run --json: exit 0, valid JSON, ledger/backup/store-lock/prompts hashes and mtimes unchanged
- full go test -short ./...: changed package passes; one unrelated baseline failure remains in internal/agents TestNormalizeAgentType/gpt-6-astra

Tracks downstream bead agent-factory-uygc.